### PR TITLE
Minor bugfixes

### DIFF
--- a/msc_disk.c
+++ b/msc_disk.c
@@ -98,7 +98,11 @@ uint8_t msc_disk[MSC_DEMO_DISK_BLOCK_NUM][MSC_DEMO_DISK_BLOCK_SIZE] =
       // second entry is readme file
       'R' , 'E' , 'A' , 'D' , 'M' , 'E' , ' ' , ' ' , 'T' , 'X' , 'T' , 0x20, 0x00, 0xC6, 0x52, 0x6D,
       0x65, 0x43, 0x65, 0x43, 0x00, 0x00, 0x88, 0x6D, 0x65, 0x43, 0x02, 0x00,
-      sizeof(README_CONTENTS)-1, 0x00, 0x00, 0x00 // readme's files size (4 Bytes)
+      
+      (sizeof(README_CONTENTS)-1 >> (8*0)), // readme's files size (4 Bytes, little-endian)
+      (sizeof(README_CONTENTS)-1 >> (8*1)), // readme's files size (4 Bytes, little-endian)
+      (sizeof(README_CONTENTS)-1 >> (8*2)), // readme's files size (4 Bytes, little-endian)
+      (sizeof(README_CONTENTS)-1 >> (8*3)), // readme's files size (4 Bytes, little-endian)
   },
 
   //------------- Block3: Readme Content -------------//
@@ -117,6 +121,8 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
   const char pid[] = "Storage";
   const char rev[] = "1.0";
 
+  // NOTE: Relies on behavior of TinyUSB, which sets all strings to 0x20 (space)
+  //       before calling this function.  See class/msc/msc_device.c.
   memcpy(vendor_id  , vid, strlen(vid));
   memcpy(product_id , pid, strlen(pid));
   memcpy(product_rev, rev, strlen(rev));

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -7,9 +7,10 @@
 
 #define BP_BUTTON_SHORT_PRESS_MS 550
 
-static bool button_pressed = false;
-static absolute_time_t press_start_time;
-static enum button_codes button_code = BP_BUTT_NO_PRESS;
+// volatile because these are modified in IRQ handler
+static volatile bool button_pressed = false;
+static volatile absolute_time_t press_start_time;
+static volatile enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){

--- a/pirate/mcu.c
+++ b/pirate/mcu.c
@@ -6,6 +6,7 @@
 #include "pico/bootrom.h"
 
 uint64_t mcu_get_unique_id(void){
+	static_assert(sizeof(pico_unique_board_id_t) == sizeof(uint64_t), "pico_unique_board_id_t is not 64 bits (but is cast to uint64_t)");
 	pico_unique_board_id_t id;
 	pico_get_unique_board_id(&id);
     return *((uint64_t*)(id.id));


### PR DESCRIPTION
Only one change that has potential to modify resulting code:

* Mark a global variable modified in ISR as `volatile`.

Otherwise, these are compile-time only changes with no impact on resulting binary:

* Static assertion added
* Framework to enable readme to be up to 511 bytes

If you've not been bitten by the lack of `volatile`, consider yourself lucky.  Suffice it to say that the compiler's optimizer needs to know that it really, really should not optimize some things.
