### PR TITLE
Enable USB serial number

### DIFF
--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -303,9 +303,17 @@ bool selftest_current_limit(void){
 }
 
 bool selftest_button(void){
+    //debounce value selected somewhat arbitrarily
+    static const uint32_t DEBOUNCE_DELAY_MS = 100;    
     //prompt to push button
     printf("PUSH BUTTON TO COMPLETE: ");
+    //wait for button to be pressed
     while(!button_get(0));
+    busy_wait_ms(DEBOUNCE_DELAY_MS);
+    //then wait for button to be released
+    while( button_get(0));
+    busy_wait_ms(DEBOUNCE_DELAY_MS);
+
     printf("OK\r\n");
     return false;
 }

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -305,7 +305,7 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     uint64_t unique_id = mcu_get_unique_id();
     for ( uint_fast8_t t = 0; t < 16; t++ ) {
       uint8_t nibble = (unique_id >> (t * 4u)) & 0xF;
-      _desc_str[1+t] = nibble < 10 ? '0' + nibble : 'A' + nibble - 10;
+      _desc_str[16-t] = nibble < 10 ? '0' + nibble : 'A' + nibble - 10;
     }
     chr_count = 16;
   } else if ( index >= STRING_DESC_ARR_ELEMENT_COUNT ) { // if not in table, return NULL

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -268,13 +268,24 @@ char const* string_desc_arr [] =
   (const char[]) { 0x09, 0x04 },    // 0: is supported language is English (0x0409)
   "Bus Pirate",                     // 1: Manufacturer
   "Bus Pirate 5",                   // 2: Product
-  "5buspirate",                     // 3: Serials, should use chip ID
+  "5buspirate",                     // 3: Serial -- now using chip ID (serial port can be remembered per device)
   "Bus Pirate CDC",                 // 4: CDC Interface
   "Bus Pirate MSC",                 // 5: MSC Interface
   "Bus Pirate BIN"                  // 6: Binary CDC Interface
 };
+// automatically update if an additional string is later added to the table
+#define STRING_DESC_ARR_ELEMENT_COUNT (sizeof(string_desc_arr)/sizeof(string_desc_arr[0]))
 
-static uint16_t _desc_str[32];
+// temporary buffer returned from tud_descriptor_string_cb()
+// relies on only a single outstanding call to this function
+// until the buffer is no longer used by caller.
+// "contents must exist long enough for transfer to complete"
+// Safe because each string descriptor is a separate transfer,
+// and only one is handled at a time.
+// Use of "length" is ambiguous (byte count?  element count?),
+// so use more explicit "BYTE_COUNT" or "ELEMENT_COUNT" instead.
+#define MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT 32
+static uint16_t _desc_str[MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
@@ -284,32 +295,32 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 
   uint8_t chr_count;
 
-  if ( index == 0) // supported language == English
-  {
+  if ( index == 0) { // supported language == English
     memcpy(&_desc_str[1], string_desc_arr[0], 2);
     chr_count = 1;
-  } else if ( index == 3 ) { // USB Serial number
+  } else if ( index == 3 ) { // special-case for USB Serial number
     //  1x  uint16_t for length/type
     // 16x  uint16_t to encode 64-bit value as hex (16x nibbles)
-    static_assert(sizeof(_desc_str) >= 17);
+    static_assert(MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT >= 17);
     uint64_t unique_id = mcu_get_unique_id();
     for ( uint_fast8_t t = 0; t < 16; t++ ) {
       uint8_t nibble = (unique_id >> (t * 4u)) & 0xF;
       _desc_str[1+t] = nibble < 10 ? '0' + nibble : 'A' + nibble - 10;
     }
     chr_count = 16;
-  }else
-  {
+  } else if ( index >= STRING_DESC_ARR_ELEMENT_COUNT ) { // if not in table, return NULL
+    return NULL;
+  } else {
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
-
-    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
-
     const char* str = string_desc_arr[index];
 
-    // Cap at max char
+    // Cap at max char ...
     chr_count = strlen(str);
-    if ( chr_count > 31 ) chr_count = 31;
+    if ( chr_count > (MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT-1) ) {
+      // first array element stores the length, leaving N-1 for the string
+      chr_count = MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT-1;
+    }
 
     // Convert ASCII string into UTF-16
     for(uint8_t i=0; i<chr_count; i++)


### PR DESCRIPTION
Encodes the MCU's 64-bit unique ID as a 16 character hex serial number.

Untested at the moment, awaiting hardware.  Creating PR in case others want to try this / comment.