### PR TITLE
QoL changes ... for consideration 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(bp5_common
         pirate/button.h pirate/button.c pirate/mem.c pirate/mem.h
         pirate/lcd.h pirate/lcd.c pirate/shift.h pirate/shift.c
         pirate/amux.h pirate/amux.c pirate/rgb.h pirate/rgb.c
+        pirate/intercore_helpers.c
 
         # commands
         commands.h commands.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 23)
 set(CMAKE_CXX_STANDARD 17)
 
 # initalize pico_sdk from installed location

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 # Generated Cmake Pico project file
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 
 # initalize pico_sdk from installed location
@@ -174,8 +175,8 @@ add_executable(bus_pirate5_rev8
         #tf card access control
         fatfs/tf_card.c fatfs/tf_card.h
         )
-
 target_compile_definitions(bus_pirate5_rev8 PUBLIC BP5_REV=8)
+set_property(TARGET bus_pirate5_rev8 PROPERTY C_STANDARD 23)
 
 add_executable(bus_pirate5_rev10
         ${bp5_common}
@@ -186,6 +187,7 @@ add_executable(bus_pirate5_rev10
         nand/sys_time.c nand/sys_time.h
         )
 target_compile_definitions(bus_pirate5_rev10 PUBLIC BP5_REV=10)
+set_property(TARGET bus_pirate5_rev10 PROPERTY C_STANDARD 23)
 
 set(stdlibs
         pico_stdlib

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -340,7 +340,7 @@ void cmd_selftest(void){
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");
-    icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
     busy_wait_ms(500);
     printf("OK\r\n");
 
@@ -398,7 +398,7 @@ void cmd_selftest(void){
     system_config.error=false;
 
     //enable system interrupts
-    icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
 }
 
 static const char * const usage[]={

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -339,8 +339,8 @@ void cmd_selftest(void){
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");
-    multicore_fifo_push_blocking(0xf0);
-    while(multicore_fifo_pop_blocking()!=0xf0);
+    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
+    while(multicore_fifo_pop_blocking()!=0xf0); // BUGBUG ... #define friendly constants for these magic numbers
     busy_wait_ms(500);
     printf("OK\r\n");
 
@@ -398,8 +398,8 @@ void cmd_selftest(void){
     system_config.error=false;
 
     //enable system interrupts
-    multicore_fifo_push_blocking(0xf1);
-    while(multicore_fifo_pop_blocking()!=0xf1);
+    multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
+    while(multicore_fifo_pop_blocking()!=0xf1); // BUGBUG ... #define friendly constants for these magic numbers
 }
 
 static const char * const usage[]={

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -16,6 +16,7 @@
 #include "pirate/bio.h"
 #include "pirate/amux.h"
 #include "display/scope.h"
+#include "pirate/intercore_helpers.h"
 
 #define SELF_TEST_LOW_LIMIT 300
 
@@ -339,8 +340,7 @@ void cmd_selftest(void){
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");
-    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
-    while(multicore_fifo_pop_blocking()!=0xf0); // BUGBUG ... #define friendly constants for these magic numbers
+    icm_core0_send_message(BP_ICM_VALUE_F0);
     busy_wait_ms(500);
     printf("OK\r\n");
 
@@ -398,8 +398,7 @@ void cmd_selftest(void){
     system_config.error=false;
 
     //enable system interrupts
-    multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
-    while(multicore_fifo_pop_blocking()!=0xf1); // BUGBUG ... #define friendly constants for these magic numbers
+    icm_core0_send_message(BP_ICM_VALUE_F1);
 }
 
 static const char * const usage[]={

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -340,7 +340,7 @@ void cmd_selftest(void){
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");
-    icm_core0_send_message(BP_ICM_VALUE_F0);
+    icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
     busy_wait_ms(500);
     printf("OK\r\n");
 
@@ -398,7 +398,7 @@ void cmd_selftest(void){
     system_config.error=false;
 
     //enable system interrupts
-    icm_core0_send_message(BP_ICM_VALUE_F1);
+    icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
 }
 
 static const char * const usage[]={

--- a/commands/global/dummy.c
+++ b/commands/global/dummy.c
@@ -190,6 +190,7 @@ void dummy_handler(struct command_result *res)
         if(result!=FR_OK){ 
             printf("Error writing to file %s\r\n", file);
             system_config.error=true; //set the error flag
+            // BUGBUG -- leaks file handle here
             return;
         }
         //if the write was successful

--- a/display/default.c
+++ b/display/default.c
@@ -57,8 +57,8 @@ uint32_t disp_default_setup(void)
 
 uint32_t disp_default_setup_exc(void)
 {
-	icm_core0_send_message(BP_ICM_VALUE_F0);
-	icm_core0_send_message(BP_ICM_VALUE_F2);
+	icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
+	icm_core0_send_message(BP_ICM_FORCE_LCD_UPDATE);
 	return 1;
 }
 

--- a/display/default.c
+++ b/display/default.c
@@ -56,11 +56,11 @@ uint32_t disp_default_setup(void)
 
 uint32_t disp_default_setup_exc(void)
 {
-    multicore_fifo_push_blocking(0xf0);
-    while(multicore_fifo_pop_blocking()!=0xf0);
+    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
+    while(multicore_fifo_pop_blocking()!=0xf0); // BUGBUG ... #define friendly constants for these magic numbers
 
-    multicore_fifo_push_blocking(0xf2);
-    while(multicore_fifo_pop_blocking()!=0xf2);
+    multicore_fifo_push_blocking(0xf2); // BUGBUG ... #define friendly constants for these magic numbers
+    while(multicore_fifo_pop_blocking()!=0xf2); // BUGBUG ... #define friendly constants for these magic numbers
 	return 1;
 }
 

--- a/display/default.c
+++ b/display/default.c
@@ -27,6 +27,7 @@
 #include "ui/ui_parse.h"
 #include "ui/ui_cmdln.h"
 #include "usb_rx.h"
+#include "pirate/intercore_helpers.h"
 
 
 void
@@ -56,11 +57,8 @@ uint32_t disp_default_setup(void)
 
 uint32_t disp_default_setup_exc(void)
 {
-    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
-    while(multicore_fifo_pop_blocking()!=0xf0); // BUGBUG ... #define friendly constants for these magic numbers
-
-    multicore_fifo_push_blocking(0xf2); // BUGBUG ... #define friendly constants for these magic numbers
-    while(multicore_fifo_pop_blocking()!=0xf2); // BUGBUG ... #define friendly constants for these magic numbers
+	icm_core0_send_message(BP_ICM_VALUE_F0);
+	icm_core0_send_message(BP_ICM_VALUE_F2);
 	return 1;
 }
 

--- a/display/default.c
+++ b/display/default.c
@@ -57,8 +57,8 @@ uint32_t disp_default_setup(void)
 
 uint32_t disp_default_setup_exc(void)
 {
-	icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
-	icm_core0_send_message(BP_ICM_FORCE_LCD_UPDATE);
+	icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
+	icm_core0_send_message_synchronous(BP_ICM_FORCE_LCD_UPDATE);
 	return 1;
 }
 

--- a/mode/logicanalyzer.c
+++ b/mode/logicanalyzer.c
@@ -320,8 +320,8 @@ la_x:
 
 void logicanalyzer_reset_led(void)
 {
-    multicore_fifo_push_blocking(0xf4);
-    multicore_fifo_pop_blocking();
+    multicore_fifo_push_blocking(0xf4); // BUGBUG ... #define friendly constants for these magic numbers
+    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
 }
 
 
@@ -484,8 +484,8 @@ bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uin
     irq_set_enabled(pio_get_dreq(pio, sm, false), true);
     irq_clear(pio_get_dreq(pio, sm, false));
     la_status=LA_ARMED_INIT;
-    multicore_fifo_push_blocking(0xf3);
-    multicore_fifo_pop_blocking();
+    multicore_fifo_push_blocking(0xf3); // BUGBUG ... #define friendly constants for these magic numbers
+    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
     //rgb_irq_enable(false);
     busy_wait_ms(5);
     rgb_set_all(0xff,0,0); //RED LEDs for armed

--- a/mode/logicanalyzer.c
+++ b/mode/logicanalyzer.c
@@ -321,7 +321,7 @@ la_x:
 
 void logicanalyzer_reset_led(void)
 {
-    icm_core0_send_message(BP_ICM_VALUE_F4);
+    icm_core0_send_message(BP_ICM_ENABLE_RGB_UPDATES);
 }
 
 
@@ -484,7 +484,7 @@ bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uin
     irq_set_enabled(pio_get_dreq(pio, sm, false), true);
     irq_clear(pio_get_dreq(pio, sm, false));
     la_status=LA_ARMED_INIT;
-    icm_core0_send_message(BP_ICM_VALUE_F3);
+    icm_core0_send_message(BP_ICM_DISABLE_RGB_UPDATES);
     multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
     //rgb_irq_enable(false);
     busy_wait_ms(5);

--- a/mode/logicanalyzer.c
+++ b/mode/logicanalyzer.c
@@ -20,6 +20,7 @@
 #include "pico/multicore.h"
 #include "pirate/amux.h"
 #include "ui/ui_cmdln.h"
+#include "pirate/intercore_helpers.h"
 
 enum logicanalyzer_status
 {
@@ -320,8 +321,7 @@ la_x:
 
 void logicanalyzer_reset_led(void)
 {
-    multicore_fifo_push_blocking(0xf4); // BUGBUG ... #define friendly constants for these magic numbers
-    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
+    icm_core0_send_message(BP_ICM_VALUE_F4);
 }
 
 
@@ -484,7 +484,7 @@ bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uin
     irq_set_enabled(pio_get_dreq(pio, sm, false), true);
     irq_clear(pio_get_dreq(pio, sm, false));
     la_status=LA_ARMED_INIT;
-    multicore_fifo_push_blocking(0xf3); // BUGBUG ... #define friendly constants for these magic numbers
+    icm_core0_send_message(BP_ICM_VALUE_F3);
     multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
     //rgb_irq_enable(false);
     busy_wait_ms(5);

--- a/mode/logicanalyzer.c
+++ b/mode/logicanalyzer.c
@@ -321,7 +321,7 @@ la_x:
 
 void logicanalyzer_reset_led(void)
 {
-    icm_core0_send_message(BP_ICM_ENABLE_RGB_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_RGB_UPDATES);
 }
 
 
@@ -484,7 +484,7 @@ bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uin
     irq_set_enabled(pio_get_dreq(pio, sm, false), true);
     irq_clear(pio_get_dreq(pio, sm, false));
     la_status=LA_ARMED_INIT;
-    icm_core0_send_message(BP_ICM_DISABLE_RGB_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_RGB_UPDATES);
     multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
     //rgb_irq_enable(false);
     busy_wait_ms(5);

--- a/msc_disk.c
+++ b/msc_disk.c
@@ -117,6 +117,8 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
   const char pid[] = "Storage";
   const char rev[] = "1.0";
 
+  // NOTE: tinyusb (class/msc/msc_device.c) sets all values
+  //       to spaces by default, so safe to only copy changes
   memcpy(vendor_id  , vid, strlen(vid));
   memcpy(product_id , pid, strlen(pid));
   memcpy(product_rev, rev, strlen(rev));

--- a/msc_disk.c
+++ b/msc_disk.c
@@ -46,6 +46,8 @@ static bool writable = true;
 enum
 {
   MSC_DEMO_DISK_BLOCK_NUM  = 16, // 8KB is the smallest size that windows allow to mount
+  // should this be MSC_DEMO_DISK_SECTOR_SIZE?
+  // ..._BLOCK_SIZE refers to an erase size (e.g., for 4k physical, 512b logical sectors)
   MSC_DEMO_DISK_BLOCK_SIZE = 512 //512
 };
 

--- a/pirate.c
+++ b/pirate.c
@@ -176,9 +176,9 @@ int main(){
     // begin main loop on secondary core
     // this will also setup the USB device
     // we need to have read any config files on the TF flash card before now
-    multicore_fifo_push_blocking(0); 
+    multicore_fifo_push_blocking(0);  // BUGBUG ... #define friendly constants for these magic numbers
     // wait for init to complete  
-    while(multicore_fifo_pop_blocking()!=0xff);
+    while(multicore_fifo_pop_blocking()!=0xff); // BUGBUG ... #define friendly constants for these magic numbers
 
     //test for PCB revision
     //must be done after shift register setup
@@ -374,7 +374,7 @@ void core1_entry(void){
         rx_uart_init_irq();
     }
 
-    multicore_fifo_push_blocking(0xff); 
+    multicore_fifo_push_blocking(0xff);  // BUGBUG ... #define friendly constants for these magic numbers
 
     while(1){
         //service (thread safe) tinyusb tasks
@@ -430,29 +430,29 @@ void core1_entry(void){
         while(multicore_fifo_rvalid()){
             temp=multicore_fifo_pop_blocking();
             switch(temp){
-                case 0xf0:
+                case 0xf0: // BUGBUG ... #define friendly constants for these magic numbers
                     lcd_irq_disable();
                     lcd_update_request=false;
                     break;
-                case 0xf1:
+                case 0xf1: // BUGBUG ... #define friendly constants for these magic numbers
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_request=true;
                     break;
-                case 0xf2:
+                case 0xf2: // BUGBUG ... #define friendly constants for these magic numbers
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_force=true;
                     lcd_update_request=true;
                     break;
-                case 0xf3:
+                case 0xf3: // BUGBUG ... #define friendly constants for these magic numbers
                     rgb_irq_enable(false);
                     break;
-                case 0xf4:
+                case 0xf4: // BUGBUG ... #define friendly constants for these magic numbers
                     rgb_irq_enable(true);
                     break;
                 default:
                     break;
             }
-            multicore_fifo_push_blocking(temp); //acknowledge
+            multicore_fifo_push_blocking(temp); // acknowledge ...  // BUGBUG ... #define friendly constants for these magic numbers
         }
 
     }// while(1)

--- a/pirate.c
+++ b/pirate.c
@@ -431,23 +431,23 @@ void core1_entry(void){
         while(multicore_fifo_rvalid()){
             temp=multicore_fifo_pop_blocking();
             switch(icm_get_message(temp)){
-                case BP_ICM_VALUE_F0:
+                case BP_ICM_DISABLE_LCD_UPDATES:
                     lcd_irq_disable();
                     lcd_update_request=false;
                     break;
-                case BP_ICM_VALUE_F1:
+                case BP_ICM_ENABLE_LCD_UPDATES:
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_request=true;
                     break;
-                case BP_ICM_VALUE_F2:
+                case BP_ICM_FORCE_LCD_UPDATE:
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_force=true;
                     lcd_update_request=true;
                     break;
-                case BP_ICM_VALUE_F3:
+                case BP_ICM_DISABLE_RGB_UPDATES:
                     rgb_irq_enable(false);
                     break;
-                case BP_ICM_VALUE_F4:
+                case BP_ICM_ENABLE_RGB_UPDATES:
                     rgb_irq_enable(true);
                     break;
                 default:

--- a/pirate.c
+++ b/pirate.c
@@ -61,8 +61,6 @@ int64_t ui_term_screensaver_enable(alarm_id_t id, void *user_data){
 }
 
 int main(){
-    char c;
-    
     uint8_t bp_rev=mcu_detect_revision();
 
     //init buffered IO pins

--- a/pirate.c
+++ b/pirate.c
@@ -175,7 +175,7 @@ int main(){
     // begin main loop on secondary core
     // this will also setup the USB device
     // we need to have read any config files on the TF flash card before now
-    icm_core0_send_message(BP_ICM_INIT_CORE1);
+    icm_core0_send_message_synchronous(BP_ICM_INIT_CORE1);
 
     //test for PCB revision
     //must be done after shift register setup

--- a/pirate.h
+++ b/pirate.h
@@ -117,15 +117,5 @@ void spi_busy_wait(bool enable);
 #define M_LED_SDO BIO0
 #define M_LED_SCL BIO1 //only used on APA102
 
-// Intercore messages (always requested by core 0, always completed by core 1)
-// NOTE: values should be kept in a range that would not be a valid pointer,
-//       to allow for later expansion to passing data buffers directly.
-#define BP_ICM_INIT_CORE1__REQUEST   ((uint32_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
-#define BP_ICM_INIT_CORE1__COMPLETE  ((uint32_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
-#define BP_ICM_VALUE_F0              ((uint32_t)0xF0) // disables LCD IRQ, disabled LCD updates
-#define BP_ICM_VALUE_F1              ((uint32_t)0xF1) // enables LCD IRQ, enables LCD updates
-#define BP_ICM_VALUE_F2              ((uint32_t)0xF2) // enable LCD IRQ, enabled and forces LCD update
-#define BP_ICM_VALUE_F3              ((uint32_t)0xF3) // disables RGB IRQ
-#define BP_ICM_VALUE_F4              ((uint32_t)0xF4) // enables RGB IRQ
 
 #endif

--- a/pirate.h
+++ b/pirate.h
@@ -117,5 +117,15 @@ void spi_busy_wait(bool enable);
 #define M_LED_SDO BIO0
 #define M_LED_SCL BIO1 //only used on APA102
 
+// Intercore messages (always requested by core 0, always completed by core 1)
+// NOTE: values should be kept in a range that would not be a valid pointer,
+//       to allow for later expansion to passing data buffers directly.
+#define BP_ICM_INIT_CORE1__REQUEST   ((uint32_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
+#define BP_ICM_INIT_CORE1__COMPLETE  ((uint32_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
+#define BP_ICM_VALUE_F0              ((uint32_t)0xF0) // disables LCD IRQ, disabled LCD updates
+#define BP_ICM_VALUE_F1              ((uint32_t)0xF1) // enables LCD IRQ, enables LCD updates
+#define BP_ICM_VALUE_F2              ((uint32_t)0xF2) // enable LCD IRQ, enabled and forces LCD update
+#define BP_ICM_VALUE_F3              ((uint32_t)0xF3) // disables RGB IRQ
+#define BP_ICM_VALUE_F4              ((uint32_t)0xF4) // enables RGB IRQ
 
 #endif

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -2,7 +2,8 @@
 #include "pico/stdlib.h"
 #include "pirate.h"
 
-static bool button_pressed = false;
+// TODO -- consider marking this `volatile`, as value is modified in ISR.
+static bool button_pressed = false; 
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){

--- a/pirate/intercore_helpers.c
+++ b/pirate/intercore_helpers.c
@@ -4,30 +4,51 @@
 
 
 // This wrapper is a response to manual code review noting
-// at least two coding patterns, neither of which is all
-// that safe...
-// Using a wrapper also makes it easier to later
-// change to a more robust cross-core communication
-// with minimal code changes elsewhere.
+// at least two coding patterns, neither of which provided
+// any indication when things were awry.
+//
+// Using this wrapper increases the detectability of code
+// errors, and also makes it easier to later change to
+// alternative cross-core communication methods if needed.
 
 
-void icm_core0_send_message(uint8_t message_id) {
-    static uint8_t static_message_count = 0u;
-
+void icm_core0_send_message(bp_icm_message_t message_id) {
     // NOTE: although split into multiple lines for readability,
     //       the compiler optimizes this quite well!
 
-    // encode a message counter into the value,
-    // but keep top byte as zero to avoid overlap with RP2040 valid memory locations
-    uint32_t icm_value = ++static_message_count;
+    static_assert(sizeof(message_id) <= 2); // else have to update encoding / decoding
 
-    // shift those bits to avoid overlap with the encoded message_id parameter
-    static_assert(sizeof(message_id) < sizeof(icm_value));
-    icm_value <<= sizeof(message_id)*8;
+    static uint8_t static_message_count = 0u;
 
-    // add in the message_id
-    icm_value |= message_id;
+    // Basic concepts:
+    // 1. Encode a counter within the message ID.
+    //    This prevents various code errors from
+    //    causing intercore synchronization to be lost.
+    //    The counter is incremented each time core0
+    //    sends a message using this API, and the wait
+    //    ensure this same message is received confirming
+    //    the message was processed.
+    // 2. Ensure that the message ID is not a valid pointer.
+    //    Per the RP2040 memory map, the range 0x60000000..0xCFFFFFFF
+    //    is unmapped, and will cause a bus error if accessed.
+    //
+    // RP2040 uses a `uint32_t` value for the message.
+    // Currently this is functionally equivalent to:
+    // typedef struct {
+    //     uint32_t map   : 8 = 0x80u;      // constant
+    //     uint32_t cnt   : 8 = counter;    // incremented each time a message is sent
+    //     uint32_t RFU   : 8 = 0x00u;      // reserved for future use
+    //     uint32_t Value : 8 = message_id; // actual message
+    // } icm_message_t;
+    // 
 
+    // Values in range 0x60000000 to 0xCFFFFFFF are unmapped on RP2040
+    // Choosing 0x80000000..0x80FFFFFF for intercore messages
+    ++static_message_count;
+    uint32_t icm_value =
+        (uint32_t)0x80000000u
+        |  (((uint32_t)static_message_count) << 16)
+        |  message_id;
     multicore_fifo_push_blocking(icm_value);
 
     do {

--- a/pirate/intercore_helpers.c
+++ b/pirate/intercore_helpers.c
@@ -12,7 +12,7 @@
 // alternative cross-core communication methods if needed.
 
 
-void icm_core0_send_message(bp_icm_message_t message_id) {
+void icm_core0_send_message_synchronous(bp_icm_message_t message_id) {
     // NOTE: although split into multiple lines for readability,
     //       the compiler optimizes this quite well!
 

--- a/pirate/intercore_helpers.c
+++ b/pirate/intercore_helpers.c
@@ -1,0 +1,40 @@
+#include "pirate/intercore_helpers.h"
+#include "pirate.h"
+#include "assert.h"
+
+
+// This wrapper is a response to manual code review noting
+// at least two coding patterns, neither of which is all
+// that safe...
+// Using a wrapper also makes it easier to later
+// change to a more robust cross-core communication
+// with minimal code changes elsewhere.
+
+
+void icm_core0_send_message(uint8_t message_id) {
+    static uint8_t static_message_count = 0u;
+
+    // NOTE: although split into multiple lines for readability,
+    //       the compiler optimizes this quite well!
+
+    // encode a message counter into the value,
+    // but keep top byte as zero to avoid overlap with RP2040 valid memory locations
+    uint32_t icm_value = ++static_message_count;
+
+    // shift those bits to avoid overlap with the encoded message_id parameter
+    static_assert(sizeof(message_id) < sizeof(icm_value));
+    icm_value <<= sizeof(message_id)*8;
+
+    // add in the message_id
+    icm_value |= message_id;
+
+    multicore_fifo_push_blocking(icm_value);
+
+    do {
+        uint32_t response = multicore_fifo_pop_blocking();
+        // in the current design, any message other than
+        // the one sent indicates a serious de-synchronization
+        assert(response == message_id);
+        if (response == message_id) return;
+    } while (1);
+}

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -11,21 +11,23 @@
 //
 
 // Having defined names (rather than magic numbers) improves readability of the code.
-#define BP_ICM_INIT_CORE1            ((uint8_t)0xA5) // Used to synchronize Core0 and Core1 intialization.
-#define BP_ICM_DISABLE_LCD_UPDATES   ((uint8_t)0xF0) // disables LCD updates / IRQ
-#define BP_ICM_ENABLE_LCD_UPDATES    ((uint8_t)0xF1) // enables LCD updates / IRQ
-#define BP_ICM_FORCE_LCD_UPDATE      ((uint8_t)0xF2) // enable LCD updates / IRQ and force an update
-#define BP_ICM_DISABLE_RGB_UPDATES   ((uint8_t)0xF3) // disables RGB updates / IRQ
-#define BP_ICM_ENABLE_RGB_UPDATES    ((uint8_t)0xF4) // enables RGB updates / IRQ
+typedef uint8_t bp_icm_message_t;
+#define BP_ICM_INIT_CORE1            ((bp_icm_message_t)0xA5) // Used to synchronize Core0 and Core1 intialization.
+#define BP_ICM_DISABLE_LCD_UPDATES   ((bp_icm_message_t)0xF0) // disables LCD updates / IRQ
+#define BP_ICM_ENABLE_LCD_UPDATES    ((bp_icm_message_t)0xF1) // enables LCD updates / IRQ
+#define BP_ICM_FORCE_LCD_UPDATE      ((bp_icm_message_t)0xF2) // enable LCD updates / IRQ and force an update
+#define BP_ICM_DISABLE_RGB_UPDATES   ((bp_icm_message_t)0xF3) // disables RGB updates / IRQ
+#define BP_ICM_ENABLE_RGB_UPDATES    ((bp_icm_message_t)0xF4) // enables RGB updates / IRQ
 
 // While core1 has a single point where these messages are received / responded to,
 // core0 sends the messages from many files.
 // Funnel into low-overhead wrapper to catch errors in cross-core synchronization,
 // because debugging such issues is ... non-trivial.
-void icm_core0_send_message(uint8_t message_id);
+void icm_core0_send_message(bp_icm_message_t message_id);
 
 
 // Ultra-low overhead ... maybe even zero overhead with full optimizations.
-inline uint8_t icm_get_message(uint32_t icm_value) {
-    return (uint8_t)(icm_value & 0xFFu);
+inline bp_icm_message_t icm_get_message(uint32_t icm_raw_value) {
+    static_assert(sizeof(bp_icm_message_t) == 1); // else have to update this to mask differently
+    return (bp_icm_message_t)(icm_raw_value & 0xFFu);
 }

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -13,11 +13,11 @@
 // Having defined names (rather than magic numbers) improves readability of the code.
 #define BP_ICM_INIT_CORE1__REQUEST   ((uint8_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
 #define BP_ICM_INIT_CORE1__COMPLETE  ((uint8_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
-#define BP_ICM_VALUE_F0              ((uint8_t)0xF0) // disables LCD IRQ, disabled LCD updates
-#define BP_ICM_VALUE_F1              ((uint8_t)0xF1) // enables LCD IRQ, enables LCD updates
-#define BP_ICM_VALUE_F2              ((uint8_t)0xF2) // enable LCD IRQ, enabled and forces LCD update
-#define BP_ICM_VALUE_F3              ((uint8_t)0xF3) // disables RGB IRQ
-#define BP_ICM_VALUE_F4              ((uint8_t)0xF4) // enables RGB IRQ
+#define BP_ICM_DISABLE_LCD_UPDATES   ((uint8_t)0xF0) // disables LCD updates / IRQ
+#define BP_ICM_ENABLE_LCD_UPDATES    ((uint8_t)0xF1) // enables LCD updates / IRQ
+#define BP_ICM_FORCE_LCD_UPDATE      ((uint8_t)0xF2) // enable LCD updates / IRQ and force an update
+#define BP_ICM_DISABLE_RGB_UPDATES   ((uint8_t)0xF3) // disables RGB updates / IRQ
+#define BP_ICM_ENABLE_RGB_UPDATES    ((uint8_t)0xF4) // enables RGB updates / IRQ
 
 // While core1 has a single point where these messages are received / responded to,
 // core0 sends the messages from many files.

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -1,0 +1,21 @@
+// Inter-Core Messages
+
+#include "pico/multicore.h"
+
+// BUGBUG -- Not using particularly safe techniques...
+//           Some places, core0 sends, and then loops until core1 sends same value as response.
+//           (This could lose other messages that are sent, if any.)
+//           Other places, core0 sends, and then loops until core1 sends any value as response.
+//           (This could improperly continue even if the response is for a different message.)
+#define BP_ICM_INIT_CORE1__REQUEST   ((uint8_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
+#define BP_ICM_INIT_CORE1__COMPLETE  ((uint8_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
+#define BP_ICM_VALUE_F0              ((uint8_t)0xF0) // disables LCD IRQ, disabled LCD updates
+#define BP_ICM_VALUE_F1              ((uint8_t)0xF1) // enables LCD IRQ, enables LCD updates
+#define BP_ICM_VALUE_F2              ((uint8_t)0xF2) // enable LCD IRQ, enabled and forces LCD update
+#define BP_ICM_VALUE_F3              ((uint8_t)0xF3) // disables RGB IRQ
+#define BP_ICM_VALUE_F4              ((uint8_t)0xF4) // enables RGB IRQ
+
+void icm_core0_send_message(uint8_t message_id);
+inline uint8_t icm_get_message(uint32_t icm_value) {
+    return (uint8_t)(icm_value & 0xFFu);
+}

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -2,11 +2,15 @@
 
 #include "pico/multicore.h"
 
-// BUGBUG -- Not using particularly safe techniques...
-//           Some places, core0 sends, and then loops until core1 sends same value as response.
-//           (This could lose other messages that are sent, if any.)
-//           Other places, core0 sends, and then loops until core1 sends any value as response.
-//           (This could improperly continue even if the response is for a different message.)
+// This file added in response to manual code review discovering the following:
+//     Some places, core0 sends, and then loops until core1 sends ***same*** value as response.
+//     (This could lose other messages that are sent, if any.)
+//
+//     Other places, core0 sends, and then loops until core1 sends ***any*** value as response.
+//     (This could improperly continue even if the response is for a different message.)
+//
+
+// Having defined names (rather than magic numbers) improves readability of the code.
 #define BP_ICM_INIT_CORE1__REQUEST   ((uint8_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
 #define BP_ICM_INIT_CORE1__COMPLETE  ((uint8_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
 #define BP_ICM_VALUE_F0              ((uint8_t)0xF0) // disables LCD IRQ, disabled LCD updates
@@ -15,7 +19,14 @@
 #define BP_ICM_VALUE_F3              ((uint8_t)0xF3) // disables RGB IRQ
 #define BP_ICM_VALUE_F4              ((uint8_t)0xF4) // enables RGB IRQ
 
+// While core1 has a single point where these messages are received / responded to,
+// core0 sends the messages from many files.
+// Funnel into low-overhead wrapper to catch errors in cross-core synchronization,
+// because debugging such issues is ... non-trivial.
 void icm_core0_send_message(uint8_t message_id);
+
+
+// Ultra-low overhead ... maybe even zero overhead with full optimizations.
 inline uint8_t icm_get_message(uint32_t icm_value) {
     return (uint8_t)(icm_value & 0xFFu);
 }

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -9,6 +9,9 @@
 //     Other places, core0 sends, and then loops until core1 sends ***any*** value as response.
 //     (This could improperly continue even if the response is for a different message.)
 //
+//     There are strong warnings AGAINST using multicore FIFOs unless can be sure not used
+//     by any RTOS layer, intercore lockout functionality, etc.  Thus, consider changing these
+//     to use a standard queue instead.
 
 // Having defined names (rather than magic numbers) improves readability of the code.
 typedef uint8_t bp_icm_message_t;

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -23,7 +23,7 @@ typedef uint8_t bp_icm_message_t;
 // core0 sends the messages from many files.
 // Funnel into low-overhead wrapper to catch errors in cross-core synchronization,
 // because debugging such issues is ... non-trivial.
-void icm_core0_send_message(bp_icm_message_t message_id);
+void icm_core0_send_message_synchronous(bp_icm_message_t message_id);
 
 
 // Ultra-low overhead ... maybe even zero overhead with full optimizations.

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -11,8 +11,7 @@
 //
 
 // Having defined names (rather than magic numbers) improves readability of the code.
-#define BP_ICM_INIT_CORE1__REQUEST   ((uint8_t)0x00) // BUGBUG -- Most messages use same ID for request/response...
-#define BP_ICM_INIT_CORE1__COMPLETE  ((uint8_t)0xFF) // BUGBUG -- Most messages use same ID for request/response...
+#define BP_ICM_INIT_CORE1            ((uint8_t)0xA5) // Used to synchronize Core0 and Core1 intialization.
 #define BP_ICM_DISABLE_LCD_UPDATES   ((uint8_t)0xF0) // disables LCD updates / IRQ
 #define BP_ICM_ENABLE_LCD_UPDATES    ((uint8_t)0xF1) // enables LCD updates / IRQ
 #define BP_ICM_FORCE_LCD_UPDATE      ((uint8_t)0xF2) // enable LCD updates / IRQ and force an update

--- a/pirate/mcu.c
+++ b/pirate/mcu.c
@@ -6,6 +6,7 @@
 #include "pico/bootrom.h"
 
 uint64_t mcu_get_unique_id(void){
+	static_assert(sizeof(pico_unique_board_id_t) == sizeof(uint64_t), "pico_unique_board_id_t is not 64 bits");
 	pico_unique_board_id_t id;
 	pico_get_unique_board_id(&id);
     return *((uint64_t*)(id.id));

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -107,9 +107,9 @@ uint32_t color_wheel_div(uint8_t pos) {
 }
 
 
-void rgb_assign_color(uint32_t l, uint32_t color){
+void rgb_assign_color(uint32_t index_mask, uint32_t color){
     for (int i=0;i<RGB_LEN; i++){
-        if(l&(1u<<i)) {
+        if(index_mask&(1u<<i)) {
             leds[i]=color;
         }
     }

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -360,7 +360,7 @@ bool rgb_timer_callback(struct repeating_timer *t){
     uint32_t color_grb;
     bool next=false;
 
-    if(system_config.led_effect<7) {
+    if(system_config.led_effect<7) { // BUGBUG -- define enum for the valid set of led effects (with appropriately descriptive names)
         mode = system_config.led_effect;
     }
     

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -8,18 +8,103 @@
 
 #define RGB_MAX_BRIGHT 32
 
-// pairs of LEDs for a top left corner to bottom right corner fade
-// not all LEDs have a pair, they are included with a neighboring LED pair
+// Note that both the layout and overall count of pixels
+// has changed between revisions.  As a result, the count
+// of elements for any of these arrays may differ.
+//
+// groups_top_left[]:
+//    defines led_bitmasks that generally start at the top left corner of the device,
+//    and continue in a diagnol pattern.  Generally setup in pairs, although some groups
+//    may set three pixels at a time.
+//
+// groups_center_left[]:
+//    tbd
+//
+// groups_center_clockwise[]:
+//    tbd
+//
+// groups_top_down[]:
+//    tbd
+//
+// Also add a new constant, COUNT_OF_PIXELS, to define the number
+// pixels on each revision of board.
 #if BP5_REV <= 9
-    const uint32_t groups_top_left[]={((1u<<1) | (1u<<2)), ((1u<<0) | (1u<<3)), ((1u<<4) | (1u<<5) | (1u<<15)), ((1u<<6) | (1u<<7) | (1u<<14)), ((1u<<8) | (1u<<13)), ((1u<<9) | (1u<<12)), ((1u<<10) | (1u<<11)) };
-    const uint32_t groups_center_left[]={(1u<<3)|(1u<<4),(1u<<2)|(1u<<5),(1u<<1)|(1u<<6),(1u<<0)|(1u<<7)|(1u<<8)|(1<<9),(1u<<10)|(1u<<15),(1u<<11)|(1u<<14),(1u<<12)|(1u<<13)};  
-    const uint32_t groups_center_clockwise[]={(1u<<13)|(1u<<14),(1u<<15), (1u<<0)|(1u<<1), (1u<<2)|(1u<<3), (1u<<4)|(1u<<5),(1u<<6)|(1u<<7),(1u<<8)|(1u<<9), (1u<<10),(1u<<11)|(1u<<12)};
-    const uint32_t groups_top_down[]={0b0011001010011001,0b1100110101100110}; //MSB is last led in string...
+    static const uint8_t COUNT_OF_PIXELS = 16;
+    const uint32_t groups_top_left[]={
+        ((1u <<  1)              | (1u <<  2)),
+        ((1u <<  0)              | (1u <<  3)),
+        ((1u <<  4) | (1u <<  5) | (1u << 15)),
+        ((1u <<  6) | (1u <<  7) | (1u << 14)),
+        ((1u <<  8)              | (1u << 13)),
+        ((1u <<  9)              | (1u << 12)),
+        ((1u << 10)              | (1u << 11)),
+    };
+    const uint32_t groups_center_left[]={
+        ((1u <<  3) | (1u <<  4)),
+        ((1u <<  2) | (1u <<  5)),
+        ((1u <<  1) | (1u <<  6)),
+        ((1u <<  0) | (1u <<  7) | (1u <<  8) | (1 <<  9)), // BUGBUG -- this seems ... off?  combines 7/8/9 as one logical pixel for this?
+        ((1u << 15) | (1u << 10)),
+        ((1u << 14) | (1u << 11)),
+        ((1u << 13) | (1u << 12)),
+    };
+    const uint32_t groups_center_clockwise[]={
+        ((1u << 13) | (1u << 14)),
+        ((1u << 15)             ), 
+        ((1u <<  0) | (1u <<  1)),
+        ((1u <<  2) | (1u <<  3)),
+        ((1u <<  4) | (1u <<  5)),
+        ((1u <<  6) | (1u <<  7)),
+        ((1u <<  8) | (1u <<  9)),
+        ((1u << 10)             ), 
+        ((1u << 11) | (1u << 12)),
+    };
+    const uint32_t groups_top_down[]={ //MSB is last led in string...
+        0b0011001010011001,
+        0b1100110101100110,
+        //|...|...|...|... == 16 bits == COUNT_OF_PIXELS
+    }; 
 #elif BP5_REV >= 10
-    const uint32_t groups_top_left[]={((1u<<2) | (1u<<3)), ((1u<<1) | (1u<<4)), ((1u<<0) | (1u<<17) | (1u<<5)), ((1u<<16) | (1u<<6)), ((1u<<15) | (1u<<7)), ((1u<<14) | (1u<<9) | (1u<<8)), ((1u<<13) | (1u<<10) | (1u<<5)), ((1u<<12)|(1u<<11))};
-    const uint32_t groups_center_left[]={(1u<<4)|(1u<<5),(1u<<3)|(1u<<6),(1u<<2)|(1u<<7),(1u<<1)|(1u<<8), (1u<<0)|(1<<9), (1u<<17)|(1u<<10), (1u<<16)|(1u<<11), (1u<<12)|(1u<<15), (1u<<13)|(1u<<14)};  
-    const uint32_t groups_center_clockwise[]={(1u<<14)|(1u<<15),(1u<<16), (1u<<17)|(1u<<0), (1u<<1)|(1u<<2), (1u<<3)|(1u<<4), (1u<<5)|(1u<<6), (1u<<7), (1u<<8)|(1u<<9), (1u<<10)|(1u<<11), (1u<<12)|(1u<<13)};
-    const uint32_t groups_top_down[]={0b011001101011001101, 0b100110010100110010}; //MSB is last led in string...
+
+    static const uint8_t COUNT_OF_PIXELS = 18;
+    const uint32_t groups_top_left[]={
+        ((1u <<  2) | (1u <<  3)),
+        ((1u <<  1) | (1u <<  4)),
+        ((1u <<  0) | (1u <<  5) | (1u << 17)), // three LEDs at a time here (17&0 as pair)
+        ((1u << 16) | (1u <<  6)),
+        ((1u << 15) | (1u <<  7)),
+        ((1u << 14) | (1u <<  8) | (1u <<  9)), // three LEDs at a time here (8&9 as pair)
+        ((1u << 13) | (1u << 10) | (1u <<  5)), // BUGBUG -- 5 is repeated here
+        ((1u << 12) | (1u << 11)),
+    };
+    const uint32_t groups_center_left[]={
+        (1u <<  4) | (1u <<  5),
+        (1u <<  3) | (1u <<  6),
+        (1u <<  2) | (1u <<  7),
+        (1u <<  1) | (1u <<  8),
+        (1u <<  0) | (1u <<  9),
+        (1u << 17) | (1u << 10),
+        (1u << 16) | (1u << 11),
+        (1u << 15) | (1u << 12),
+        (1u << 14) | (1u << 13),
+    };
+    const uint32_t groups_center_clockwise[]={
+        (1u << 14) | (1u << 15),
+        (1u << 16)             ,
+        (1u << 17) | (1u <<  0),
+        (1u <<  1) | (1u <<  2),
+        (1u <<  3) | (1u <<  4),
+        (1u <<  5) | (1u <<  6),
+        (1u <<  7)             ,
+        (1u <<  8) | (1u <<  9),
+        (1u << 10) | (1u << 11),
+        (1u << 12) | (1u << 13),
+    };
+    const uint32_t groups_top_down[]={ //MSB is last led in string...
+        0b011001101011001101,
+        0b100110010100110010,
+        //..|...|...|...|... == 18 bits == COUNT_OF_PIXELS
+    };
 #endif
 
 uint32_t leds[RGB_LEN];
@@ -113,78 +198,124 @@ uint32_t color_wheel_div(uint8_t pos) {
     return ((g/system_config.led_brightness)<<16) | ((r/system_config.led_brightness)<<8) | (b/system_config.led_brightness);
 }
 
-
-void rgb_assign_grb_color(uint32_t index_mask, uint32_t color){
+// BUGBUG -- Many of the callers convert an RGB color to GRB before passing
+//           it to this function.  This means the color parameter is GRB (not RGB)?
+// TODO: define RGB and GRB structures, and use them for clarity rather than uint32_t
+void rgb_assign_grb_color(uint32_t index_mask, uint32_t grb_color){
     for (int i=0;i<RGB_LEN; i++){
         if(index_mask&(1u<<i)) {
-            leds[i]=color;
+            leds[i]=grb_color;
         }
     }
 }
 
 //something like this to cycle, delay, return done
-bool rgb_master(const uint32_t *groups, uint8_t group_count, uint32_t (*color_wheel)(uint8_t color), uint8_t color_count, uint8_t color_increment, uint8_t cycles, uint8_t delay_ms ){
-    static uint8_t color=0;
-    static uint16_t c=0;
+//This needs some more documentation:
+//  groups          the pixel groups; a pointer to an array of index_masks,
+//                  each index_mask indicating which LEDs are considered part of the group
+//  group_count     how many groups in that array
+//  color_wheel     a function pointer; Function must take a single byte parameter
+//                  and return a ***GRB-formatted*** color -- BUGBUG -- Verify color order that is expected?
+//  color_count     the distinct seed values for color_wheel() parameter.
+//                  rgb_master() will ensure the parameter is always in range [0..color_count-1]
+//  color_increment the PER GROUP increment of colors for the color_wheel() parameter.
+//returns false if additional iterations are needed.
+//returns true if sufficient iterations have been completed.
+//
+// HACKHACK -- to ensure known starting state (reset the static variables)
+//             can call with group_count=0, cycles=0
+bool rgb_master(
+    const uint32_t *groups,
+    uint8_t group_count,
+    uint32_t (*color_wheel)(uint8_t color),
+    uint8_t color_count,
+    uint8_t color_increment,
+    uint8_t cycles,
+    uint8_t delay_ms_unused_parameter /* unused parameter ... was delay_ms ... BUGBUG: Remove unused parameter */
+    ){
+    static uint8_t color_idx=0; // one cycle is defined as `color_count` calls to this function
+    static uint16_t completed_cycles=0;
 
-    for(int i=0; i< group_count; i++){
-        rgb_assign_grb_color(groups[i], color_wheel( (color+(i*color_increment))) );
+    for(int i=0; i< group_count; i++) {
+        // group_count     is uint8_t (1..255)
+        // color_increment is uint8_t (0..255)
+        // color_count     is uint8_t (1..255)
+        // therefore, maximum value of tmp_color is
+        // color_count + (group_count * color_increment) = 255 + (255 * 255) = 65010
+        // This value fits in uint16_t ... but just use 32-bits.
+        uint32_t tmp_color_idx = color_idx + (i*color_increment);
+        tmp_color_idx %= color_count; // ensures safe to cast to uint8_t
+        uint32_t rgb_color = color_wheel((uint8_t)tmp_color_idx);
+        rgb_assign_grb_color(groups[i], rgb_color);
     }
     rgb_send();
+    ++color_idx;
 
-    //finished one complete cycle
-    if((color==color_count)){
-        color=0;
-        c++;
-        if(c==cycles){
-            c=0;
+    //finished one complete cycle through the colors
+    if (color_idx == color_count) {
+        color_idx = 0;
+        ++completed_cycles;
+        if (completed_cycles >= cycles) {
+            // returning TRUE indicates to the caller that the animation has completed.
+            // resets the cycle count to zero
+            // BUGBUG - LEAVES THE color_idx AT CURRENT VALUE (?!) ... non-deterministic for caller
+            completed_cycles = 0;
+            // color_idx = 0
             return true;
-        }        
+        }
     }
 
-    color+=1;
     return false;
 }
 
 struct repeating_timer rgb_timer;
 
-bool rgb_scanner(void){
-    static uint16_t bitmask=0b1000000;
-    static uint8_t delay=0;
-    static uint8_t color=0;
+bool rgb_scanner(void) {
+    // TODO: decode this animation and add notes on what it's intended result is
+    static_assert(count_of(groups_center_left) <= (sizeof(uint16_t)*8), "uint16_t too small to hold count_of(groups_center_left) elements");
+    
+    // led_bitmask has two purposes:
+    // 1. it
+    static uint16_t led_bitmask = 0b1000000; // BUGBUG -- should this be (0x01 << (count_of(groups_center_left)))?
+    static uint8_t frame_delay_count = 0;
+    static uint8_t color_idx = 0;
     
     const uint32_t colors[]={
-    0xFF0000, 0xD52A00, 0xAB5500, 0xAB7F00,
-    0xABAB00, 0x56D500, 0x00FF00, 0x00D52A,
-    0x00AB55, 0x0056AA, 0x0000FF, 0x2A00D5,
-    0x5500AB, 0x7F0081, 0xAB0055, 0xD5002B
+        0xFF0000, 0xD52A00, 0xAB5500, 0xAB7F00,
+        0xABAB00, 0x56D500, 0x00FF00, 0x00D52A,
+        0x00AB55, 0x0056AA, 0x0000FF, 0x2A00D5,
+        0x5500AB, 0x7F0081, 0xAB0055, 0xD5002B
     };
 
-    if(delay){
-        delay--;
+    if (frame_delay_count){
+        frame_delay_count--;
         return false;
     }
-    uint32_t color_grb=((((colors[color]&0xff0000)/system_config.led_brightness)&0xff0000)>>8);
-    color_grb|=((((colors[color]&0x00ff00)/system_config.led_brightness)&0x00ff00)<<8);
-    color_grb|=((((colors[color]&0x0000ff)/system_config.led_brightness)&0x0000ff));
+    uint32_t color_grb = 0; // swap from RGB to GRB
+    color_grb |= (( ((colors[color_idx] & 0xff0000) / system_config.led_brightness) & 0xff0000) >> 8);
+    color_grb |= (( ((colors[color_idx] & 0x00ff00) / system_config.led_brightness) & 0x00ff00) << 8);
+    color_grb |= (( ((colors[color_idx] & 0x0000ff) / system_config.led_brightness) & 0x0000ff)     );
     for(int i=0; i< count_of(groups_center_left); i++){
-        rgb_assign_grb_color(groups_center_left[i], (bitmask & (1u<<i))?color_grb:0x0a0a0a);
+        rgb_assign_grb_color(groups_center_left[i], (led_bitmask & (1u<<i)) ? color_grb : 0x0a0a0a);
     }   
     rgb_send();
     
-    if(bitmask & 0b1){
-        delay=0xF0;
-        bitmask=(0x01 << (count_of(groups_center_left)));
-        color++;
-        if(color==count_of(colors)){
-            color=0;
-            bitmask=bitmask>>1;
+    // led_bitmask has two purposes:
+    // this detects the end of one cycle of animation
+
+    if(led_bitmask & 0b1) {
+        frame_delay_count=0xF0; // the final step of animation is shown 241 times (the last step of each cycle)
+        led_bitmask = (0x01 << (count_of(groups_center_left)));
+        color_idx++;
+        if(color_idx==count_of(colors)){
+            color_idx=0;
+            led_bitmask >>= 1;
             return true;
         }
     }else{
-        delay=0x8;
+        frame_delay_count = 0x8; // every non-final step of the animation is shown nine times
     }
-    bitmask=bitmask>>1;
+    led_bitmask >>= 1;
     return false;
 }
 
@@ -204,18 +335,18 @@ bool rgb_timer_callback(struct repeating_timer *t){
             rgb_send();  
             break;          
         case 1:
-            //solid
-            color_grb  = (( ((system_config.led_color & 0xff0000) / system_config.led_brightness ) & 0xff0000) >> 8);
-            color_grb |= (( ((system_config.led_color & 0x00ff00) / system_config.led_brightness ) & 0x00ff00) << 8);
-            color_grb |= (( ((system_config.led_color & 0x0000ff) / system_config.led_brightness ) & 0x0000ff)     );
+            //solid color ... so just convert from RGB to GRB
+            color_grb  = (( ((system_config.led_color & 0xff0000) / system_config.led_brightness) & 0xff0000) >> 8);
+            color_grb |= (( ((system_config.led_color & 0x00ff00) / system_config.led_brightness) & 0x00ff00) << 8);
+            color_grb |= (( ((system_config.led_color & 0x0000ff) / system_config.led_brightness) & 0x0000ff)     );
             rgb_assign_grb_color(0xffffffff, color_grb);
             rgb_send();
             break;
         case 2:
-            next = rgb_master(groups_top_left,         count_of(groups_top_left),         &color_wheel_div, 0xff, (0xff/count_of(groups_top_left)), 5, 10);
+            next = rgb_master(groups_top_left,         count_of(groups_top_left),         &color_wheel_div, 0xff, (0xff/count_of(groups_top_left)        ), 5, 10);
             break;
         case 3:
-            next = rgb_master(groups_center_left,      count_of(groups_center_left),      &color_wheel_div, 0xff, (0xff/count_of(groups_center_left)), 5, 10);
+            next = rgb_master(groups_center_left,      count_of(groups_center_left),      &color_wheel_div, 0xff, (0xff/count_of(groups_center_left)     ), 5, 10);
             break;
         case 4:
             next = rgb_master(groups_center_clockwise, count_of(groups_center_clockwise), &color_wheel_div, 0xff, (0xff/count_of(groups_center_clockwise)), 5, 10);

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -84,6 +84,13 @@ uint32_t color_wheel(uint8_t pos) {
   }   
 }
 
+/*
+ * Put a value 0 to 255 in to get a color value.
+ * The colours are a transition r -> g -> b -> back to r
+ * Inspired by the Adafruit examples.
+ * The ..._div() version of the function divides each of
+ * the R/G/B values by the system config's led brightness.
+ */
 uint32_t color_wheel_div(uint8_t pos) {
     pos = 255 - pos;
     uint8_t r,g,b;
@@ -202,26 +209,26 @@ bool rgb_timer_callback(struct repeating_timer *t){
             break;          
         case 1:
             //solid
-            color_grb=((((colors[system_config.led_color]&0xff0000)/system_config.led_brightness)&0xff0000)>>8);
+            color_grb =((((colors[system_config.led_color]&0xff0000)/system_config.led_brightness)&0xff0000)>>8);
             color_grb|=((((colors[system_config.led_color]&0x00ff00)/system_config.led_brightness)&0x00ff00)<<8);
             color_grb|=((((colors[system_config.led_color]&0x0000ff)/system_config.led_brightness)&0x0000ff));            
             rgb_assign_color(0xffffffff, color_grb);
             rgb_send();
             break;
         case 2:
-            next = rgb_master(groups_top_left, count_of(groups_top_left), &color_wheel_div, 0xff, (0xff/count_of(groups_top_left)), 5, 10);
+            next = rgb_master(groups_top_left,         count_of(groups_top_left),         &color_wheel_div, 0xff, (0xff/count_of(groups_top_left)), 5, 10);
             break;
         case 3:
-            next=rgb_master(groups_center_left, count_of(groups_center_left), &color_wheel_div, 0xff, (0xff/count_of(groups_center_left)), 5, 10);
+            next = rgb_master(groups_center_left,      count_of(groups_center_left),      &color_wheel_div, 0xff, (0xff/count_of(groups_center_left)), 5, 10);
             break;
         case 4:
-            next=rgb_master(groups_center_clockwise, count_of(groups_center_clockwise), &color_wheel_div, 0xff, (0xff/count_of(groups_center_clockwise)), 5, 10);
+            next = rgb_master(groups_center_clockwise, count_of(groups_center_clockwise), &color_wheel_div, 0xff, (0xff/count_of(groups_center_clockwise)), 5, 10);
             break;
         case 5:
-            next = rgb_master(groups_top_down, count_of(groups_top_down), &color_wheel_div, 0xff, 30, 5, 10);
+            next = rgb_master(groups_top_down,         count_of(groups_top_down),         &color_wheel_div, 0xff, 30, 5, 10);
             break;
         case 6:
-            next= rgb_scanner();
+            next = rgb_scanner();
             break;
     }
 

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -114,7 +114,7 @@ uint32_t color_wheel_div(uint8_t pos) {
 }
 
 
-void rgb_assign_color(uint32_t index_mask, uint32_t color){
+void rgb_assign_grb_color(uint32_t index_mask, uint32_t color){
     for (int i=0;i<RGB_LEN; i++){
         if(index_mask&(1u<<i)) {
             leds[i]=color;
@@ -128,7 +128,7 @@ bool rgb_master(const uint32_t *groups, uint8_t group_count, uint32_t (*color_wh
     static uint16_t c=0;
 
     for(int i=0; i< group_count; i++){
-        rgb_assign_color(groups[i], color_wheel( (color+(i*color_increment))) );
+        rgb_assign_grb_color(groups[i], color_wheel( (color+(i*color_increment))) );
     }
     rgb_send();
 
@@ -168,7 +168,7 @@ bool rgb_scanner(void){
     color_grb|=((((colors[color]&0x00ff00)/system_config.led_brightness)&0x00ff00)<<8);
     color_grb|=((((colors[color]&0x0000ff)/system_config.led_brightness)&0x0000ff));
     for(int i=0; i< count_of(groups_center_left); i++){
-        rgb_assign_color(groups_center_left[i], (bitmask & (1u<<i))?color_grb:0x0a0a0a);
+        rgb_assign_grb_color(groups_center_left[i], (bitmask & (1u<<i))?color_grb:0x0a0a0a);
     }   
     rgb_send();
     
@@ -191,10 +191,6 @@ bool rgb_scanner(void){
 bool rgb_timer_callback(struct repeating_timer *t){
     static uint8_t mode=2;
 
-    //shortened list of HSV colors from fastLED
-    const uint32_t colors[]={0xFF0000, 0xD52A00, 0xAB7F00,0x00FF00, 0x0000FF, 0x5500AB, 0xAB0055};
-
-
     uint32_t color_grb;
     bool next=false;
 
@@ -204,15 +200,15 @@ bool rgb_timer_callback(struct repeating_timer *t){
     
     switch(mode) {
         case 0: //disable
-            rgb_assign_color(0xffffffff, 0x000000);
+            rgb_assign_grb_color(0xffffffff, 0x000000);
             rgb_send();  
             break;          
         case 1:
             //solid
-            color_grb =((((colors[system_config.led_color]&0xff0000)/system_config.led_brightness)&0xff0000)>>8);
-            color_grb|=((((colors[system_config.led_color]&0x00ff00)/system_config.led_brightness)&0x00ff00)<<8);
-            color_grb|=((((colors[system_config.led_color]&0x0000ff)/system_config.led_brightness)&0x0000ff));            
-            rgb_assign_color(0xffffffff, color_grb);
+            color_grb  = (( ((system_config.led_color & 0xff0000) / system_config.led_brightness ) & 0xff0000) >> 8);
+            color_grb |= (( ((system_config.led_color & 0x00ff00) / system_config.led_brightness ) & 0x00ff00) << 8);
+            color_grb |= (( ((system_config.led_color & 0x0000ff) / system_config.led_brightness ) & 0x0000ff)     );
+            rgb_assign_grb_color(0xffffffff, color_grb);
             rgb_send();
             break;
         case 2:
@@ -281,7 +277,7 @@ void rgb_init(void)
 
 void rgb_set_all(uint8_t r, uint8_t g, uint8_t b){
     uint32_t color= ((g/system_config.led_brightness)<<16) | ((r/system_config.led_brightness)<<8) | (b/system_config.led_brightness);
-    rgb_assign_color(0xffffffff, color);
+    rgb_assign_grb_color(0xffffffff, color);
     rgb_send();
 }
 

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -271,20 +271,20 @@ bool storage_ls(const char *location, const char *ext, const uint8_t flags)
 const char system_config_file[]="bpconfig.bp";
 
 struct _mode_config_t system_config_json[]={
-    {"$.terminal_language", &system_config.terminal_language},
-    {"$.terminal_ansi_color", &system_config.terminal_ansi_color},
-    {"$.terminal_ansi_statusbar", &system_config.terminal_ansi_statusbar},
-    {"$.display_format", &system_config.display_format},   
-    {"$.lcd_screensaver_active", &system_config.lcd_screensaver_active},
-    {"$.lcd_timeout", &system_config.lcd_timeout},
-    {"$.led_effect", &system_config.led_effect},
-    {"$.led_color", &system_config.led_color},
-    {"$.led_brightness", &system_config.led_brightness},   
-    {"$.terminal_usb_enable", &system_config.terminal_usb_enable},
-    {"$.terminal_uart_enable", &system_config.terminal_uart_enable},
-    {"$.terminal_uart_number", &system_config.terminal_uart_number},
-    {"$.debug_uart_enable", &system_config.debug_uart_enable},
-    {"$.debug_uart_number", &system_config.debug_uart_number},
+    {"$.terminal_language",       &system_config.terminal_language       },
+    {"$.terminal_ansi_color",     &system_config.terminal_ansi_color     },
+    {"$.terminal_ansi_statusbar", &system_config.terminal_ansi_statusbar },
+    {"$.display_format",          &system_config.display_format          },   
+    {"$.lcd_screensaver_active",  &system_config.lcd_screensaver_active  },
+    {"$.lcd_timeout",             &system_config.lcd_timeout             },
+    {"$.led_effect",              &system_config.led_effect              },
+    {"$.led_color",               &system_config.led_color               },
+    {"$.led_brightness",          &system_config.led_brightness          },   
+    {"$.terminal_usb_enable",     &system_config.terminal_usb_enable     },
+    {"$.terminal_uart_enable",    &system_config.terminal_uart_enable    },
+    {"$.terminal_uart_number",    &system_config.terminal_uart_number    },
+    {"$.debug_uart_enable",       &system_config.debug_uart_enable       },
+    {"$.debug_uart_number",       &system_config.debug_uart_number       },
 };
 
 uint32_t storage_save_config(void){

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -17,9 +17,9 @@
 #include "pirate/mem.h"
 #include "ui/ui_cmdln.h"
 
-FATFS fs;		/* FatFs work area needed for each volume */
-//FIL fil;			/* File object needed for each open file */
-//FRESULT fr;     /* FatFs return code */
+FATFS fs;        /* FatFs work area needed for each volume */
+//FIL fil;         /* File object needed for each open file */
+//FRESULT fr;      /* FatFs return code */
 // Size of read/write.
 #define BUF_SIZE 512
 // Insure 4-byte alignment.
@@ -37,27 +37,27 @@ const char storage_fat_type_labels[][8] = {
 };
 
 const char *fresult_msg[]={
-	[FR_OK]="ok",                               /* (0) Succeeded */
-	[FR_DISK_ERR]="disk error",                 /* (1) A hard error occurred in the low level disk I/O layer */
-	[FR_INT_ERR]="assertion failed",            /* (2) Assertion failed */
-	[FR_NOT_READY]="drive not ready",			/* (3) The physical drive cannot work */
-	[FR_NO_FILE]="file not found",				/* (4) Could not find the file */
-	[FR_NO_PATH]="path not found",				/* (5) Could not find the path */
-	[FR_INVALID_NAME]="invalid path",		/* (6) The path name format is invalid */
-	[FR_DENIED]="access denied",				/* (7) Access denied due to prohibited access or directory full */
-	[FR_EXIST]="access denied",				/* (8) Access denied due to prohibited access */
-	[FR_INVALID_OBJECT]="invalid object",		/* (9) The file/directory object is invalid */
-	[FR_WRITE_PROTECTED]="write prohibited",		/* (10) The physical drive is write protected */
-	[FR_INVALID_DRIVE]="invalid drive",		/* (11) The logical drive number is invalid */
-	[FR_NOT_ENABLED]="drive not enabled",			/* (12) The volume has no work area */
-	[FR_NO_FILESYSTEM]="filesystem not found",		/* (13) There is no valid FAT volume */
-	[FR_MKFS_ABORTED]="format aborted",		/* (14) The f_mkfs() aborted due to any problem */
-	[FR_TIMEOUT]="timeout",				/* (15) Could not get a grant to access the volume within defined period */
-	[FR_LOCKED]="file locked",				/* (16) The operation is rejected according to the file sharing policy */
-	[FR_NOT_ENOUGH_CORE]="buffer full",		/* (17) LFN working buffer could not be allocated */
-	[FR_TOO_MANY_OPEN_FILES]="too many open files",	/* (18) Number of open files > FF_FS_LOCK */
-	[FR_INVALID_PARAMETER]="invalid parameter"	/* (19) Given parameter is invalid */
-};
+    [FR_OK]="ok",                                    /* ( 0) Succeeded */
+    [FR_DISK_ERR]="disk error",                      /* ( 1) A hard error occurred in the low level disk I/O layer */
+    [FR_INT_ERR]="assertion failed",                 /* ( 2) Assertion failed */
+    [FR_NOT_READY]="drive not ready",                /* ( 3) The physical drive cannot work */
+    [FR_NO_FILE]="file not found",                   /* ( 4) Could not find the file */
+    [FR_NO_PATH]="path not found",                   /* ( 5) Could not find the path */
+    [FR_INVALID_NAME]="invalid path",                /* ( 6) The path name format is invalid */
+    [FR_DENIED]="access denied",                     /* ( 7) Access denied due to prohibited access or directory full */
+    [FR_EXIST]="access denied",                      /* ( 8) Access denied due to prohibited access */
+    [FR_INVALID_OBJECT]="invalid object",            /* ( 9) The file/directory object is invalid */
+    [FR_WRITE_PROTECTED]="write prohibited",         /* (10) The physical drive is write protected */
+    [FR_INVALID_DRIVE]="invalid drive",              /* (11) The logical drive number is invalid */
+    [FR_NOT_ENABLED]="drive not enabled",            /* (12) The volume has no work area */
+    [FR_NO_FILESYSTEM]="filesystem not found",       /* (13) There is no valid FAT volume */
+    [FR_MKFS_ABORTED]="format aborted",              /* (14) The f_mkfs() aborted due to any problem */
+    [FR_TIMEOUT]="timeout",                          /* (15) Could not get a grant to access the volume within defined period */
+    [FR_LOCKED]="file locked",                       /* (16) The operation is rejected according to the file sharing policy */
+    [FR_NOT_ENOUGH_CORE]="buffer full",              /* (17) LFN working buffer could not be allocated */
+    [FR_TOO_MANY_OPEN_FILES]="too many open files",  /* (18) Number of open files > FF_FS_LOCK */
+    [FR_INVALID_PARAMETER]="invalid parameter"       /* (19) Given parameter is invalid */
+    };
 
 void storage_file_error(uint8_t res){
     if(res>0){
@@ -138,18 +138,18 @@ uint8_t storage_format(void){
 
 bool storage_save_binary_blob_rollover(char *data, uint32_t ptr,uint32_t size, uint32_t rollover){
     FRESULT fr;     /* FatFs return code */
-    FIL fil;			/* File object needed for each open file */
-    fr = f_open(&fil, "la.bin", FA_WRITE | FA_CREATE_ALWAYS);	
+    FIL fil;        /* File object needed for each open file */
+    fr = f_open(&fil, "la.bin", FA_WRITE | FA_CREATE_ALWAYS);    
     if (fr == FR_OK) {   
         //middle to end
         if(ptr+size<=rollover){     
-            f_write(&fil, &data[ptr], size, &bw);	
+            f_write(&fil, &data[ptr], size, &bw);    
         }else{
-            f_write(&fil, &data[ptr], rollover-ptr, &bw);	
-            f_write(&fil, &data[0], size-(rollover-ptr), &bw);	
+            f_write(&fil, &data[ptr], rollover-ptr, &bw);    
+            f_write(&fil, &data[0], size-(rollover-ptr), &bw);    
         }
-        fr = f_close(&fil);							
-        if (fr == FR_OK) {		
+        fr = f_close(&fil);                            
+        if (fr == FR_OK) {        
             return true;
         }else{
             return false;
@@ -174,8 +174,8 @@ uint32_t storage_save_mode(const char *filename, struct _mode_config_t *config_t
         return 0;
     }
     FRESULT fr;     /* FatFs return code */
-    FIL fil;			/* File object needed for each open file */
-    fr = f_open(&fil, filename, FA_CREATE_ALWAYS | FA_WRITE);	
+    FIL fil;        /* File object needed for each open file */
+    fr = f_open(&fil, filename, FA_CREATE_ALWAYS | FA_WRITE);    
     if (fr != FR_OK) {
         storage_file_error(fr);
         return 0;
@@ -196,8 +196,8 @@ uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t
         return 0;
     }
     FRESULT fr;     /* FatFs return code */
-    FIL fil;			/* File object needed for each open file */
-    fr = f_open(&fil, filename, FA_READ);	
+    FIL fil;        /* File object needed for each open file */
+    fr = f_open(&fil, filename, FA_READ);    
     if (fr != FR_OK) {
         return 0;
     }
@@ -206,7 +206,7 @@ uint32_t storage_load_mode(const char *filename, struct _mode_config_t *config_t
     //UINT btr,    /* [IN] Number of bytes to read */
     //UINT* br     /* [OUT] Number of bytes read */
     fr = f_read ( &fil, &json, sizeof(json), &br);
-	int found;
+    int found;
     for(uint8_t i=0; i<count; i++){
         uint32_t val=getint(json, br, config_t[i].tag, 0, &found);
         if(found){
@@ -228,7 +228,7 @@ bool storage_ls(const char *location, const char *ext, const uint8_t flags)
     FILINFO fno;
     int nfile, ndir;
 
-    fr = f_opendir(&dir, location);                       /* Open the directory */
+    fr = f_opendir(&dir, location);                   /* Open the directory */
     if (fr != FR_OK) {
         return false;
     }
@@ -274,12 +274,12 @@ struct _mode_config_t system_config_json[]={
     {"$.terminal_language",       &system_config.terminal_language       },
     {"$.terminal_ansi_color",     &system_config.terminal_ansi_color     },
     {"$.terminal_ansi_statusbar", &system_config.terminal_ansi_statusbar },
-    {"$.display_format",          &system_config.display_format          },   
+    {"$.display_format",          &system_config.display_format          },
     {"$.lcd_screensaver_active",  &system_config.lcd_screensaver_active  },
     {"$.lcd_timeout",             &system_config.lcd_timeout             },
     {"$.led_effect",              &system_config.led_effect              },
-    {"$.led_color",               &system_config.led_color               },
-    {"$.led_brightness",          &system_config.led_brightness          },   
+    {"$.led_color_rgb",           &system_config.led_color               },
+    {"$.led_brightness",          &system_config.led_brightness          },
     {"$.terminal_usb_enable",     &system_config.terminal_usb_enable     },
     {"$.terminal_uart_enable",    &system_config.terminal_uart_enable    },
     {"$.terminal_uart_number",    &system_config.terminal_uart_number    },
@@ -292,5 +292,5 @@ uint32_t storage_save_config(void){
 }
 
 uint32_t storage_load_config(void){
- 	return storage_load_mode(system_config_file, system_config_json, count_of(system_config_json));
+     return storage_load_mode(system_config_file, system_config_json, count_of(system_config_json));
 }

--- a/system_config.c
+++ b/system_config.c
@@ -32,6 +32,13 @@ void system_init(void)
     
     system_config.led_effect=7;
     system_config.led_color=0x00FF0000u;            // Now stores actual RGB value in common form 0x00RRGGBB
+    
+    // stores a DIVISOR that is used to reduce power ...
+    // which is the exact OPPOSITE of brightness:
+    //    larger values == dimmer pixels
+    // consider storing a NUMERATOR instead, but only
+    // after determining a good denominator that would
+    // allow for minimal sharp edge artifacts.
     system_config.led_brightness=10;
 
     system_config.terminal_ansi_rows=24;
@@ -164,67 +171,3 @@ bool system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register)
     return true;
 }
 
-bool system_load_config(void)
-{
-/*
-    system_config.terminal_usb_enable=true; 		//enable USB CDC terminal
-
-    system_config.terminal_uart_enable=false; 		//enable UART terminal on IO pins
-    system_config.terminal_uart_number=1; 	//which UART to use (0 or 1)
-
-    system_config.debug_uart_enable=false;			//initializes a UART for general developer use
-    system_config.debug_uart_number=0;		//which UART to use (0 or 1)
-
-    system_config.lcd_screensaver_active=false;
-    system_config.lcd_timeout=0;
-    
-    system_config.led_effect=7;
-    system_config.led_color=0xFF0000;
-    system_config.led_brightness=5;
-
-    system_config.display_format=df_auto;
-*/
-
-    const char *s ="{\"terminal_usb_enable\":true, 	//enable USB CDC terminal \
-    \"terminal_uart_enable\":false, //enable UART terminal on IO pins\
-    \"terminal_uart_number\":1, 	//which UART to use (0 or 1)\
-    \"debug_uart_enable\"=false,	//initializes a UART for general developer use\
-    \"debug_uart_number\"=0,		//which UART to use (0 or 1)\
-    \"lcd_screensaver_active\"=false,\
-    \"lcd_timeout\"=0, \
-    \"led_effect\"=7,\
-    \"led_color\"=1,\
-    \"led_brightness\"=5,\
-    \"display_format\"=0}";
-
-
-
-    int v;                                           // Extract `false`
-    if (mjson_get_bool(s, strlen(s), "$.terminal_usb_enable", &v))  // into C variable `v`
-    printf("boolean: %d\r\n", v);                    // boolean: 0	
-
-    //int v;                                           // Extract `false`
-    if (mjson_get_bool(s, strlen(s), "$.terminal_uart_enable", &v))  // into C variable `v`
-    printf("boolean: %d\r\n", v);                    // boolean: 0	
-
-    double val;                                       // Get `a` attribute
-    if (mjson_get_number(s, strlen(s), "$.terminal_uart_number", &val))  // into C variable `val`
-    printf("a: %g\r\n", val);       	
-
-    //const char *s = "{\"a\":1,\"b\":[2,false]}";  // {"a":1,"b":[2,false]}
-/*
-    double val;                                       // Get `a` attribute
-    if (mjson_get_number(s, strlen(s), "$.a", &val))  // into C variable `val`
-    printf("a: %g\n", val);                         // a: 1
-
-    const char *buf;  // Get `b` sub-object
-    int len;          // into C variables `buf,len`
-    if (mjson_find(s, strlen(s), "$.b", &buf, &len))  // And print it
-    printf("%.*s\n", len, buf);                     // [2,false]
-
-    int v;                                           // Extract `false`
-    if (mjson_get_bool(s, strlen(s), "$.b[1]", &v))  // into C variable `v`
-    printf("boolean: %d\n", v);                    // boolean: 0
-
-    */
-}

--- a/system_config.c
+++ b/system_config.c
@@ -31,7 +31,7 @@ void system_init(void)
     system_config.lcd_timeout=0;
     
     system_config.led_effect=7;
-    system_config.led_color=0;                      // OFF (black) is the default color at power-up
+    system_config.led_color=0x00FF0000u;            // Now stores actual RGB value in common form 0x00RRGGBB
     system_config.led_brightness=10;
 
     system_config.terminal_ansi_rows=24;
@@ -179,7 +179,7 @@ bool system_load_config(void)
     system_config.lcd_timeout=0;
     
     system_config.led_effect=7;
-    system_config.led_color=1;
+    system_config.led_color=0xFF0000;
     system_config.led_brightness=5;
 
     system_config.display_format=df_auto;

--- a/system_config.c
+++ b/system_config.c
@@ -16,52 +16,52 @@ struct _system_config system_config;
 
 void system_init(void)
 {
-	system_config.binmode=false;
-	system_config.terminal_language=0;
-	system_config.config_loaded_from_file=false;
-	system_config.terminal_usb_enable=true; 		//enable USB CDC terminal
+    system_config.binmode=false;
+    system_config.terminal_language=0;
+    system_config.config_loaded_from_file=false;
+    system_config.terminal_usb_enable=true;         //enable USB CDC terminal
 
-	system_config.terminal_uart_enable=false; 		//enable UART terminal on IO pins
-	system_config.terminal_uart_number=1; 	//which UART to use (0 or 1)
+    system_config.terminal_uart_enable=false;       //enable UART terminal on IO pins
+    system_config.terminal_uart_number=1;           //which UART to use (0 or 1)
 
-	system_config.debug_uart_enable=false;			//initializes a UART for general developer use
-	system_config.debug_uart_number=0;		//which UART to use (0 or 1)
+    system_config.debug_uart_enable=false;          //initializes a UART for general developer use
+    system_config.debug_uart_number=0;              //which UART to use (0 or 1)
 
     system_config.lcd_screensaver_active=false;
     system_config.lcd_timeout=0;
     
     system_config.led_effect=7;
-    system_config.led_color=0;
+    system_config.led_color=0;                      // OFF (black) is the default color at power-up
     system_config.led_brightness=10;
 
-	system_config.terminal_ansi_rows=24;
-	system_config.terminal_ansi_columns=80;
-	system_config.terminal_ansi_statusbar=0;
-	system_config.terminal_ansi_statusbar_update=false;
-	system_config.terminal_ansi_color=UI_TERM_NO_COLOR;
-	system_config.terminal_update=0;
-	system_config.terminal_hide_cursor=false;
-	system_config.terminal_ansi_statusbar_pause=false;
+    system_config.terminal_ansi_rows=24;
+    system_config.terminal_ansi_columns=80;
+    system_config.terminal_ansi_statusbar=0;
+    system_config.terminal_ansi_statusbar_update=false;
+    system_config.terminal_ansi_color=UI_TERM_NO_COLOR;
+    system_config.terminal_update=0;
+    system_config.terminal_hide_cursor=false;
+    system_config.terminal_ansi_statusbar_pause=false;
 
-	system_config.storage_available=0;
-	system_config.storage_mount_error=3;
-	system_config.storage_fat_type=5;
-	system_config.storage_size=0;
+    system_config.storage_available=0;
+    system_config.storage_mount_error=3;
+    system_config.storage_fat_type=5;
+    system_config.storage_size=0;
 
-	//start in auto format
-	system_config.display_format=df_auto;
+    //start in auto format
+    system_config.display_format=df_auto;
 
-	system_config.hiz=1;
- 	system_config.mode=0;
- 	system_config.display=0;
-	system_config.subprotocol_name=0;
-	for(int i=0;i<HW_PINS;i++)
-	{
-		system_config.pin_labels[i]=0;
-	}
+    system_config.hiz=1;
+    system_config.mode=0;
+    system_config.display=0;
+    system_config.subprotocol_name=0;
+    for(int i=0;i<HW_PINS;i++)
+    {
+        system_config.pin_labels[i]=0;
+    }
     //TODO: connect to a struct with info on each pin features and options, label automatically
-	system_config.pin_labels[0]=ui_const_pin_states[0];
-	system_config.pin_labels[9]=ui_const_pin_states[2];
+    system_config.pin_labels[0]=ui_const_pin_states[0];
+    system_config.pin_labels[9]=ui_const_pin_states[2];
 
     system_config.pin_func[0]=BP_PIN_VREF;
     system_config.pin_func[9]=BP_PIN_GROUND;
@@ -71,54 +71,54 @@ void system_init(void)
     }
     
 
-	system_config.pin_changed=0xffffffff;
+    system_config.pin_changed=0xffffffff;
     system_config.info_bar_changed=0;
 
-	system_config.num_bits=8;
-	system_config.bit_order=0;
-	system_config.write_with_read=0;
-	system_config.open_drain=0;
+    system_config.num_bits=8;
+    system_config.bit_order=0;
+    system_config.write_with_read=0;
+    system_config.open_drain=0;
 
-	system_config.pullup_enabled=0;
-	system_config.mode_active=0;
-	system_config.pwm_active=0; //todo: store the period and duty cycle in array of structs
-	system_config.freq_active=0;//todo: store ranging info in array of structs
-	system_config.aux_active=0;
+    system_config.pullup_enabled=0;
+    system_config.mode_active=0;
+    system_config.pwm_active=0; //todo: store the period and duty cycle in array of structs
+    system_config.freq_active=0;//todo: store ranging info in array of structs
+    system_config.aux_active=0;
 
-	system_config.psu=0;
+    system_config.psu=0;
     system_config.psu_current_limit_en=false;     
     system_config.psu_voltage=0;               
     system_config.psu_current_limit=0;  
     system_config.psu_current_error=false;
     system_config.psu_error=false;   
-	system_config.psu_irq_en=false;   
-	
-	
-	system_config.error=0;
+    system_config.psu_irq_en=false;   
+    
+    
+    system_config.error=0;
 
-	system_config.mosiport=0;
-	system_config.mosipin=0;
-	system_config.misoport=0;
-	system_config.misopin=0;
-	system_config.csport=0;
-	system_config.cspin=0;
-	system_config.clkport=0;
-	system_config.clkpin=0;
+    system_config.mosiport=0;
+    system_config.mosipin=0;
+    system_config.misoport=0;
+    system_config.misopin=0;
+    system_config.csport=0;
+    system_config.cspin=0;
+    system_config.clkport=0;
+    system_config.clkpin=0;
 
-	system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
+    system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
 
-	system_config.rts=0;
+    system_config.rts=0;
 }
 
 bool system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label)
 {
-  	//#ifdef BP_DEBUG_ENABLED
-    	//don't blow up our debug UART settings
-	    if(system_config.pin_func[pin]==BP_PIN_DEBUG)
+      //#ifdef BP_DEBUG_ENABLED
+        //don't blow up our debug UART settings
+        if(system_config.pin_func[pin]==BP_PIN_DEBUG)
         {
             return false;
         }
-	//#endif	 
+    //#endif	 
 
     if(enable)
     {
@@ -143,15 +143,15 @@ bool system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const
 bool system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register)
 {
     /*#ifdef BP_DEBUG_ENABLED
-	    if(bio_pin==BP_DEBUG_UART_TX || bio_pin==BP_DEBUG_UART_RX)
+        if(bio_pin==BP_DEBUG_UART_TX || bio_pin==BP_DEBUG_UART_RX)
         {
             return false;
         }
-	#endif	 */
-	if(system_config.pin_func[bio_pin+1]==BP_PIN_DEBUG)
-	{
-		return false;
-	}
+    #endif	 */
+    if(system_config.pin_func[bio_pin+1]==BP_PIN_DEBUG)
+    {
+        return false;
+    }
     
     if(active)
     {
@@ -167,13 +167,13 @@ bool system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register)
 bool system_load_config(void)
 {
 /*
-	system_config.terminal_usb_enable=true; 		//enable USB CDC terminal
+    system_config.terminal_usb_enable=true; 		//enable USB CDC terminal
 
-	system_config.terminal_uart_enable=false; 		//enable UART terminal on IO pins
-	system_config.terminal_uart_number=1; 	//which UART to use (0 or 1)
+    system_config.terminal_uart_enable=false; 		//enable UART terminal on IO pins
+    system_config.terminal_uart_number=1; 	//which UART to use (0 or 1)
 
-	system_config.debug_uart_enable=false;			//initializes a UART for general developer use
-	system_config.debug_uart_number=0;		//which UART to use (0 or 1)
+    system_config.debug_uart_enable=false;			//initializes a UART for general developer use
+    system_config.debug_uart_number=0;		//which UART to use (0 or 1)
 
     system_config.lcd_screensaver_active=false;
     system_config.lcd_timeout=0;
@@ -182,49 +182,49 @@ bool system_load_config(void)
     system_config.led_color=1;
     system_config.led_brightness=5;
 
-	system_config.display_format=df_auto;
+    system_config.display_format=df_auto;
 */
 
-	const char *s ="{\"terminal_usb_enable\":true, 	//enable USB CDC terminal \
-	\"terminal_uart_enable\":false, //enable UART terminal on IO pins\
-	\"terminal_uart_number\":1, 	//which UART to use (0 or 1)\
-	\"debug_uart_enable\"=false,	//initializes a UART for general developer use\
-	\"debug_uart_number\"=0,		//which UART to use (0 or 1)\
+    const char *s ="{\"terminal_usb_enable\":true, 	//enable USB CDC terminal \
+    \"terminal_uart_enable\":false, //enable UART terminal on IO pins\
+    \"terminal_uart_number\":1, 	//which UART to use (0 or 1)\
+    \"debug_uart_enable\"=false,	//initializes a UART for general developer use\
+    \"debug_uart_number\"=0,		//which UART to use (0 or 1)\
     \"lcd_screensaver_active\"=false,\
     \"lcd_timeout\"=0, \
     \"led_effect\"=7,\
     \"led_color\"=1,\
     \"led_brightness\"=5,\
-	\"display_format\"=0}";
+    \"display_format\"=0}";
 
 
 
-	int v;                                           // Extract `false`
-	if (mjson_get_bool(s, strlen(s), "$.terminal_usb_enable", &v))  // into C variable `v`
-	printf("boolean: %d\r\n", v);                    // boolean: 0	
+    int v;                                           // Extract `false`
+    if (mjson_get_bool(s, strlen(s), "$.terminal_usb_enable", &v))  // into C variable `v`
+    printf("boolean: %d\r\n", v);                    // boolean: 0	
 
-	//int v;                                           // Extract `false`
-	if (mjson_get_bool(s, strlen(s), "$.terminal_uart_enable", &v))  // into C variable `v`
-	printf("boolean: %d\r\n", v);                    // boolean: 0	
+    //int v;                                           // Extract `false`
+    if (mjson_get_bool(s, strlen(s), "$.terminal_uart_enable", &v))  // into C variable `v`
+    printf("boolean: %d\r\n", v);                    // boolean: 0	
 
-	double val;                                       // Get `a` attribute
-	if (mjson_get_number(s, strlen(s), "$.terminal_uart_number", &val))  // into C variable `val`
-	printf("a: %g\r\n", val);       	
+    double val;                                       // Get `a` attribute
+    if (mjson_get_number(s, strlen(s), "$.terminal_uart_number", &val))  // into C variable `val`
+    printf("a: %g\r\n", val);       	
 
-	//const char *s = "{\"a\":1,\"b\":[2,false]}";  // {"a":1,"b":[2,false]}
+    //const char *s = "{\"a\":1,\"b\":[2,false]}";  // {"a":1,"b":[2,false]}
 /*
-	double val;                                       // Get `a` attribute
-	if (mjson_get_number(s, strlen(s), "$.a", &val))  // into C variable `val`
-	printf("a: %g\n", val);                         // a: 1
+    double val;                                       // Get `a` attribute
+    if (mjson_get_number(s, strlen(s), "$.a", &val))  // into C variable `val`
+    printf("a: %g\n", val);                         // a: 1
 
-	const char *buf;  // Get `b` sub-object
-	int len;          // into C variables `buf,len`
-	if (mjson_find(s, strlen(s), "$.b", &buf, &len))  // And print it
-	printf("%.*s\n", len, buf);                     // [2,false]
+    const char *buf;  // Get `b` sub-object
+    int len;          // into C variables `buf,len`
+    if (mjson_find(s, strlen(s), "$.b", &buf, &len))  // And print it
+    printf("%.*s\n", len, buf);                     // [2,false]
 
-	int v;                                           // Extract `false`
-	if (mjson_get_bool(s, strlen(s), "$.b[1]", &v))  // into C variable `v`
-	printf("boolean: %d\n", v);                    // boolean: 0
+    int v;                                           // Extract `false`
+    if (mjson_get_bool(s, strlen(s), "$.b[1]", &v))  // into C variable `v`
+    printf("boolean: %d\n", v);                    // boolean: 0
 
-	*/
+    */
 }

--- a/system_config.h
+++ b/system_config.h
@@ -26,8 +26,8 @@ typedef struct _system_config
     uint32_t lcd_timeout;                  // in what units?
 
     uint32_t led_effect;
-    uint32_t led_color;                    // index into predefined list of colors (see rgb_timer_callback()) ... TODO: store actual RGB values
-    uint32_t led_brightness;               // why is this stored units of 10%?
+    uint32_t led_color;                    // RGB value stored as 0x00RRGGBB
+    uint32_t led_brightness;               // Note: limited to 30% ... they could draw too much power and are ultra-bright even at 30%
 
     uint8_t terminal_ansi_rows;
     uint8_t terminal_ansi_columns;

--- a/system_config.h
+++ b/system_config.h
@@ -7,95 +7,95 @@ typedef struct _pwm_config
 
 typedef struct _system_config
 {
-	bool config_loaded_from_file;
-	uint8_t hardware_revision;
+    bool config_loaded_from_file;          // true if config was loaded from file
+    uint8_t hardware_revision;             // hardware revision
 
-	bool binmode;
+    bool binmode;
 
-	uint32_t terminal_language;
+    uint32_t terminal_language;
 
-	uint32_t terminal_usb_enable; 		//enable USB CDC terminal
+    uint32_t terminal_usb_enable;          //enable USB CDC terminal
 
-	uint32_t terminal_uart_enable; 		//enable UART terminal on IO pins
-	uint32_t terminal_uart_number; 	//which UART to use
+    uint32_t terminal_uart_enable;         //enable UART terminal on IO pins
+    uint32_t terminal_uart_number;         //which UART to use
 
-	uint32_t debug_uart_enable;			//initializes a UART for general developer use
-	uint32_t debug_uart_number;		//which UART to use
+    uint32_t debug_uart_enable;            //initializes a UART for general developer use
+    uint32_t debug_uart_number;            //which UART to use
 
-    uint32_t lcd_screensaver_active;
-    uint32_t lcd_timeout;
+    uint32_t lcd_screensaver_active;       // boolean?
+    uint32_t lcd_timeout;                  // in what units?
 
     uint32_t led_effect;
-    uint32_t led_color;
-    uint32_t led_brightness;
-    
-	uint8_t terminal_ansi_rows;
-	uint8_t terminal_ansi_columns;
-	uint32_t terminal_ansi_color;
-	uint32_t terminal_ansi_statusbar;
-	bool terminal_ansi_statusbar_update;
-	bool terminal_hide_cursor;
-	bool terminal_ansi_statusbar_pause;
-	uint8_t terminal_update;
+    uint32_t led_color;                    // index into predefined list of colors (see rgb_timer_callback()) ... TODO: store actual RGB values
+    uint32_t led_brightness;               // why is this stored units of 10%?
 
-	uint8_t storage_available;
+    uint8_t terminal_ansi_rows;
+    uint8_t terminal_ansi_columns;
+    uint32_t terminal_ansi_color;
+    uint32_t terminal_ansi_statusbar;
+    bool terminal_ansi_statusbar_update;
+    bool terminal_hide_cursor;
+    bool terminal_ansi_statusbar_pause;
+    uint8_t terminal_update;
+
+    uint8_t storage_available;
     uint8_t storage_mount_error;
     uint8_t storage_fat_type;
     float storage_size;
 
-	uint32_t display_format;			// display format (dec, hex, oct, bin)	
-	
-	uint8_t hiz;					// is hiz pin mode?
-	uint8_t mode;					// which mode we are in?
-	uint8_t display;				// which display mode we are in?
-	const char *subprotocol_name;		// can be set if there is a sub protocol
-	
-	uint8_t num_bits;				// number of used bits
-	uint8_t bit_order;				// bitorder (0=msb, 1=lsb)
-	uint8_t write_with_read;		// write with read
-	uint8_t open_drain;				// open drain pin mode (1=true)
+    uint32_t display_format;               // display format (dec, hex, oct, bin)	
 
-	uint8_t pullup_enabled;			// pullup enabled? (0=off, 1=on)
-	
+    uint8_t hiz;                           // is hiz pin mode?
+    uint8_t mode;                          // which mode we are in?
+    uint8_t display;                       // which display mode we are in?
+    const char *subprotocol_name;          // can be set if there is a sub protocol
 
-	const char *pin_labels[HW_PINS];	// pointer to labels for each pin on the bus pirate header
+    uint8_t num_bits;                      // number of used bits
+    uint8_t bit_order;                     // bitorder (0=msb, 1=lsb)
+    uint8_t write_with_read;               // write with read
+    uint8_t open_drain;                    // open drain pin mode (1=true)
+
+    uint8_t pullup_enabled;                // pullup enabled? (0=off, 1=on)
+
+
+    const char *pin_labels[HW_PINS];       // pointer to labels for each pin on the bus pirate header
     enum bp_pin_func pin_func[HW_PINS];
     uint32_t pin_changed;
     bool info_bar_changed;
     
-	uint8_t mode_active;
-	uint8_t pwm_active;				// pwm active, one bit per PWN channel/pin
+    uint8_t mode_active;
+    uint8_t pwm_active;                    // pwm active, one bit per PWN channel/pin
     _pwm_config freq_config[BIO_MAX_PINS]; //holds PWM or FREQ settings for easier display later
-	uint8_t freq_active;			// freq measure active, one bit per channel/pin
-	uint8_t aux_active;				//user controlled auc pins are outputs, resets when input
+    uint8_t freq_active;                   // freq measure active, one bit per channel/pin
+    uint8_t aux_active;                    //user controlled auc pins are outputs, resets when input
 
-	uint8_t psu;					// psu (0=off, 1=on)
-    //uint8_t psu_dat_bits_readable;  // dac bits in human readable format
-    //uint16_t psu_dac_bits_mask;          // 8/10/12 bit psu dac possible, this is the bitmask 0xff 0x3ff or 0x7ff
-	uint16_t psu_dac_v_set;			// psu voltage adjust DAC setting
-	uint16_t psu_dac_i_set;			// psu current limit DAC setting
-    uint32_t psu_voltage;               // psu voltage output setting in decimal * 10000
-	bool psu_current_limit_en;
-    uint32_t psu_current_limit;         // psu current limit in decimal * 10000
-    bool psu_current_error;             // psu over current limit fuse tripped
-    bool psu_error;                     //error, usually with the dac
-	bool psu_irq_en;
-	
-	uint8_t error;					// error occurred
-	
-	// TODO: rework this here and in pin info function
-	uint32_t csport;				// cs is located on this port/gpio
-	uint32_t cspin; 
-	uint32_t misoport;				// cs is located on this port/gpio
-	uint32_t misopin;
-	uint32_t clkport;				// cs is located on this port/gpio
-	uint32_t clkpin;
-	uint32_t mosiport;				// cs is located on this port/gpio
-	uint32_t mosipin;
+    uint8_t psu;                           // psu (0=off, 1=on)
+    //uint8_t psu_dat_bits_readable;         // dac bits in human readable format
+    //uint16_t psu_dac_bits_mask;            // 8/10/12 bit psu dac possible, this is the bitmask 0xff 0x3ff or 0x7ff
+    uint16_t psu_dac_v_set;                // psu voltage adjust DAC setting
+    uint16_t psu_dac_i_set;                // psu current limit DAC setting
+    uint32_t psu_voltage;                  // psu voltage output setting in decimal * 10000
+    bool psu_current_limit_en;
+    uint32_t psu_current_limit;            // psu current limit in decimal * 10000
+    bool psu_current_error;                // psu over current limit fuse tripped
+    bool psu_error;                        //error, usually with the dac
+    bool psu_irq_en;
 
-	uint32_t big_buffer_owner;
+    uint8_t error;                         // error occurred (when?  how long ago?  what kinds of error should set this?)
 
-	bool rts;
+    // TODO: rework this here and in pin info function
+    uint32_t csport;                       // cs is located on this port/gpio
+    uint32_t cspin; 
+    uint32_t misoport;                     // cs is located on this port/gpio
+    uint32_t misopin;
+    uint32_t clkport;                      // cs is located on this port/gpio
+    uint32_t clkpin;
+    uint32_t mosiport;                     // cs is located on this port/gpio
+    uint32_t mosipin;
+
+    uint32_t big_buffer_owner;
+
+    bool rts;
 
 
 } _system_config;

--- a/system_config.h
+++ b/system_config.h
@@ -27,7 +27,7 @@ typedef struct _system_config
 
     uint32_t led_effect;
     uint32_t led_color;                    // RGB value stored as 0x00RRGGBB
-    uint32_t led_brightness;               // Note: limited to 30% ... they could draw too much power and are ultra-bright even at 30%
+    uint32_t led_brightness;               // BUGBUG - Poor naming as this is a DIVISOR of the r/g/b component values
 
     uint8_t terminal_ansi_rows;
     uint8_t terminal_ansi_columns;
@@ -106,4 +106,3 @@ void system_init(void);
 bool system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label);
 bool system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label);
 bool system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register);
-bool system_load_config(void);

--- a/ui/ui_config.c
+++ b/ui/ui_config.c
@@ -46,6 +46,10 @@ uint32_t ui_config_action_led_effect(uint32_t a, uint32_t b)
 }
 
 // LED color (?) Rainbow short, rainbow long, ROYGBIV
+// shortened list of HSV colors (as RGB) from fastLED
+// Any color can be configured in the configuration file
+// as a 24-bit RGB value; The menu simply provides common
+// colors as a convenience.
 static const struct prompt_item menu_items_led_color[]=
 {
     {T_CONFIG_LEDS_COLOR_RED},
@@ -59,8 +63,21 @@ static const struct prompt_item menu_items_led_color[]=
 
 uint32_t ui_config_action_led_color(uint32_t a, uint32_t b)
 {
+    // This needs to stay in sync with the above list of colors
+    static const uint32_t menu_based_colors[]= {
+        0xFF0000, // aka T_CONFIG_LEDS_COLOR_RED  
+        0xD52A00, // aka T_CONFIG_LEDS_COLOR_ORANGE  
+        0xAB7F00, // aka T_CONFIG_LEDS_COLOR_YELLOW  
+        0x00FF00, // aka T_CONFIG_LEDS_COLOR_GREEN  
+        0x0000FF, // aka T_CONFIG_LEDS_COLOR_BLUE  
+        0x5500AB, // aka T_CONFIG_LEDS_COLOR_PURPLE  
+        0xAB0055, // aka T_CONFIG_LEDS_COLOR_PINK 
+    };
+ 
+    static_assert(count_of(menu_based_colors) == count_of(menu_items_led_color), "menu_based_colors and menu_items_led_color must have the same number of items");
     if (b < count_of(menu_items_led_color)) {
-        system_config.led_color=b;
+        system_config.led_color=menu_based_colors[b];
+
     }
 }
 

--- a/ui/ui_config.c
+++ b/ui/ui_config.c
@@ -21,53 +21,82 @@ bool ui_config_menu(const struct ui_prompt * menu);
 // menu items options
 static const struct prompt_item menu_items_disable_enable[]=
 {
-    {T_CONFIG_DISABLE},{T_CONFIG_ENABLE}
+    {T_CONFIG_DISABLE},
+    {T_CONFIG_ENABLE}
 };
 
 // LED effect
 static const struct prompt_item menu_items_led_effect[]=
 {
-    {T_CONFIG_DISABLE},{T_CONFIG_LEDS_EFFECT_SOLID},{T_CONFIG_LEDS_EFFECT_ANGLEWIPE},{T_CONFIG_LEDS_EFFECT_CENTERWIPE},{T_CONFIG_LEDS_EFFECT_CLOCKWISEWIPE},{T_CONFIG_LEDS_EFFECT_TOPDOWNWIPE},{T_CONFIG_LEDS_EFFECT_SCANNER},{T_CONFIG_LEDS_EFFECT_CYCLE}
+    {T_CONFIG_DISABLE},
+    {T_CONFIG_LEDS_EFFECT_SOLID},
+    {T_CONFIG_LEDS_EFFECT_ANGLEWIPE},
+    {T_CONFIG_LEDS_EFFECT_CENTERWIPE},
+    {T_CONFIG_LEDS_EFFECT_CLOCKWISEWIPE},
+    {T_CONFIG_LEDS_EFFECT_TOPDOWNWIPE},
+    {T_CONFIG_LEDS_EFFECT_SCANNER},
+    {T_CONFIG_LEDS_EFFECT_CYCLE}
 };
 
 uint32_t ui_config_action_led_effect(uint32_t a, uint32_t b)
 {
-    system_config.led_effect=b;
+    if (b < count_of(menu_items_led_effect)) {
+        system_config.led_effect=b;
+    }
 }
 
 // LED color (?) Rainbow short, rainbow long, ROYGBIV
 static const struct prompt_item menu_items_led_color[]=
 {
-    {T_CONFIG_LEDS_COLOR_RED},{T_CONFIG_LEDS_COLOR_ORANGE},{T_CONFIG_LEDS_COLOR_YELLOW},{T_CONFIG_LEDS_COLOR_GREEN},{T_CONFIG_LEDS_COLOR_BLUE},{T_CONFIG_LEDS_COLOR_PURPLE},{T_CONFIG_LEDS_COLOR_PINK}
+    {T_CONFIG_LEDS_COLOR_RED},
+    {T_CONFIG_LEDS_COLOR_ORANGE},
+    {T_CONFIG_LEDS_COLOR_YELLOW},
+    {T_CONFIG_LEDS_COLOR_GREEN},
+    {T_CONFIG_LEDS_COLOR_BLUE},
+    {T_CONFIG_LEDS_COLOR_PURPLE},
+    {T_CONFIG_LEDS_COLOR_PINK}
 };
 
 uint32_t ui_config_action_led_color(uint32_t a, uint32_t b)
 {
-    system_config.led_color=b;    
+    if (b < count_of(menu_items_led_color)) {
+        system_config.led_color=b;
+    }
 }
 
 // LED brightness %?
 static const struct prompt_item menu_items_led_brightness[]=
 {
-    {T_CONFIG_LEDS_BRIGHTNESS_10},{T_CONFIG_LEDS_BRIGHTNESS_20},{T_CONFIG_LEDS_BRIGHTNESS_30}//,{T_CONFIG_LEDS_BRIGHTNESS_40},{T_CONFIG_LEDS_BRIGHTNESS_50},{T_CONFIG_LEDS_BRIGHTNESS_100},
+    {T_CONFIG_LEDS_BRIGHTNESS_10},
+    {T_CONFIG_LEDS_BRIGHTNESS_20},
+    {T_CONFIG_LEDS_BRIGHTNESS_30}
+    //,{T_CONFIG_LEDS_BRIGHTNESS_40}
+    //,{T_CONFIG_LEDS_BRIGHTNESS_50}
+    //,{T_CONFIG_LEDS_BRIGHTNESS_100}
 };
 
 uint32_t ui_config_action_led_brightness(uint32_t a, uint32_t b)
 {
-    if(b==5) system_config.led_brightness=1;
-    else system_config.led_brightness=10/(b+1);     
+    if (b < count_of(menu_items_led_brightness)) {
+        system_config.led_brightness=10/(b+1);     
+    }
 }
 
 
 // config menu helper functions
 static const struct prompt_item menu_items_screensaver[]=
 {
-    {T_CONFIG_DISABLE}, {T_CONFIG_SCREENSAVER_5}, {T_CONFIG_SCREENSAVER_10}, {T_CONFIG_SCREENSAVER_15}
+    {T_CONFIG_DISABLE},
+    {T_CONFIG_SCREENSAVER_5},
+    {T_CONFIG_SCREENSAVER_10},
+    {T_CONFIG_SCREENSAVER_15}
 };
 
 uint32_t ui_config_action_screensaver(uint32_t a, uint32_t b)
 {
-    system_config.lcd_timeout=b;
+    if (b < count_of(menu_items_screensaver)) {
+        system_config.lcd_timeout=b;
+    }
 }
 
 static const struct prompt_item menu_items_ansi_color[] =
@@ -78,23 +107,25 @@ static const struct prompt_item menu_items_ansi_color[] =
     {T_CONFIG_ANSI_COLOR_256}
 #endif
 };
+
 uint32_t ui_config_action_ansi_color(uint32_t a, uint32_t b)
 {
-    system_config.terminal_ansi_color=b;
-    if(!b)
-    {
-        system_config.terminal_ansi_statusbar=0; //disable the toolbar if ansi is disabled....
+    if (b < count_of(menu_items_ansi_color)) {
+        system_config.terminal_ansi_color=b;
+        if(!b)
+        {
+            system_config.terminal_ansi_statusbar=0; //disable the toolbar if ansi is disabled....
+        }
+        else
+        {
+            ui_term_detect(); // Do we detect a VT100 ANSI terminal? what is the size?
+        }
     }
-    else
-    {
-        ui_term_detect(); // Do we detect a VT100 ANSI terminal? what is the size?
-    }
-
 }
 
 uint32_t ui_config_action_ansi_toolbar(uint32_t a, uint32_t b)
 {
-    system_config.terminal_ansi_statusbar=b;
+    system_config.terminal_ansi_statusbar=b; // true/false?
     if(b)
     {   
         if(!system_config.terminal_ansi_color) system_config.terminal_ansi_color=UI_TERM_FULL_COLOR; //enable ANSI color more
@@ -115,29 +146,31 @@ static const struct prompt_item menu_items_language[]=
 
 uint32_t ui_config_action_language(uint32_t a, uint32_t b)
 {
-    system_config.terminal_language=b; 
-    translation_set(b);
+    if (b < count_of(menu_items_language)) {
+        system_config.terminal_language=b;
+        translation_set(b);
+    }
 }
 
 static const struct ui_prompt_config cfg=
 {
-	false, //bool allow_prompt_text;
-	false, //bool allow_prompt_defval;
-	false, //bool allow_defval; 
-	true, //bool allow_exit;
-	&ui_prompt_menu_ordered_list, //bool (*menu_print)(const struct ui_prompt* menu);
-	&ui_prompt_prompt_ordered_list,     //bool (*menu_prompt)(const struct ui_prompt* menu);
-	&ui_prompt_validate_ordered_list //bool (*menu_validate)(const struct ui_prompt* menu, uint32_t* value);
+    false, //bool allow_prompt_text;
+    false, //bool allow_prompt_defval;
+    false, //bool allow_defval; 
+    true,  //bool allow_exit;
+    &ui_prompt_menu_ordered_list,    //bool (*menu_print   )(const struct ui_prompt* menu);
+    &ui_prompt_prompt_ordered_list,  //bool (*menu_prompt  )(const struct ui_prompt* menu);
+    &ui_prompt_validate_ordered_list //bool (*menu_validate)(const struct ui_prompt* menu, uint32_t* value);
 };
 
 static const struct ui_prompt sub_prompts[]={
-    {T_CONFIG_LANGUAGE, menu_items_language, count_of(menu_items_language),0,0,0,0,&ui_config_action_language, &cfg},
-    {T_CONFIG_ANSI_COLOR_MODE,menu_items_ansi_color,count_of(menu_items_ansi_color),0,0,0,0,&ui_config_action_ansi_color, &cfg},
-    {T_CONFIG_ANSI_TOOLBAR_MODE,menu_items_disable_enable,count_of(menu_items_disable_enable),0,0,0,0,&ui_config_action_ansi_toolbar,&cfg},
-    {T_CONFIG_SCREENSAVER,menu_items_screensaver,count_of(menu_items_screensaver),0,0,0,0,&ui_config_action_screensaver,&cfg},
-    {T_CONFIG_LEDS_EFFECT, menu_items_led_effect, count_of(menu_items_led_effect),0,0,0,0, &ui_config_action_led_effect, &cfg},
-    {T_CONFIG_LEDS_COLOR, menu_items_led_color, count_of(menu_items_led_color),0,0,0,0, &ui_config_action_led_color, &cfg},
-    {T_CONFIG_LEDS_BRIGHTNESS, menu_items_led_brightness, count_of(menu_items_led_brightness),0,0,0,0, &ui_config_action_led_brightness, &cfg}
+    {T_CONFIG_LANGUAGE,         menu_items_language,       count_of(menu_items_language),       0,0,0,0, &ui_config_action_language,       &cfg},
+    {T_CONFIG_ANSI_COLOR_MODE,  menu_items_ansi_color,     count_of(menu_items_ansi_color),     0,0,0,0, &ui_config_action_ansi_color,     &cfg},
+    {T_CONFIG_ANSI_TOOLBAR_MODE,menu_items_disable_enable, count_of(menu_items_disable_enable), 0,0,0,0, &ui_config_action_ansi_toolbar,   &cfg},
+    {T_CONFIG_SCREENSAVER,      menu_items_screensaver,    count_of(menu_items_screensaver),    0,0,0,0, &ui_config_action_screensaver,    &cfg},
+    {T_CONFIG_LEDS_EFFECT,      menu_items_led_effect,     count_of(menu_items_led_effect),     0,0,0,0, &ui_config_action_led_effect,     &cfg},
+    {T_CONFIG_LEDS_COLOR,       menu_items_led_color,      count_of(menu_items_led_color),      0,0,0,0, &ui_config_action_led_color,      &cfg},
+    {T_CONFIG_LEDS_BRIGHTNESS,  menu_items_led_brightness, count_of(menu_items_led_brightness), 0,0,0,0, &ui_config_action_led_brightness, &cfg}
 };
 
 static const struct ui_prompt_config main_cfg=

--- a/ui/ui_config.c
+++ b/ui/ui_config.c
@@ -77,7 +77,6 @@ uint32_t ui_config_action_led_color(uint32_t a, uint32_t b)
     static_assert(count_of(menu_based_colors) == count_of(menu_items_led_color), "menu_based_colors and menu_items_led_color must have the same number of items");
     if (b < count_of(menu_items_led_color)) {
         system_config.led_color=menu_based_colors[b];
-
     }
 }
 
@@ -95,7 +94,16 @@ static const struct prompt_item menu_items_led_brightness[]=
 uint32_t ui_config_action_led_brightness(uint32_t a, uint32_t b)
 {
     if (b < count_of(menu_items_led_brightness)) {
-        system_config.led_brightness=10/(b+1);     
+        if (b == 0) {
+            system_config.led_brightness=10; // 10% brightness = divide by 10
+        } else if (b == 1){
+            system_config.led_brightness=5; // 20% brightness = divide by 5
+        } else if (b == 2){
+            system_config.led_brightness=3; // 30% brightness ~= divide by 3
+        } else {
+            assert(false);
+            static_assert(count_of(menu_items_led_brightness) == 3, "must update this switch statement");
+        }
     }
 }
 

--- a/ui/ui_process.c
+++ b/ui/ui_process.c
@@ -28,14 +28,14 @@ bool ui_process_syntax(void)
             printf("Syntax compile error\r\n");
             return true;
     }
-    icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
     if(syntax_run())
     {
-            icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
+            icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
             printf("Syntax execution error\r\n");
             return true;
     }
-    icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
     if(syntax_post())
     {
             printf("Syntax post process error\r\n");

--- a/ui/ui_process.c
+++ b/ui/ui_process.c
@@ -28,14 +28,14 @@ bool ui_process_syntax(void)
             printf("Syntax compile error\r\n");
             return true;
     }
-    icm_core0_send_message(BP_ICM_VALUE_F0);
+    icm_core0_send_message(BP_ICM_DISABLE_LCD_UPDATES);
     if(syntax_run())
     {
-            icm_core0_send_message(BP_ICM_VALUE_F1);
+            icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
             printf("Syntax execution error\r\n");
             return true;
     }
-    icm_core0_send_message(BP_ICM_VALUE_F1);
+    icm_core0_send_message(BP_ICM_ENABLE_LCD_UPDATES);
     if(syntax_post())
     {
             printf("Syntax post process error\r\n");

--- a/ui/ui_process.c
+++ b/ui/ui_process.c
@@ -16,6 +16,7 @@
 #include "ui/ui_cmdln.h"
 #include "string.h"
 #include "syntax.h"
+#include "pirate/intercore_helpers.h"
 
 // const structs are init'd with 0s, we'll make them here and copy in the main loop
 static const struct command_result result_blank;
@@ -27,17 +28,14 @@ bool ui_process_syntax(void)
             printf("Syntax compile error\r\n");
             return true;
     }
-    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
-    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
+    icm_core0_send_message(BP_ICM_VALUE_F0);
     if(syntax_run())
     {
-            multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
-            multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
+            icm_core0_send_message(BP_ICM_VALUE_F1);
             printf("Syntax execution error\r\n");
             return true;
     }
-    multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
-    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?    
+    icm_core0_send_message(BP_ICM_VALUE_F1);
     if(syntax_post())
     {
             printf("Syntax post process error\r\n");

--- a/ui/ui_process.c
+++ b/ui/ui_process.c
@@ -27,17 +27,17 @@ bool ui_process_syntax(void)
             printf("Syntax compile error\r\n");
             return true;
     }
-    multicore_fifo_push_blocking(0xf0);
-    multicore_fifo_pop_blocking();
+    multicore_fifo_push_blocking(0xf0); // BUGBUG ... #define friendly constants for these magic numbers
+    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
     if(syntax_run())
     {
-            multicore_fifo_push_blocking(0xf1);
-            multicore_fifo_pop_blocking(); 
+            multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
+            multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?
             printf("Syntax execution error\r\n");
             return true;
     }
-    multicore_fifo_push_blocking(0xf1);
-    multicore_fifo_pop_blocking();            
+    multicore_fifo_push_blocking(0xf1); // BUGBUG ... #define friendly constants for these magic numbers
+    multicore_fifo_pop_blocking(); // BUGBUG ... other code paths loop until this pops the expected value?    
     if(syntax_post())
     {
             printf("Syntax post process error\r\n");

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -292,7 +292,6 @@ static uint16_t _desc_str[MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT];
 uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 {
   (void) langid;
-
   uint8_t chr_count;
 
   if ( index == 0) { // supported language == English


### PR DESCRIPTION
There are some substantive improvements around inter-core messaging.
This PR is intended as a DRAFT / Untested changes, primarily to allow easier review/commenting/discussion.

* Helper functions for inter-core messaging add ~136 bytes to flash.  The inclusion of a counter byte in the ICM value was responsible for only ~8 of those bytes, and seems efficiently optimized by the compiler.
* Reduced precious RAM usage by 16 bytes
* Restricting invalid values being set from configuration only added ~8 bytes(!) to flash.
* Cannot seem to get CMake to require C23... sigh.
* Lots of comment-only changes
* Lots of formatting-only changes
* A few TODO/BUGBUG items noted (but not addressed)