### PR TITLE
LA and sump improvement / cleanup

### DIFF
--- a/mode/logicanalyzer.h
+++ b/mode/logicanalyzer.h
@@ -1,9 +1,10 @@
 void la_test_args (struct command_result *res);
 bool logicanalyzer_setup(void);
+void restart_dma();
 int logicanalyzer_status(void);
 uint8_t logicanalyzer_dump(uint8_t *txbuf);
 bool logic_analyzer_is_done(void);
-bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uint32_t trigger_direction);
+bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uint32_t trigger_direction, bool edge);
 bool logic_analyzer_cleanup(void);
 void logicanalyzer_reset_led(void);
 void la_periodic(void);

--- a/mode/logicanalyzer.pio
+++ b/mode/logicanalyzer.pio
@@ -7,23 +7,25 @@
 
 .program logicanalyzer_no_trigger
 ; get post trigger sample count
-    pull block
-    mov x, osr
+    out x, 32
 ; count down the samples
 capture:
     in pins, 8
     jmp x-- capture
     irq 0
-; done, forever loop
-done:
-    jmp done
+
 
 .program logicanalyzer_high_trigger
-; get post trigger sample count
-    pull block
-    mov x, osr
+
 ; sample and loop for trigger
-.wrap_target
+public edge_trigger_rising:
+wait_low:
+    in pins, 8
+    jmp pin wait_low
+public high_trigger:
+; get post trigger sample count
+    out x, 32
+.wrap_target    ; wait high
     in pins, 8
     jmp pin capture
 .wrap
@@ -32,30 +34,30 @@ capture:
     in pins, 8
     jmp x-- capture
     irq 0
-; done, forever loop
-done:
-    jmp done
+
 
 
 .program logicanalyzer_low_trigger
-; get post trigger sample count
-    pull block
-    mov x, osr
+public edge_trigger_falling:
 ; sample and loop for trigger
+.wrap_target     ;wait high
+    in pins, 8
+    jmp pin low_trigger
+.wrap
+public low_trigger:
+; get post trigger sample count
+    out x, 32
 wait_low:
     in pins, 8
     jmp pin wait_low
-; count down the samples
+;count down the samples
 capture:
-    in pins, 8
+    in pins,8
     jmp x-- capture
     irq 0
-; done, forever loop
-done:
-    jmp done
 
 % c-sdk {
-static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq) {
+static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);    
@@ -82,12 +84,13 @@ static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uin
     pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
     pio_set_irq1_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
 
+    uint program_offset = offset + (edge ? logicanalyzer_high_trigger_offset_edge_trigger_rising : logicanalyzer_high_trigger_offset_high_trigger);
     // Load our configuration, and jump to the start of the program
-    pio_sm_init(pio, sm, offset, &c);
- 
+    pio_sm_init(pio, sm, program_offset, &c);
+
 }
 
-static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq) {
+static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);    
@@ -111,9 +114,13 @@ static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint
 	float div = clock_get_hz(clk_sys) / (freq * 2); //2 instructions per sample, run twice as fast as requested sampling rate  
 	sm_config_set_clkdiv(&c, div);
 
+    pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
+    pio_set_irq1_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
+
+    uint program_offset = offset + (edge ? logicanalyzer_low_trigger_offset_edge_trigger_falling : logicanalyzer_low_trigger_offset_low_trigger);
     // Load our configuration, and jump to the start of the program
-    pio_sm_init(pio, sm, offset, &c);
- 
+    pio_sm_init(pio, sm, program_offset, &c);
+
 }
 
 static inline void logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, float freq) {
@@ -137,8 +144,11 @@ static inline void logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint 
     sm_config_set_out_shift(&c, false, true, 32);
     sm_config_set_in_shift(&c, false, true, 8);
 
-	float div = clock_get_hz(clk_sys) / (freq * 2);  
-	sm_config_set_clkdiv(&c, div);
+    float div = clock_get_hz(clk_sys) / (freq * 2);
+    sm_config_set_clkdiv(&c, div);
+
+    pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
+    pio_set_irq1_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
 
     // Load our configuration, and jump to the start of the program
     pio_sm_init(pio, sm, offset, &c);


### PR DESCRIPTION
Logic analyzer code cleanup, fix potential race condition, edge triggering support
sump support for edge triggering
pio code cleanup (shorter) and edge triggering support

@DangerousPrototypes I found the root cause of the sigrok problem. It is due to the 3rd party library libserialport. It lacks a proper handling of the Windows overlapped IO feature. I partially rewrote the OLS support just because it was quite inefficient but I believe that the original code would work with a fixed libserialport. I also added edge triggering to the OLS support. I do have a fixed Windows pulseview  setup program but I lack a place to upload it. If you could tell me where to upload it, I will do so. 