### PR TITLE
Enable 2Gbit rev10 board firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,13 @@ set(bp5_common
         usb_tx.c usb_tx.h usb_rx.c usb_rx.h
         msc_disk.c msc_disk.h usb_descriptors.c
 )
+set(bp5_rev10
+        platform/bpi-rev10.h platform/bpi-rev10.c 
+        #nand flash management and dhara
+        dhara/bytes.h dhara/error.c dhara/error.h dhara/journal.c dhara/journal.h dhara/map.c dhara/map.h dhara/nand.c dhara/nand.h
+        nand/nand_ftl_diskio.c nand/nand_ftl_diskio.h nand/spi.c nand/spi.h nand/spi_nand.c nand/spi_nand.h 
+        nand/sys_time.c nand/sys_time.h
+)
 
 add_executable(bus_pirate5_rev8
         ${bp5_common}
@@ -179,13 +186,18 @@ target_compile_definitions(bus_pirate5_rev8 PUBLIC BP5_REV=8)
 
 add_executable(bus_pirate5_rev10
         ${bp5_common}
-        platform/bpi-rev10.h platform/bpi-rev10.c 
-        #nand flash management and dhara
-        dhara/bytes.h dhara/error.c dhara/error.h dhara/journal.c dhara/journal.h dhara/map.c dhara/map.h dhara/nand.c dhara/nand.h
-        nand/nand_ftl_diskio.c nand/nand_ftl_diskio.h nand/spi.c nand/spi.h nand/spi_nand.c nand/spi_nand.h 
-        nand/sys_time.c nand/sys_time.h
+        ${bp5_rev10}
         )
 target_compile_definitions(bus_pirate5_rev10 PUBLIC BP5_REV=10)
+
+add_executable(bus_pirate5_rev10_2gbit
+        ${bp5_common}
+        ${bp5_rev10}
+        )
+target_compile_definitions(bus_pirate5_rev10_2gbit PUBLIC BP5_REV=10)
+target_compile_definitions(bus_pirate5_rev10_2gbit PUBLIC FLASH_MT29F2G01ABAFDWB)
+
+
 
 set(stdlibs
         pico_stdlib
@@ -213,9 +225,11 @@ set(stdlibs
 set(revisions
         bus_pirate5_rev8  
         bus_pirate5_rev10
+        bus_pirate5_rev10_2gbit
         )
         
 
+# Compile the various PIO programs to generate the header files
 foreach(revision ${revisions})
         ADD_DEPENDENCIES (${revision} timestamp)
         pico_generate_pio_header(${revision} ${CMAKE_CURRENT_LIST_DIR}/pirate/hw2wire.pio)
@@ -258,8 +272,9 @@ set(USE_LGPL3 TRUE CACHE BOOL "indicated if to include LGPL3 protected code")
 include(cmake/ansi_colours_import.cmake)
 if(USE_LGPL3)
 if(LEGACY_ANSI_COLOURS_ENABLED)
-        target_link_libraries(bus_pirate5_rev10 lib_ansi_colours)
-        target_link_libraries(bus_pirate5_rev8 lib_ansi_colours)
+        target_link_libraries(bus_pirate5_rev10_2gbit lib_ansi_colours)
+        target_link_libraries(bus_pirate5_rev10       lib_ansi_colours)
+        target_link_libraries(bus_pirate5_rev8        lib_ansi_colours)
 endif()
 endif()
 

--- a/nand/attic/shell_cmd.c
+++ b/nand/attic/shell_cmd.c
@@ -222,7 +222,7 @@ static void command_get_bad_block_table(int argc, char *argv[])
     }
     // read block status into page buffer
     bool success = true;
-    for (int i = 0; i < SPI_NAND_BLOCKS_PER_LUN; i++) {
+    for (int i = 0; i < SPI_NAND_ERASE_BLOCKS_PER_LUN; i++) {
         bool is_bad;
         row_address_t row = {.block = i, .page = 0};
         int ret = spi_nand_block_is_bad(row, &is_bad);
@@ -238,7 +238,7 @@ static void command_get_bad_block_table(int argc, char *argv[])
 
     // print bad block table
     if (success) {
-        print_bytes(page_buffer, SPI_NAND_BLOCKS_PER_LUN);
+        print_bytes(page_buffer, SPI_NAND_ERASE_BLOCKS_PER_LUN);
     }
     mem_free(page_buffer);
 }

--- a/nand/nand_ftl_diskio.c
+++ b/nand/nand_ftl_diskio.c
@@ -25,8 +25,8 @@ static struct dhara_map map;
 static uint8_t page_buffer[SPI_NAND_PAGE_SIZE];
 static struct dhara_nand nand = {
     .log2_page_size = SPI_NAND_LOG2_PAGE_SIZE,
-    .log2_ppb = SPI_NAND_LOG2_PAGES_PER_BLOCK,
-    .num_blocks = SPI_NAND_BLOCKS_PER_LUN,
+    .log2_ppb = SPI_NAND_LOG2_PAGES_PER_ERASE_BLOCK,
+    .num_blocks = SPI_NAND_ERASE_BLOCKS_PER_LUN,
 };
 
 // public function definitions


### PR DESCRIPTION
* Add new target in CMakefiles.txt
* Change NAND terms to use `ERASE_BLOCK` instead of simply `BLOCK`
* Use `#define` to select between two flash chips for firmware
* Pass `row_address_t` to additional nand functions to support multi-plane
* Fix for cross-plane copy (less efficient, but required until command found that copies from one plane's cache register to the other plane's cache register...)

( Replaces PR #65  )