### PR TITLE
USB string descriptors now mention Bus Pirate

### DIFF
--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -265,11 +265,11 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
-  "TinyUSB",                     // 1: Manufacturer
-  "TinyUSB Device",              // 2: Product
+  "Bus Pirate",                  // 1: Manufacturer
+  "Bus Pirate 5",                // 2: Product
   "123456789012",                // 3: Serials, should use chip ID
-  "TinyUSB CDC",                 // 4: CDC Interface
-  "TinyUSB MSC",                 // 5: MSC Interface
+  "Bus Pirate CDC",                 // 4: CDC Interface
+  "Bus Pirate MSC",                 // 5: MSC Interface
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
Changed default tinyusb strings to Bus Pirate ones, so the enumerated USB functions have fancier names:

<img width="960" alt="image" src="https://github.com/DangerousPrototypes/BusPirate5-firmware/assets/5928359/5d0f9c3b-c907-4fa1-958e-428cdc7b6daa">
