### PR TITLE
Fix storage hex command dump format typo

### DIFF
--- a/commands/global/disk.c
+++ b/commands/global/disk.c
@@ -45,7 +45,7 @@ void disk_hex_handler(struct command_result *res){
             break;
         }
         for(uint16_t i=0; i<bytes_read; i++){
-            printf(" 0x%02u ", file[i]);
+            printf(" 0x%02x ", file[i]);
             grouping++;
             if(grouping>=8){
                 grouping=0;


### PR DESCRIPTION
(Forum user: Gabri74)
Fix wrong printf format string (%02d instead of %02x) in the storage hex dump command
NOTE: github diff viewer show an added bracket in this commit at line 270, which is not true. That line was not modified and the bracket already exists in the original file ¯_(ツ)_/¯