### PR TITLE
fix: action depreciation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,6 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-  
-
 env:
   BUILD_TYPE: Release
   BUILD_TARGET: all
@@ -21,7 +19,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Linux setup
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -45,7 +43,6 @@ jobs:
         git submodule init
         git submodule update
 
-
     - name: Configure CMake Linux & MacOS
       if: ${{ matrix.os != 'windows-latest'}}
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
@@ -58,8 +55,9 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --target ${{env.BUILD_TARGET}}
     
     - name: Save Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: buspirate 5 firmware
+        name: firmare-${{ matrix.os }}
         path: ${{github.workspace}}/build/*.uf2
         retention-days: 7
+        if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Save Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: firmare-${{ matrix.os }}
+        name: firmware-${{ matrix.os }}
         path: ${{github.workspace}}/build/*.uf2
         retention-days: 7
         if-no-files-found: error


### PR DESCRIPTION
v3 checkout and upload-artifact actions have been depreciated for several months now, and the upload-artifact will stop working in November. 

Usage of the v3 actions leads to the first three warnings in the action build summary, due to [NodeJS 16 being EoL](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), with the last one being regarding upload-artifacts <4 will cease functioning in November. 

![image](https://github.com/DangerousPrototypes/BusPirate5-firmware/assets/5500713/1929e061-1949-4093-aae9-1a5817d3d6fc)

One gotcha with the v4 upload-artifact is that it is no longer possible to upload to the same named Artifact multiple times... instead it must be a unique name for each upload, and you can merge them in a later step if necessary.

i.e. I use this in with a other project as we have around 20 different firmware targets, with a unique filename for each, so each individual matrix upload can be merged into one file once they are all complete. 
```
      - name: Merge firmware artifact packages
        uses: actions/upload-artifact/merge@v4
        with:
          name: "${{ env.artifact_name }}"
          pattern: firmware-*
          delete-merged: true
          retention-days: 15
```