### PR TITLE
feat: button exits osl sump

### DIFF
--- a/mode/sump.c
+++ b/mode/sump.c
@@ -41,6 +41,7 @@
 #include "usb_rx.h"
 #include "usb_tx.h"
 #include "pirate/bio.h"
+#include "pirate/button.h"
 #include "system_config.h"
 #include "bytecode.h" //needed because modes.h has some functions that use it TODO: move all the opt args and bytecode stuff to a single helper file
 #include "opt_args.h" //needed for same reason as bytecode and needs same fix
@@ -557,6 +558,8 @@ void sump_logic_analyzer(void){
     while (1) {
         //tud_task(); // tinyusb device task
         cdc_sump_task();
+        // exit out on button press
+        if(button_get(0)) break;
     }
     logic_analyzer_cleanup();
     psu_disable();


### PR DESCRIPTION
The forums indicated there wasn't the ability to exit sump mode, so I added the pirate button to do that: https://forum.buspirate.com/t/com-port-issues/247/59

There's not really a contribution guide, so here's what I did for testing:

* build from clean source repo
* tested with pulseview 0.4.2
* connect to bp in binary mode `/dev/ttyACM1`
* run a capture
* push button - verified returned to serial prompt

As always, please let me know if I can provide additional details or a better test method.