### PR TITLE
Intercore messaging Quality-of-Life improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(bp5_common
         pirate/button.h pirate/button.c pirate/mem.c pirate/mem.h
         pirate/lcd.h pirate/lcd.c pirate/shift.h pirate/shift.c
         pirate/amux.h pirate/amux.c pirate/rgb.h pirate/rgb.c
+        pirate/intercore_helpers.c
 
         # commands
         commands.h commands.c

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -16,6 +16,7 @@
 #include "pirate/bio.h"
 #include "pirate/amux.h"
 #include "display/scope.h"
+#include "pirate/intercore_helpers.h"
 
 #define SELF_TEST_LOW_LIMIT 300
 
@@ -339,8 +340,7 @@ void cmd_selftest(void){
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");
-    multicore_fifo_push_blocking(0xf0);
-    while(multicore_fifo_pop_blocking()!=0xf0);
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
     busy_wait_ms(500);
     printf("OK\r\n");
 
@@ -398,8 +398,7 @@ void cmd_selftest(void){
     system_config.error=false;
 
     //enable system interrupts
-    multicore_fifo_push_blocking(0xf1);
-    while(multicore_fifo_pop_blocking()!=0xf1);
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
 }
 
 static const char * const usage[]={

--- a/display/default.c
+++ b/display/default.c
@@ -27,7 +27,7 @@
 #include "ui/ui_parse.h"
 #include "ui/ui_cmdln.h"
 #include "usb_rx.h"
-
+#include "pirate/intercore_helpers.h"
 
 void
 disp_default_settings(void)
@@ -56,11 +56,8 @@ uint32_t disp_default_setup(void)
 
 uint32_t disp_default_setup_exc(void)
 {
-    multicore_fifo_push_blocking(0xf0);
-    while(multicore_fifo_pop_blocking()!=0xf0);
-
-    multicore_fifo_push_blocking(0xf2);
-    while(multicore_fifo_pop_blocking()!=0xf2);
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
+    icm_core0_send_message_synchronous(BP_ICM_FORCE_LCD_UPDATE);
 	return 1;
 }
 

--- a/mode/logicanalyzer.c
+++ b/mode/logicanalyzer.c
@@ -20,6 +20,7 @@
 #include "pico/multicore.h"
 #include "pirate/amux.h"
 #include "ui/ui_cmdln.h"
+#include "pirate/intercore_helpers.h"
 
 enum logicanalyzer_status
 {
@@ -320,8 +321,7 @@ la_x:
 
 void logicanalyzer_reset_led(void)
 {
-    multicore_fifo_push_blocking(0xf4);
-    multicore_fifo_pop_blocking();
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_RGB_UPDATES);
 }
 
 
@@ -484,8 +484,7 @@ bool logic_analyzer_arm(float freq, uint32_t samples, uint32_t trigger_mask, uin
     irq_set_enabled(pio_get_dreq(pio, sm, false), true);
     irq_clear(pio_get_dreq(pio, sm, false));
     la_status=LA_ARMED_INIT;
-    multicore_fifo_push_blocking(0xf3);
-    multicore_fifo_pop_blocking();
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_RGB_UPDATES);
     //rgb_irq_enable(false);
     busy_wait_ms(5);
     rgb_set_all(0xff,0,0); //RED LEDs for armed

--- a/pirate.c
+++ b/pirate.c
@@ -48,6 +48,7 @@
 //#include "display/scope.h"
 #include "mode/logicanalyzer.h"
 #include "msc_disk.h"
+#include "pirate/intercore_helpers.h"
 
 static mutex_t spi_mutex;
 
@@ -176,9 +177,7 @@ int main(){
     // begin main loop on secondary core
     // this will also setup the USB device
     // we need to have read any config files on the TF flash card before now
-    multicore_fifo_push_blocking(0); 
-    // wait for init to complete  
-    while(multicore_fifo_pop_blocking()!=0xff);
+    icm_core0_send_message_synchronous(BP_ICM_INIT_CORE1);
 
     //test for PCB revision
     //must be done after shift register setup
@@ -352,16 +351,16 @@ bool lcd_update_force=false;
 
 // begin of code execution for the second core (core1)
 void core1_entry(void){ 
-    char c;
-    uint32_t temp;
-
     tx_fifo_init();
     rx_fifo_init();
 
     rgb_init();
 
     // wait for main core to signal start
-    while(multicore_fifo_pop_blocking()!=0);
+    bp_icm_raw_message_t raw_init_message;
+    do {
+        raw_init_message = icm_core1_get_raw_message();
+    } while(get_embedded_message(raw_init_message) != BP_ICM_INIT_CORE1);
 
     // USB init
     if(system_config.terminal_usb_enable){
@@ -375,7 +374,7 @@ void core1_entry(void){
         rx_uart_init_irq();
     }
 
-    multicore_fifo_push_blocking(0xff); 
+    icm_core1_notify_completion(raw_init_message);
 
     while(1){
         //service (thread safe) tinyusb tasks
@@ -429,31 +428,31 @@ void core1_entry(void){
         
         // service any requests with priority
         while(multicore_fifo_rvalid()){
-            temp=multicore_fifo_pop_blocking();
-            switch(temp){
-                case 0xf0:
+            bp_icm_raw_message_t raw_message = icm_core1_get_raw_message();
+            switch(get_embedded_message(raw_message)){
+                case BP_ICM_DISABLE_LCD_UPDATES:
                     lcd_irq_disable();
                     lcd_update_request=false;
                     break;
-                case 0xf1:
+                case BP_ICM_ENABLE_LCD_UPDATES:
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_request=true;
                     break;
-                case 0xf2:
+                case BP_ICM_FORCE_LCD_UPDATE:
                     lcd_irq_enable(BP_LCD_REFRESH_RATE_MS);
                     lcd_update_force=true;
                     lcd_update_request=true;
                     break;
-                case 0xf3:
+                case BP_ICM_ENABLE_RGB_UPDATES:
                     rgb_irq_enable(false);
                     break;
-                case 0xf4:
+                case BP_ICM_DISABLE_RGB_UPDATES:
                     rgb_irq_enable(true);
                     break;
                 default:
                     break;
             }
-            multicore_fifo_push_blocking(temp); //acknowledge
+            icm_core1_notify_completion(raw_message);
         }
 
     }// while(1)

--- a/pirate/intercore_helpers.c
+++ b/pirate/intercore_helpers.c
@@ -1,0 +1,57 @@
+#include "pirate/intercore_helpers.h"
+#include "pirate.h"
+#include "assert.h"
+
+// This wrapper is a response to manual code review noting
+// at least two coding patterns, neither of which provided
+// any indication when things were awry.
+//
+// Using this wrapper increases the detectability of code
+// errors, and also makes it easier to later change to
+// alternative cross-core communication methods if needed.
+
+
+void icm_core0_send_message_synchronous(bp_icm_message_t message_id) {
+
+    // NOTE: although split into multiple lines for readability,
+    //       the compiler optimizes this quite well!
+    static uint8_t static_message_count = 0u;
+
+    // Basic concepts:
+    // 1. Encode a counter within the message ID.
+    //    This prevents various code errors from
+    //    causing intercore synchronization to be lost.
+    //    The counter is incremented each time core0
+    //    sends a message using this API, and the wait
+    //    ensures this same message (including the counter)
+    //    is received, confirming the message was processed.
+    // 2. Ensure that the message ID is not a valid pointer.
+    //    Per the RP2040 memory map, the range 0x60000000..0xCFFFFFFF
+    //    is unmapped, and will cause a bus error if accessed.
+    //
+    // RP2040 uses a `uint32_t` value for the intercore message.
+    //
+    // Here, we pack that `uint32_t` with the following data:
+    // typedef struct {
+    //     uint8_t map          = 0xABu;      // constant
+    //     uint8_t cnt          = counter;    // incremented each time a message is sent
+    //     uint8_t RFU          = 0x00u;      // reserved for future use
+    //     bp_icm_message_t msg = message_id; // actual message
+    // } bp_icm_raw_message_t;
+
+    bp_icm_raw_message_t raw_msg = {
+        .map = 0x80u,
+        .cnt = ++static_message_count,
+        .rfu = 0x00u,
+        .msg = message_id
+    };
+    multicore_fifo_push_blocking(raw_msg.raw);
+
+    do {
+        uint32_t response = multicore_fifo_pop_blocking();
+        // in the current design, any message other than
+        // the one sent indicates a serious de-synchronization
+        assert(response == raw_msg.raw);
+        if (response == raw_msg.raw) return;
+    } while (1);
+}

--- a/pirate/intercore_helpers.h
+++ b/pirate/intercore_helpers.h
@@ -1,0 +1,58 @@
+// Inter-Core Messages
+
+#include "pico/multicore.h"
+
+// This file added in response to manual code review discovering the following:
+//     Some places, core0 sends, and then loops until core1 sends ***same*** value as response.
+//     (This could lose other messages that are sent, if any.)
+//
+//     Other places, core0 sends, and then loops until core1 sends ***any*** value as response.
+//     (This could improperly continue even if the response is for a different message.)
+//
+//     There are strong warnings AGAINST using multicore FIFOs unless can be sure not used
+//     by any RTOS layer, intercore lockout functionality, etc.  Thus, consider changing these
+//     to use a standard queue instead.
+//
+typedef uint8_t bp_icm_message_t;
+#define BP_ICM_INIT_CORE1            ((bp_icm_message_t)0xA5) // Used to synchronize Core0 and Core1 intialization.
+#define BP_ICM_DISABLE_LCD_UPDATES   ((bp_icm_message_t)0xF0) // disables LCD updates / IRQ
+#define BP_ICM_ENABLE_LCD_UPDATES    ((bp_icm_message_t)0xF1) // enables LCD updates / IRQ
+#define BP_ICM_FORCE_LCD_UPDATE      ((bp_icm_message_t)0xF2) // enable LCD updates / IRQ and force an update
+#define BP_ICM_DISABLE_RGB_UPDATES   ((bp_icm_message_t)0xF3) // disables RGB updates / IRQ
+#define BP_ICM_ENABLE_RGB_UPDATES    ((bp_icm_message_t)0xF4) // enables RGB updates / IRQ
+
+// This is intended to be an opaque data type
+typedef struct _bp_icm_raw_message_t {
+    union {
+        uint32_t raw;
+        struct {
+            uint8_t map;          // set to 0xABu to create invalid pointer, per RP2040 memory map
+            uint8_t cnt;          // incremented each time a message is sent, to catch desynchronization
+            uint8_t rfu;          // reserved for future use
+            bp_icm_message_t msg; // actual message, aka bp_icm_message_t
+        };
+    };
+} bp_icm_raw_message_t; // wrapper to clarify that this differs from bp_icm_message_t
+static_assert(sizeof(bp_icm_message_t) == sizeof(uint8_t), "sizeof(bp_icm_message_t) must be sizeof(uint8_t), else structure must be updated");
+static_assert(sizeof(bp_icm_raw_message_t) == sizeof(uint32_t), "sizeof(bp_icm_raw_message_t) must be sizeof(uint32_t) to be used by intercore messaging");
+
+
+// While core1 has a single point where these messages are received / responded to,
+// core0 sends the messages from many files.
+// Funnel into low-overhead wrapper to catch errors in cross-core synchronization,
+// because debugging such issues is ... non-trivial.
+void icm_core0_send_message_synchronous(bp_icm_message_t message_id);
+
+
+// These are ultra-low overhead ... maybe even zero overhead with full optimizations.
+inline bp_icm_raw_message_t icm_core1_get_raw_message() {
+    bp_icm_raw_message_t result;
+    result.raw = multicore_fifo_pop_blocking();
+    return result;
+}
+inline void icm_core1_notify_completion(bp_icm_raw_message_t icm_raw_value) {
+    multicore_fifo_push_blocking(icm_raw_value.raw);
+}
+inline bp_icm_message_t get_embedded_message(bp_icm_raw_message_t icm_raw_value) {
+    return icm_raw_value.msg;
+}

--- a/ui/ui_process.c
+++ b/ui/ui_process.c
@@ -16,6 +16,7 @@
 #include "ui/ui_cmdln.h"
 #include "string.h"
 #include "syntax.h"
+#include "pirate/intercore_helpers.h"
 
 // const structs are init'd with 0s, we'll make them here and copy in the main loop
 static const struct command_result result_blank;
@@ -24,20 +25,17 @@ bool ui_process_syntax(void)
 {
     if(syntax_compile())
     {
-            printf("Syntax compile error\r\n");
-            return true;
+        printf("Syntax compile error\r\n");
+        return true;
     }
-    multicore_fifo_push_blocking(0xf0);
-    multicore_fifo_pop_blocking();
+    icm_core0_send_message_synchronous(BP_ICM_DISABLE_LCD_UPDATES);
     if(syntax_run())
     {
-            multicore_fifo_push_blocking(0xf1);
-            multicore_fifo_pop_blocking(); 
-            printf("Syntax execution error\r\n");
-            return true;
+        icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
+        printf("Syntax execution error\r\n");
+        return true;
     }
-    multicore_fifo_push_blocking(0xf1);
-    multicore_fifo_pop_blocking();            
+    icm_core0_send_message_synchronous(BP_ICM_ENABLE_LCD_UPDATES);
     if(syntax_post())
     {
             printf("Syntax post process error\r\n");


### PR DESCRIPTION
Provide friendly names for intercore messages.

Use the same standard technique in all locations
for intercore messaging (at least two different
methods were used before).

Validate that the confirmation response for each
message corresponds to the one sent.

Debugging cross-core synchronization issues is ... not fun.  With nearly zero overhead, this update
provides the ability to catch most synchronization errors between cores via the insertion of a counter for each message.