### PR TITLE
Add a flags field in disk_ls (now storage_ls) and integare it into existing code

### DIFF
--- a/commands/global/disk.c
+++ b/commands/global/disk.c
@@ -225,29 +225,12 @@ void disk_ls_handler(struct command_result *res){
     //is there a trailing path to ls?
     char location[32];
     cmdln_args_string_by_position(1, sizeof(location), location);  
-    fr = f_opendir(&dir, location);                       /* Open the directory */
-    if (fr != FR_OK) {
+
+    if (!storage_ls(location, NULL, LS_ALL)) {
         storage_file_error(fr);
         res->error=true;
         return;
     }
-
-    nfile = ndir = 0;
-    for(;;){
-        fr = f_readdir(&dir, &fno);                   /* Read a directory item */
-        if(fr != FR_OK || fno.fname[0] == 0) break;  /* Error or end of dir */
-        strlwr(fno.fname); //FAT16 is only UPPERCASE, make it lower to be easy on the eyes...
-        if(fno.fattrib & AM_DIR){   /* Directory */
-            printf("%s   <DIR>   %s%s%s\r\n",ui_term_color_prompt(), ui_term_color_info(), fno.fname, ui_term_color_reset());
-            ndir++;
-        }else{   /* File */
-            printf("%s%10u %s%s%s\r\n", 
-            ui_term_color_prompt(),fno.fsize, ui_term_color_info(),fno.fname, ui_term_color_reset());
-            nfile++;
-        }
-    }
-    f_closedir(&dir);
-    printf("%s%d dirs, %d files%s\r\n", ui_term_color_info(), ndir, nfile, ui_term_color_reset());
 }
 
 uint8_t disk_format(void){

--- a/commands/global/macro.c
+++ b/commands/global/macro.c
@@ -57,7 +57,7 @@ void macro_handler(struct command_result *res){
     //list of mcr files
     if(cmdln_args_find_flag('a'|0x20)){
         printf("Available macro files:\r\n");
-        storage_ls("", "mcr"); //disk ls should be integrated with existing list function???
+        storage_ls("", "mcr", LS_FILES /*| LS_SIZE*/); //disk ls should be integrated with existing list function???
         return;
     }
 

--- a/commands/global/macro.c
+++ b/commands/global/macro.c
@@ -19,7 +19,6 @@
 static bool exec_macro_id(uint8_t id);
 void disk_show_macro_file(const char *location);
 void disk_get_line_id(const char *location, uint8_t id, char *line, int max_len);
-bool disk_ls(const char *location, const char *ext);
 
 static const char * const usage[]= {
     "macro <#>\r\n\t[-f <file>] [-a] [-l] [-h(elp)]",
@@ -58,7 +57,7 @@ void macro_handler(struct command_result *res){
     //list of mcr files
     if(cmdln_args_find_flag('a'|0x20)){
         printf("Available macro files:\r\n");
-        disk_ls("", "mcr"); //disk ls should be integrated with existing list function???
+        storage_ls("", "mcr"); //disk ls should be integrated with existing list function???
         return;
     }
 
@@ -174,46 +173,3 @@ void disk_get_line_id(const char *location, uint8_t id, char *line, int max_len)
     f_close(&fil);
 }
 
-//TODO: move to pirate/storage? Integrate with disk.h ls command, extend to support extensions?
-bool disk_ls(const char *location, const char *ext)
-{
-    FRESULT fr;
-    DIR dir;
-    FILINFO fno;
-    int nfile, ndir;
-
-    fr = f_opendir(&dir, location);                       /* Open the directory */
-    if (fr != FR_OK) {
-        return false;
-    }
-
-    nfile = ndir = 0;
-    for(;;) {
-        fr = f_readdir(&dir, &fno);                   /* Read a directory item */
-        if (fr != FR_OK || fno.fname[0] == 0)
-            break;  /* Error or end of dir */
-        strlwr(fno.fname); //FAT16 is only UPPERCASE, make it lower to be easy on the eyes...
-        if (ext) {
-            int fname_len = strlen(fno.fname);
-            int ext_len = strlen(ext);
-            if (fname_len > ext_len+1) {
-                if (memcmp(fno.fname+fname_len-ext_len, ext, ext_len)) {
-                    continue;
-                }
-            }
-
-        }
-        if (fno.fattrib & AM_DIR) {   /* Directory */
-            printf("%s   <DIR>   %s%s%s\r\n",ui_term_color_prompt(), ui_term_color_info(), fno.fname, ui_term_color_reset());
-            ndir++;
-        }
-        else {   /* File */
-            printf("%s%10u %s%s%s\r\n",
-            ui_term_color_prompt(),fno.fsize, ui_term_color_info(), fno.fname, ui_term_color_reset());
-            nfile++;
-        }
-    }
-    f_closedir(&dir);
-    printf("%s%d dirs, %d files%s\r\n", ui_term_color_info(), ndir, nfile, ui_term_color_reset());
-    return true;
-}

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -204,7 +204,7 @@ uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t
     return 1;
 }
 
-bool storage_ls(const char *location, const char *ext)
+bool storage_ls(const char *location, const char *ext, const uint8_t flags)
 {
     FRESULT fr;
     DIR dir;
@@ -233,17 +233,21 @@ bool storage_ls(const char *location, const char *ext)
 
         }
         if (fno.fattrib & AM_DIR) {   /* Directory */
-            printf("%s   <DIR>   %s%s%s\r\n",ui_term_color_prompt(), ui_term_color_info(), fno.fname, ui_term_color_reset());
+            if (flags & LS_DIRS)
+                printf("%s   <DIR>   %s%s%s\r\n",ui_term_color_prompt(), ui_term_color_info(), fno.fname, ui_term_color_reset());
             ndir++;
         }
         else {   /* File */
-            printf("%s%10u %s%s%s\r\n",
-            ui_term_color_prompt(),fno.fsize, ui_term_color_info(), fno.fname, ui_term_color_reset());
+            if (flags & LS_FILES)
+                if (flags & LS_SIZE)
+                    printf("%s%10u ", ui_term_color_prompt(), fno.fsize);
+                printf("%s%s%s\r\n", ui_term_color_info(), fno.fname, ui_term_color_reset());
             nfile++;
         }
     }
     f_closedir(&dir);
-    printf("%s%d dirs, %d files%s\r\n", ui_term_color_info(), ndir, nfile, ui_term_color_reset());
+    if (flags & LS_SUMM)
+        printf("%s%d dirs, %d files%s\r\n", ui_term_color_info(), ndir, nfile, ui_term_color_reset());
     return true;
 }
 

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -204,6 +204,49 @@ uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t
     return 1;
 }
 
+bool storage_ls(const char *location, const char *ext)
+{
+    FRESULT fr;
+    DIR dir;
+    FILINFO fno;
+    int nfile, ndir;
+
+    fr = f_opendir(&dir, location);                       /* Open the directory */
+    if (fr != FR_OK) {
+        return false;
+    }
+
+    nfile = ndir = 0;
+    for(;;) {
+        fr = f_readdir(&dir, &fno);                   /* Read a directory item */
+        if (fr != FR_OK || fno.fname[0] == 0)
+            break;  /* Error or end of dir */
+        strlwr(fno.fname); //FAT16 is only UPPERCASE, make it lower to be easy on the eyes...
+        if (ext) {
+            int fname_len = strlen(fno.fname);
+            int ext_len = strlen(ext);
+            if (fname_len > ext_len+1) {
+                if (memcmp(fno.fname+fname_len-ext_len, ext, ext_len)) {
+                    continue;
+                }
+            }
+
+        }
+        if (fno.fattrib & AM_DIR) {   /* Directory */
+            printf("%s   <DIR>   %s%s%s\r\n",ui_term_color_prompt(), ui_term_color_info(), fno.fname, ui_term_color_reset());
+            ndir++;
+        }
+        else {   /* File */
+            printf("%s%10u %s%s%s\r\n",
+            ui_term_color_prompt(),fno.fsize, ui_term_color_info(), fno.fname, ui_term_color_reset());
+            nfile++;
+        }
+    }
+    f_closedir(&dir);
+    printf("%s%d dirs, %d files%s\r\n", ui_term_color_info(), ndir, nfile, ui_term_color_reset());
+    return true;
+}
+
 const char system_config_file[]="bpconfig.bp";
 
 struct _mode_config_t system_config_json[]={

--- a/pirate/storage.h
+++ b/pirate/storage.h
@@ -10,7 +10,7 @@ uint32_t storage_load_config(void);
 uint32_t storage_save_config(void);
 uint32_t storage_save_mode(const char *filename, struct _mode_config_t *config_t, uint8_t count);
 uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t, uint8_t count);
-bool storage_ls(const char *location, const char *ext);
+bool storage_ls(const char *location, const char *ext, const uint8_t flags);
 
 static const char storage_fat_type_labels[][8]={
     "FAT12",
@@ -19,3 +19,10 @@ static const char storage_fat_type_labels[][8]={
     "EXFAT",
     "UNKNOWN"
 };
+
+#define LS_FILES    0x01
+#define LS_DIRS     0x02
+#define LS_SIZE     0x04
+#define LS_SUMM     0x08
+#define LS_ALL      (LS_FILES | LS_DIRS | LS_SIZE | LS_SUMM)
+

--- a/pirate/storage.h
+++ b/pirate/storage.h
@@ -10,6 +10,7 @@ uint32_t storage_load_config(void);
 uint32_t storage_save_config(void);
 uint32_t storage_save_mode(const char *filename, struct _mode_config_t *config_t, uint8_t count);
 uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t, uint8_t count);
+bool storage_ls(const char *location, const char *ext);
 
 static const char storage_fat_type_labels[][8]={
     "FAT12",


### PR DESCRIPTION
This PR moves disk_ls fro macro.c to pirate/storage.c and renames it to storage_ls.
It also add a flags field  to show/hide files/dirs/size/summary.
It uses the new implementation for disk_ls_handler (without -hopefully- changing current listing format) and for macro (showing only files, no dirs, no summary)

