### PR TITLE
Updated button_irq_callback to discern between long and short button presses

### DIFF
--- a/commands/global/button_scr.c
+++ b/commands/global/button_scr.c
@@ -21,9 +21,11 @@
 #define BUTTON_FLAG_HIDE_COMMENTS 1u<<0
 #define BUTTON_FLAG_EXIT_ON_ERROR 1u<<1
 #define BUTTON_FLAG_FILE_CONFIGURED 1u<<2
+#define LONG_BUTTON_FLAG_FILE_CONFIGURED 1u<<3
 
 static uint8_t button_flags=0;
 static char button_script_file[32];
+static char long_button_script_file[32];
 
 static const char * const usage[]= {
     "button <file> [-d (hiDe comments)] [-e(xit on error)] [-h(elp)]",
@@ -77,4 +79,22 @@ bool button_exec(void){
         return true;
     }
 
+}
+
+bool button_long_exec(void){
+
+    if(!(button_flags & LONG_BUTTON_FLAG_FILE_CONFIGURED)){
+        memcpy(long_button_script_file, "bulong.scr", sizeof("bulong.scr"));
+        button_flags|=LONG_BUTTON_FLAG_FILE_CONFIGURED;
+        printf("Using long default '%s'\r\n", long_button_script_file);
+    }
+
+    printf("\r\n");
+
+    if(script_exec(long_button_script_file, false, !(button_flags & BUTTON_FLAG_HIDE_COMMENTS), false, (button_flags & BUTTON_FLAG_EXIT_ON_ERROR))){
+        printf("\r\nError in script file '%s'. Try button -h for help\r\n", long_button_script_file);
+        return true;
+    }
+
+    return false;
 }

--- a/commands/global/button_scr.c
+++ b/commands/global/button_scr.c
@@ -17,15 +17,16 @@
 #include "modes.h"
 #include "ui/ui_help.h" // Functions to display help in a standardized way
 #include "commands/global/script.h"
+#include "button_scr.h"
 
 #define BUTTON_FLAG_HIDE_COMMENTS 1u<<0
 #define BUTTON_FLAG_EXIT_ON_ERROR 1u<<1
 #define BUTTON_FLAG_FILE_CONFIGURED 1u<<2
-#define LONG_BUTTON_FLAG_FILE_CONFIGURED 1u<<3
+#define BUTTON_LONG_FLAG_FILE_CONFIGURED 1u<<3
 
 static uint8_t button_flags=0;
-static char button_script_file[32];
-static char long_button_script_file[32];
+static const char *button_script_file = "button.scr";
+static const char *button_long_script_file = "bulong.scr";
 
 static const char * const usage[]= {
     "button <file> [-d (hiDe comments)] [-e(xit on error)] [-h(elp)]",
@@ -41,60 +42,53 @@ static const struct ui_help_options options[]= {
 
 void button_scr_handler(struct command_result *res){
    //check help
-   	if(ui_help_show(res->help_flag,usage,count_of(usage), &options[0],count_of(options) )) return;
+    if(ui_help_show(res->help_flag,usage,count_of(usage), &options[0],count_of(options) )) return;
     button_flags=0;
-    if(!cmdln_args_string_by_position(1, sizeof(button_script_file), button_script_file)){
+    char script_file[32];
+    if(!cmdln_args_string_by_position(1, sizeof(script_file), script_file)){
         printf("No script file specified. Try button -h for help\r\n");
         res->error=true;
         return;
     }
-    FIL fil;		/* File object needed for each open file */
+    FIL fil;        /* File object needed for each open file */
     FRESULT fr;     /* FatFs return code */    
-    fr = f_open(&fil, button_script_file, FA_READ);	
+    fr = f_open(&fil, script_file, FA_READ);    
     if (fr != FR_OK) {
-        printf("'%s' not found\r\n", button_script_file);
+        printf("'%s' not found\r\n", script_file);
         res->error=true;
         return;
     }
     f_close(&fil);  
     button_flags|=BUTTON_FLAG_FILE_CONFIGURED;
-    printf("Button script file set to '%s'\r\n", button_script_file);
+    printf("Button script file set to '%s'\r\n", script_file);
     if(cmdln_args_find_flag('d'|0x20)) button_flags|=BUTTON_FLAG_HIDE_COMMENTS;
     if(cmdln_args_find_flag('e'|0x20)) button_flags|=BUTTON_FLAG_EXIT_ON_ERROR;
 }
 
 // non zero return value indicates error
-bool button_exec(void){
+bool button_exec(enum button_codes button_code){
+    const char *script_file;
 
-    if(!(button_flags & BUTTON_FLAG_FILE_CONFIGURED)){
-        memcpy(button_script_file, "button.scr", sizeof("button.scr"));
-        button_flags|=BUTTON_FLAG_FILE_CONFIGURED;
-        printf("Using default '%s'\r\n", button_script_file); 
+    if(button_code == BP_BUTT_LONG_PRESS){
+        if(!(button_flags & BUTTON_LONG_FLAG_FILE_CONFIGURED)){
+            button_flags |= BUTTON_LONG_FLAG_FILE_CONFIGURED;
+            printf("Using long default '%s'\r\n", button_long_script_file);
+        }
+        script_file = button_long_script_file;
+    } else {
+        if(!(button_flags & BUTTON_FLAG_FILE_CONFIGURED)){
+            button_flags |= BUTTON_FLAG_FILE_CONFIGURED;
+            printf("Using default '%s'\r\n", button_script_file);
+        }
+        script_file = button_script_file;
     }
 
     printf("\r\n");
 
-    if(script_exec(button_script_file, false, !(button_flags & BUTTON_FLAG_HIDE_COMMENTS), false, (button_flags & BUTTON_FLAG_EXIT_ON_ERROR))){
-        printf("\r\nError in script file '%s'. Try button -h for help\r\n", button_script_file);
+    if(script_exec((char *)script_file, false, !(button_flags & BUTTON_FLAG_HIDE_COMMENTS), false, (button_flags & BUTTON_FLAG_EXIT_ON_ERROR))){
+        printf("\r\nError in script file '%s'. Try button -h for help\r\n", script_file);
         return true;
     }
-
-}
-
-bool button_long_exec(void){
-
-    if(!(button_flags & LONG_BUTTON_FLAG_FILE_CONFIGURED)){
-        memcpy(long_button_script_file, "bulong.scr", sizeof("bulong.scr"));
-        button_flags|=LONG_BUTTON_FLAG_FILE_CONFIGURED;
-        printf("Using long default '%s'\r\n", long_button_script_file);
-    }
-
-    printf("\r\n");
-
-    if(script_exec(long_button_script_file, false, !(button_flags & BUTTON_FLAG_HIDE_COMMENTS), false, (button_flags & BUTTON_FLAG_EXIT_ON_ERROR))){
-        printf("\r\nError in script file '%s'. Try button -h for help\r\n", long_button_script_file);
-        return true;
-    }
-
     return false;
+
 }

--- a/commands/global/button_scr.h
+++ b/commands/global/button_scr.h
@@ -1,3 +1,2 @@
 void button_scr_handler(struct command_result *res);
-bool button_exec(void);
-bool button_long_exec(void);
+bool button_exec(enum button_codes button_code);

--- a/commands/global/button_scr.h
+++ b/commands/global/button_scr.h
@@ -1,2 +1,3 @@
 void button_scr_handler(struct command_result *res);
 bool button_exec(void);
+bool button_long_exec(void);

--- a/commands/global/script.c
+++ b/commands/global/script.c
@@ -54,7 +54,7 @@ void script_handler(struct command_result *res){
 }
 
 // non zero return value indicates error
-bool script_exec(char *location, bool pause_for_input, bool show_comments, bool show_tip, bool exit_on_error){
+bool script_exec(const char *location, bool pause_for_input, bool show_comments, bool show_tip, bool exit_on_error){
 
     FIL fil;		/* File object needed for each open file */
     FRESULT fr;     /* FatFs return code */    

--- a/commands/global/script.h
+++ b/commands/global/script.h
@@ -1,2 +1,2 @@
-bool script_exec(char *location, bool pause_for_input, bool show_comments, bool show_tip, bool exit_on_error);
+bool script_exec(const char *location, bool pause_for_input, bool show_comments, bool show_tip, bool exit_on_error);
 void script_handler(struct command_result *res);

--- a/pirate.c
+++ b/pirate.c
@@ -301,14 +301,11 @@ int main(){
                         button_irq_disable(0);
                         break;
                 }
-                if(button_check_irq(0, &long_press)){
+                enum button_codes press_code = button_check_press(0);
+                if(press_code != BP_BUTT_NO_PRESS){
                     button_irq_disable(0);
-                    if (long_press) {
-                        button_long_exec(); // over long press threshold execute bulong.scr
-                    } else {
-                        button_exec(); // short press execute button.scr
-                    }
-                    bp_state=BP_SM_COMMAND_PROMPT;  //return to command prompt
+                    button_exec(press_code);
+                    bp_state=BP_SM_COMMAND_PROMPT;
                 }
                 break;
             

--- a/pirate.c
+++ b/pirate.c
@@ -207,6 +207,7 @@ int main(){
     struct prompt_result result; 
     alarm_id_t screensaver;
     bool has_been_connected = false;
+    bool long_press = false;
     while(1){
 
         if(script_entry()){ //enter scripting mode?
@@ -300,9 +301,13 @@ int main(){
                         button_irq_disable(0);
                         break;
                 }
-                if(button_check_irq(0)){
+                if(button_check_irq(0, &long_press)){
                     button_irq_disable(0);
-                    button_exec(); //if button pressed, run button.scr script
+                    if (long_press) {
+                        button_long_exec(); // over long press threshold execute bulong.scr
+                    } else {
+                        button_exec(); // short press execute button.scr
+                    }
                     bp_state=BP_SM_COMMAND_PROMPT;  //return to command prompt
                 }
                 break;

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -2,14 +2,19 @@
 #include "pico/stdlib.h"
 #include "pirate.h"
 
+#define BP_BUTTON_SHORT_PRESS_MS 500 // Threshold for short button press
+
 static bool button_pressed = false;
+static bool button_long_pressed = false;
+static absolute_time_t press_start_time;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){
     return gpio_get(EXT1);
 } 
-bool button_check_irq(uint8_t button_id){
+bool button_check_irq(uint8_t button_id, bool *long_press){
     if(button_pressed){
+        *long_press = button_long_pressed;
         button_pressed=false;
         return true;
     }
@@ -17,18 +22,37 @@ bool button_check_irq(uint8_t button_id){
 }
 // example irq callback handler, copy for your own uses
 void button_irq_callback(uint gpio, uint32_t events){
+    // Check if button was pressed (rising edge)
+    if (events & GPIO_IRQ_EDGE_RISE) {
+        press_start_time =  get_absolute_time();
+    }
+
+    // Check if button was released (falling edge)
+    if (events & GPIO_IRQ_EDGE_FALL) {
+        absolute_time_t press_end_time = get_absolute_time();
+        int64_t duration_ms = absolute_time_diff_us(press_start_time, press_end_time) / 1000;
+    
+    if (duration_ms <= BP_BUTTON_SHORT_PRESS_MS) {
+        button_long_pressed = false;
+    } else {
+        button_long_pressed = true;
+    }
+    
+    button_pressed = true;
+}
+
     gpio_acknowledge_irq(gpio, events);   
     gpio_set_irq_enabled(gpio, events, true);
-    button_pressed=true;
 }
+
 // enable the irq for button button_id
 void button_irq_enable(uint8_t button_id, void *callback){
     button_pressed=false;
-    gpio_set_irq_enabled_with_callback(EXT1, GPIO_IRQ_EDGE_RISE, true, callback);
+    gpio_set_irq_enabled_with_callback(EXT1, GPIO_IRQ_EDGE_RISE|GPIO_IRQ_EDGE_FALL, true, callback);
 } 
 // disable the irq for button button_id
 void button_irq_disable(uint8_t button_id){
-    gpio_set_irq_enabled(EXT1, GPIO_IRQ_EDGE_RISE, false);
+    gpio_set_irq_enabled(EXT1, GPIO_IRQ_EDGE_RISE|GPIO_IRQ_EDGE_FALL, false);
     button_pressed=false;
 }
 // initialize all buttons

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -1,58 +1,63 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include "pirate.h"
+#include "button.h"
+#include <pico/time.h>
 
 #define BP_BUTTON_SHORT_PRESS_MS 500 // Threshold for short button press
 
 static bool button_pressed = false;
-static bool button_long_pressed = false;
 static absolute_time_t press_start_time;
+static enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){
     return gpio_get(EXT1);
 } 
-bool button_check_irq(uint8_t button_id, bool *long_press){
-    if(button_pressed){
-        *long_press = button_long_pressed;
-        button_pressed=false;
-        return true;
+
+enum button_codes button_check_press(uint8_t button_id) {
+    if (button_pressed) {
+        enum button_codes press_code = button_code;
+        button_code = BP_BUTT_NO_PRESS;
+        button_pressed = false;
+        return press_code;
     }
-    return false;
+    return BP_BUTT_NO_PRESS;
 }
+
 // example irq callback handler, copy for your own uses
 void button_irq_callback(uint gpio, uint32_t events){
     // Check if button was pressed (rising edge)
     if (events & GPIO_IRQ_EDGE_RISE) {
-        press_start_time =  get_absolute_time();
+        press_start_time = get_absolute_time();
     }
 
     // Check if button was released (falling edge)
     if (events & GPIO_IRQ_EDGE_FALL) {
         absolute_time_t press_end_time = get_absolute_time();
         int64_t duration_ms = absolute_time_diff_us(press_start_time, press_end_time) / 1000;
-    
-    if (duration_ms <= BP_BUTTON_SHORT_PRESS_MS) {
-        button_long_pressed = false;
+
+    if (duration_ms >= BP_BUTTON_SHORT_PRESS_MS) {
+        button_code = BP_BUTT_LONG_PRESS;
     } else {
-        button_long_pressed = true;
+        button_code = BP_BUTT_SHORT_PRESS;
     }
     
     button_pressed = true;
 }
 
     gpio_acknowledge_irq(gpio, events);   
-    gpio_set_irq_enabled(gpio, events, true);
+    gpio_set_irq_enabled(gpio, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
 }
 
 // enable the irq for button button_id
 void button_irq_enable(uint8_t button_id, void *callback){
     button_pressed=false;
-    gpio_set_irq_enabled_with_callback(EXT1, GPIO_IRQ_EDGE_RISE|GPIO_IRQ_EDGE_FALL, true, callback);
+    gpio_set_irq_enabled_with_callback(EXT1, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, callback);
 } 
 // disable the irq for button button_id
 void button_irq_disable(uint8_t button_id){
-    gpio_set_irq_enabled(EXT1, GPIO_IRQ_EDGE_RISE|GPIO_IRQ_EDGE_FALL, false);
+    gpio_set_irq_enabled(EXT1, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
     button_pressed=false;
 }
 // initialize all buttons

--- a/pirate/button.h
+++ b/pirate/button.h
@@ -9,4 +9,4 @@ void button_irq_callback(uint gpio, uint32_t events);
 // poll the value of button button_id
 bool button_get(uint8_t button_id);
 //check for interrupt and clear interrupt flag
-bool button_check_irq(uint8_t button_id);
+bool button_check_irq(uint8_t button_id, bool *long_press);

--- a/pirate/button.h
+++ b/pirate/button.h
@@ -9,4 +9,14 @@ void button_irq_callback(uint gpio, uint32_t events);
 // poll the value of button button_id
 bool button_get(uint8_t button_id);
 //check for interrupt and clear interrupt flag
-bool button_check_irq(uint8_t button_id, bool *long_press);
+// bool button_check_irq(uint8_t button_id, bool *long_press);
+
+enum button_codes {
+    BP_BUTT_NO_PRESS = 0,
+    BP_BUTT_SHORT_PRESS,
+    BP_BUTT_LONG_PRESS,
+    BP_BUTT_DOUBLE_TAP,
+};
+
+enum button_codes button_check_press(uint8_t button_id);
+


### PR DESCRIPTION
Updated button_irq_callback to handle RISE and FALL(press and release). Added button_long_exec() in button_scr.c. . Added logic in pirate.c to run bulong.scr instead of button.scr on long press. 