### PR TITLE
proof of concept to solve sync between the BP5 and the host.

### DIFF
--- a/commands/global/dummy.c
+++ b/commands/global/dummy.c
@@ -20,6 +20,8 @@
 #include "pirate/amux.h"   // Analog voltage measurement functions
 #include "pirate/button.h" // Button press functions
 
+void refresh_usbmsdrive(void);
+
 // This array of strings is used to display help USAGE examples for the dummy command
 static const char * const usage[]= 
 {
@@ -202,6 +204,8 @@ void dummy_handler(struct command_result *res)
         }
         //if the file was closed
         printf("File %s closed\r\n", file);
+        //make the file available to the host
+        refresh_usbmsdrive();
 
         /* Open file and read */
         //open the file

--- a/msc_disk.c
+++ b/msc_disk.c
@@ -37,6 +37,10 @@
 
 // whether host does safe-eject
 bool ejected = false;
+//latch the ejected status until read by the host
+static bool latch_ejected = false;
+
+static bool writable = true;
 
 // Some MCU doesn't have enough 8KB SRAM to store the whole disk
 // We will use Flash as read-only disk with board that has
@@ -149,10 +153,12 @@ bool tud_msc_test_unit_ready_cb(uint8_t lun)
   (void) lun;
 
   // RAM disk is ready until ejected
-  if (ejected) {
+  if (ejected || latch_ejected) {
     tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
+    latch_ejected = false;
     return false;
   }
+  tud_msc_set_sense(lun, 0x00, 0x00, 0x00);
 
   return true;
 }
@@ -201,6 +207,7 @@ bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, boo
     }else
     {
       // unload disk storage
+      latch_ejected = true;
       ejected = true;
     }
   }
@@ -312,6 +319,40 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   }
 
   return resplen;
+}
+
+bool tud_msc_is_writable_cb(uint8_t lun)
+{
+  return writable;
+}
+
+//eject and insert the usbms drive to force the host to sync its contents
+void refresh_usbmsdrive(void)
+{
+  // eject the usb drive
+  tud_msc_start_stop_cb(0, 0, 0, 1);
+  // insert the drive back
+  tud_msc_start_stop_cb(0, 0, 1, 1);
+}
+void make_usbmsdrive_readonly()
+{
+  if (!writable)
+    return;
+  // eject the usb drive
+  tud_msc_start_stop_cb(0, 0, 0, 1);
+  writable = false;
+  // insert the drive back
+  tud_msc_start_stop_cb(0, 0, 1, 1);
+}
+void make_usbmsdrive_writable()
+{
+  if(writable)
+    return;
+  // eject the usb drive
+  tud_msc_start_stop_cb(0, 0, 0, 1);
+  writable = true;
+  //insert the drive back
+  tud_msc_start_stop_cb(0, 0, 1, 1);
 }
 
 #endif

--- a/pirate.c
+++ b/pirate.c
@@ -50,6 +50,9 @@ lock_core_t core;
 spin_lock_t *spi_spin_lock;
 uint spi_spin_lock_num;
 
+void make_usbmsdrive_readonly();
+void make_usbmsdrive_writable();
+
 void core1_entry(void);
 
 int64_t ui_term_screensaver_enable(alarm_id_t id, void *user_data){
@@ -211,6 +214,13 @@ int main(){
         if(script_entry()){ //enter scripting mode?
             bp_state=BP_SM_SCRIPT_MODE; //reset and show prompt
         }
+
+        if (tud_cdc_n_connected(0)){
+            make_usbmsdrive_readonly();
+            //need to sync fatfs to sync with host
+        }
+        else
+            make_usbmsdrive_writable();
 
         switch(bp_state){
             case BP_SM_DISPLAY_MODE:


### PR DESCRIPTION
Initially the host view is writable, until the host connects to the BP5. After this point the host view is read only and BP5 writes need to call refresh_usbmsdrive() to get the host view in sync When the connection with the BP5 is closed, the host view becomes writable again TODO:
call refresh_usbmsdrive() to get the host view in sync. sync fatfs on connection to get the host changes
Notes:
the dummy command does call refresh_usbmsdrive() to verify the POC