### PR TITLE
BigBuf - framework / untested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,129 +50,261 @@ set(bp5_common
 
         # commands
         commands.h commands.c
-        commands/global/w_psu.h commands/global/w_psu.c
-        commands/global/p_pullups.h commands/global/p_pullups.c
-        commands/global/cmd_mcu.h commands/global/cmd_mcu.c
-        commands/global/l_bitorder.h commands/global/l_bitorder.c
-        commands/global/cmd_convert.h commands/global/cmd_convert.c
-        commands/global/pause.h commands/global/pause.c
-        commands/global/h_help.h commands/global/h_help.c
-        commands/global/cmd_selftest.h commands/global/cmd_selftest.c
-        commands/global/a_auxio.h commands/global/a_auxio.c
-        commands/global/dummy.c commands/global/dummy.h
-        commands/global/disk.c commands/global/disk.h
-        commands/global/v_adc.c commands/global/v_adc.h
-        commands/global/i_info.c commands/global/i_info.h
-        commands/global/pwm.c commands/global/pwm.h
-        commands/global/freq.c commands/global/freq.h
-        commands/global/macro.c commands/global/macro.h
-        commands/global/script.c commands/global/script.h
-        commands/global/tutorial.c commands/global/tutorial.h
-        commands/global/button_scr.c commands/global/button_scr.h
+        commands/global/w_psu.h
+        commands/global/w_psu.c
+        commands/global/p_pullups.h
+        commands/global/p_pullups.c
+        commands/global/cmd_mcu.h
+        commands/global/cmd_mcu.c
+        commands/global/l_bitorder.h
+        commands/global/l_bitorder.c
+        commands/global/cmd_convert.h
+        commands/global/cmd_convert.c
+        commands/global/pause.h
+        commands/global/pause.c
+        commands/global/h_help.h
+        commands/global/h_help.c
+        commands/global/cmd_selftest.h
+        commands/global/cmd_selftest.c
+        commands/global/a_auxio.h
+        commands/global/a_auxio.c
+        commands/global/dummy.c
+        commands/global/dummy.h
+        commands/global/disk.c
+        commands/global/disk.h
+        commands/global/v_adc.c
+        commands/global/v_adc.h
+        commands/global/i_info.c
+        commands/global/i_info.h
+        commands/global/pwm.c
+        commands/global/pwm.h
+        commands/global/freq.c
+        commands/global/freq.h
+        commands/global/macro.c
+        commands/global/macro.h
+        commands/global/script.c
+        commands/global/script.h
+        commands/global/tutorial.c
+        commands/global/tutorial.h
+        commands/global/button_scr.c
+        commands/global/button_scr.h
+        commands/global/bigbuffer_test.c
+        commands/global/bigbuffer_test.h
+        
         # HiZ
-        mode/hiz.h mode/hiz.c
+        mode/hiz.h
+        mode/hiz.c
+        
         # 1Wire
-        mode/hw1wire.h mode/hw1wire.c
-        pirate/hw1wire_pio.h pirate/hw1wire_pio.c
-        commands/1wire/scan.h commands/1wire/scan.c
-        commands/1wire/demos.h commands/1wire/demos.c
+        mode/hw1wire.h
+        mode/hw1wire.c
+        pirate/hw1wire_pio.h
+        pirate/hw1wire_pio.c
+        commands/1wire/scan.h
+        commands/1wire/scan.c
+        commands/1wire/demos.h
+        commands/1wire/demos.c
 
         # UART
-        mode/hwuart.h mode/hwuart.c
-        pirate/hwuart_pio.h pirate/hwuart_pio.c
-        commands/uart/nmea.c commands/uart/nmea.h
-        commands/uart/bridge.h commands/uart/bridge.c
-        commands/uart/simcard.h commands/uart/simcard.c
-        lib/minmea/minmea.h lib/minmea/minmea.c lib/minmea/gps.h lib/minmea/gps.c
+        mode/hwuart.h
+        mode/hwuart.c
+        pirate/hwuart_pio.h
+        pirate/hwuart_pio.c
+        commands/uart/nmea.c
+        commands/uart/nmea.h
+        commands/uart/bridge.h
+        commands/uart/bridge.c
+        commands/uart/simcard.h
+        commands/uart/simcard.c
+        lib/minmea/minmea.h
+        lib/minmea/minmea.c
+        lib/minmea/gps.h
+        lib/minmea/gps.c
 
         # Half duplex UART
-        mode/hwhduart.h mode/hwhduart.c
-        commands/hdplxuart/bridge.c commands/hdplxuart/bridge.h
+        mode/hwhduart.h
+        mode/hwhduart.c
+        commands/hdplxuart/bridge.c
+        commands/hdplxuart/bridge.h
 
         # I2C 
-        mode/hwi2c.c mode/hwi2c.h
-        pirate/hwi2c_pio.c pirate/hwi2c_pio.h
-        commands/i2c/scan.h commands/i2c/scan.c
-        commands/i2c/demos.h commands/i2c/demos.c
+        mode/hwi2c.c
+        mode/hwi2c.h
+        pirate/hwi2c_pio.c
+        pirate/hwi2c_pio.h
+        commands/i2c/scan.h
+        commands/i2c/scan.c
+        commands/i2c/demos.h
+        commands/i2c/demos.c
         lib/i2c_address_list/dev_i2c_addresses.h
-        lib/ms5611/ms5611.c lib/ms5611/ms5611.h lib/tsl2561/driver_tsl2561.c lib/tsl2561/driver_tsl2561.h
+        lib/ms5611/ms5611.c
+        lib/ms5611/ms5611.h
+        lib/tsl2561/driver_tsl2561.c
+        lib/tsl2561/driver_tsl2561.h
 
         # SPI
-        mode/hwspi.c mode/hwspi.h
-        pirate/hwspi.c pirate/hwspi.h
-        commands/spi/flash.c commands/spi/flash.h commands/spi/spiflash.h commands/spi/spiflash.c
-        commands/spi/sniff.c commands/spi/sniff.h
-        lib/sfud/inc/sfud.h lib/sfud/inc/sfud.c lib/sfud/inc/sfud_cfg.h lib/sfud/inc/sfud_def.h
-        lib/sfud/inc/sfud_flash_def.h lib/sfud/inc/sfud_port.c lib/sfud/inc/sfud_sfdp.c
+        mode/hwspi.c
+        mode/hwspi.h
+        pirate/hwspi.c
+        pirate/hwspi.h
+        commands/spi/flash.c
+        commands/spi/flash.h
+        commands/spi/spiflash.h
+        commands/spi/spiflash.c
+        commands/spi/sniff.c
+        commands/spi/sniff.h
+        lib/sfud/inc/sfud.h
+        lib/sfud/inc/sfud.c
+        lib/sfud/inc/sfud_cfg.h
+        lib/sfud/inc/sfud_def.h
+        lib/sfud/inc/sfud_flash_def.h
+        lib/sfud/inc/sfud_port.c
+        lib/sfud/inc/sfud_sfdp.c
 
         # 2WIRE
-        mode/hw2wire.h mode/hw2wire.c
-        pirate/hw2wire_pio.h pirate/hw2wire_pio.c
-        commands/2wire/sle4442.c commands/2wire/sle4442.h
+        mode/hw2wire.h
+        mode/hw2wire.c
+        pirate/hw2wire_pio.h
+        pirate/hw2wire_pio.c
+        commands/2wire/sle4442.c
+        commands/2wire/sle4442.h
 
         # LED
-        mode/hwled.c mode/hwled.h
+        mode/hwled.c
+        mode/hwled.h
 
         # DIO
-        mode/dio.h mode/dio.c
+        mode/dio.h
+        mode/dio.c
 
         # DUMMY MODE
-        mode/dummy1.c mode/dummy1.h
+        mode/dummy1.c
+        mode/dummy1.h
 
         # UI
-        ui/ui_button.c ui/ui_button.h
-        ui/ui_cmdln.c ui/ui_cmdln.h
-        ui/ui_process.h ui/ui_process.c
+        ui/ui_button.c
+        ui/ui_button.h
+        ui/ui_cmdln.c
+        ui/ui_cmdln.h
+        ui/ui_process.h
+        ui/ui_process.c
         ui/ui_flags.h
-        ui/ui_parse.c ui/ui_parse.h
-        ui/ui_prompt.h ui/ui_prompt.c
-        ui/ui_mode.c ui/ui_mode.h
-        ui/ui_display.c ui/ui_display.h
-        ui/ui_info.h ui/ui_info.c
-        ui/ui_format.c ui/ui_format.c
-        ui/ui_init.c ui/ui_init.h
-        ui/ui_const.h ui/ui_const.c
-        ui/ui_config.h ui/ui_config.c
-        ui/ui_help.c ui/ui_help.h
-        ui/ui_term.c ui/ui_term.h
-        ui/ui_statusbar.c ui/ui_statusbar.h
-        debug.c debug.h
+        ui/ui_parse.c
+        ui/ui_parse.h
+        ui/ui_prompt.h
+        ui/ui_prompt.c
+        ui/ui_mode.c
+        ui/ui_mode.h
+        ui/ui_display.c
+        ui/ui_display.h
+        ui/ui_info.h
+        ui/ui_info.c
+        ui/ui_format.c
+        ui/ui_format.c
+        ui/ui_init.c
+        ui/ui_init.h
+        ui/ui_const.h
+        ui/ui_const.c
+        ui/ui_config.h
+        ui/ui_config.c
+        ui/ui_help.c
+        ui/ui_help.h
+        ui/ui_term.c
+        ui/ui_term.h
+        ui/ui_statusbar.c
+        ui/ui_statusbar.h
+        debug.c
+        debug.h
 
         # JSON parser for saved settings
-        mjson/mjson.h mjson/mjson.c
+        mjson/mjson.h
+        mjson/mjson.c
 
         # syntax and commands
-        syntax.h syntax.c syntax_struct.h
-        opt_args.h command_attributes.h bytecode.h
+        syntax.h
+        syntax.c
+        syntax_struct.h
+        opt_args.h
+        command_attributes.h
+        bytecode.h
 
         # FATfs
-        fatfs/diskio.c fatfs/diskio.h fatfs/ff.c fatfs/ff.h fatfs/ffconf.h fatfs/ffsystem.c fatfs/ffunicode.c
+        fatfs/diskio.c
+        fatfs/diskio.h
+        fatfs/ff.c
+        fatfs/ff.h
+        fatfs/ffconf.h
+        fatfs/ffsystem.c
+        fatfs/ffunicode.c
 
         # translations
-        translation/base.h translation/base.c
-        translation/en-us.h translation/zh-cn.h translation/pl-pl.h
+        translation/base.h
+        translation/base.c
+        translation/en-us.h
+        translation/zh-cn.h
+        translation/pl-pl.h
 
         # binary mode
-        mode/binio.c mode/binio.h mode/binio_helpers.c mode/binio_helpers.h
-        mode/logicanalyzer.h mode/logicanalyzer.c mode/sump.c mode/sump.h
+        mode/binio.c
+        mode/binio.h
+        mode/binio_helpers.c
+        mode/binio_helpers.h
+        mode/logicanalyzer.h
+        mode/logicanalyzer.c
+        mode/sump.c
+        mode/sump.h
 
         # displays
-        displays.c displays.h display/default.c display/default.h
-        ui/ui_lcd.c ui/ui_lcd.h display/scope.h display/scope.c
-        font/font.h font/hunter-14pt-19h15w.h font/hunter-12pt-16h13w.h font/hunter-20pt-21h21w.h
-        font/hunter-23pt-24h24w.h font/background.h font/background_image_v4.h
+        displays.c
+        displays.h
+        display/default.c
+        display/default.h
+        ui/ui_lcd.c
+        ui/ui_lcd.h
+        display/scope.h
+        display/scope.c
+        font/font.h
+        font/hunter-14pt-19h15w.h
+        font/hunter-12pt-16h13w.h
+        font/hunter-20pt-21h21w.h
+        font/hunter-23pt-24h24w.h
+        font/background.h
+        font/background_image_v4.h
 
         # USB
-        queue.c queue.h
-        usb_tx.c usb_tx.h usb_rx.c usb_rx.h
-        msc_disk.c msc_disk.h usb_descriptors.c
+        queue.c
+        queue.h
+        usb_tx.c
+        usb_tx.h
+        usb_rx.c
+        usb_rx.h
+        msc_disk.c
+        msc_disk.h
+        usb_descriptors.c
 )
 set(bp5_rev10
-        platform/bpi-rev10.h platform/bpi-rev10.c 
-        #nand flash management and dhara
-        dhara/bytes.h dhara/error.c dhara/error.h dhara/journal.c dhara/journal.h dhara/map.c dhara/map.h dhara/nand.c dhara/nand.h
-        nand/nand_ftl_diskio.c nand/nand_ftl_diskio.h nand/spi.c nand/spi.h nand/spi_nand.c nand/spi_nand.h 
-        nand/sys_time.c nand/sys_time.h
+        platform/bpi-rev10.h
+        platform/bpi-rev10.c
+
+        # nand flash management and dhara
+        dhara/bytes.h
+        dhara/error.c
+        dhara/error.h
+        dhara/journal.c
+        dhara/journal.h
+        dhara/map.c
+        dhara/map.h
+        dhara/nand.c
+        dhara/nand.h
+
+        nand/nand_ftl_diskio.c
+        nand/nand_ftl_diskio.h
+        nand/spi.c
+        nand/spi.h
+        nand/spi_nand.c
+        nand/spi_nand.h
+        nand/sys_time.c
+        nand/sys_time.h
 )
 
 add_executable(bus_pirate5_rev8

--- a/commands.c
+++ b/commands.c
@@ -33,6 +33,7 @@
 #include "commands/global/script.h"
 #include "commands/global/tutorial.h"
 #include "commands/global/button_scr.h"
+#include "commands/global/bigbuffer_test.h"
 #include "mode/logicanalyzer.h"
 
 // command configuration
@@ -81,6 +82,7 @@ const struct _command_struct commands[]=
     {"tutorial", true, &tutorial_handler, 0x00},
     {"script", true, &script_handler, 0x00},  
     {"button", true, &button_scr_handler, 0x00},
+    {"bb_test", true, &bigbuff_test_handler, 0x00},
 };
 
 const uint32_t commands_count=count_of(commands);

--- a/commands/global/bigbuffer_test.c
+++ b/commands/global/bigbuffer_test.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "pico/stdlib.h"
+#include "pirate.h"
+#include "bigbuffer_test.h"
+#include "pirate/mem.h"
+
+
+
+
+#define X_FN_ENTRY()     printf("bb_test @ %3d: >>>>> %s\n", __LINE__, __func__)
+#define X_FN_EXIT()      printf("bb_test @ %3d: <<<<< %s\n", __LINE__, __func__)
+#define X_DBGP(fmt, ...) printf("bb_test @ %3d: " fmt, __LINE__, ##__VA_ARGS__)
+
+static bool ensure_no_allocations(void)
+{
+    X_FN_ENTRY();
+
+    big_buffer_general_state_t state = {0};
+    bool result = BigBuffer_DebugGetStatistics(&state);
+    if (result) {
+        if (state.temp_allocations_count != 0) {
+            X_DBGP("ERROR: Temp allocations not freed\n");
+            result = false;
+        }
+        if (state.long_lived_allocations_count != 0) {
+            X_DBGP("ERROR: Long-lived allocations not freed\n");
+            result = false;
+        }
+    }
+
+    X_FN_EXIT();
+}
+
+static bool x_dispatch(void)
+{
+    X_FN_ENTRY();
+
+    X_FN_EXIT();
+}
+
+
+
+
+void bigbuff_test_handler(command_result_t *res)
+{
+    X_FN_ENTRY();
+
+    // This function is called when the user types the command "bigbuff_test"
+    // It is a simple test function that exercises the big buffer allocation
+    // and free functions, specifically focusing on ensuring edge cases are
+    // handled.
+    memset(res, 0, sizeof(command_result_t));
+    res->success = true;
+    res->error   = false;
+
+    x_dispatch();
+
+    X_FN_EXIT();
+}
+
+

--- a/commands/global/bigbuffer_test.c
+++ b/commands/global/bigbuffer_test.c
@@ -22,14 +22,20 @@ typedef struct _bool_test_t {
 #define X_BOOL_TEST(fn) { .test_fn = fn, .fn_name = #fn }
 
 
-#define X_FN_ENTRY()        printf("bb_test @ %3d: >>>>> %s\n", __LINE__, __func__)
-#define X_FN_EXIT()         printf("bb_test @ %3d: <<<<< %s\n", __LINE__, __func__)
-#define X_DBGP(fmt, ...)    printf("bb_test @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
-#define X_SUCCESS(fmt, ...) printf("bb_test @ %3d: SUCCESS " fmt "\n", __LINE__, ##__VA_ARGS__)
-#define X_FAILURE(fmt, ...) printf("bb_test @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__)
+#define X_FN_ENTRY()        printf("bb_tst @ %3d: >>>>> %s\n", __LINE__, __func__)
+#define X_FN_EXIT()         printf("bb_tst @ %3d: <<<<< %s\n", __LINE__, __func__)
+#define X_DBGP(fmt, ...)    printf("bb_tst @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+#define X_SUCCESS(fmt, ...) printf("bb_tst @ %3d: SUCCESS " fmt "\n", __LINE__, ##__VA_ARGS__)
+
+#define X_FAILURE(fmt, ...)                                                   \
+    do {                                                                      \
+        printf("bb_tst @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+        BigBuffer_DebugDumpCurrentState(true); printf("\n");                  \
+    } while (0);
 
 
-
+#define X_MAXIMUM_ALLOCATION_COUNT (32u)
+#define X_MAXIMUM_LONG_LIVED_BYTE_COUNT (8u * 1024u)
 
 
 static bool _verify_no_allocations(void) {
@@ -103,7 +109,71 @@ static bool _test_temporary_allocations_1(bool reversed_free_order) {
     return success;
 }
 
-static bool _test_longlived_allocations_1(bool reversed_free_order) {
+
+static bool _test_longlived_allocations_iterations_impl(bool reversed_free_order, allocation_iteration_t iter) {
+
+    bool verbose = iter.alloc == 0x100u && iter.align == 0x200u;
+    bool success = true;
+
+    const size_t total_size = BigBuffer_GetAvailableLongLivedMemory(iter.align);
+    void * allocations[X_MAXIMUM_ALLOCATION_COUNT] = {NULL};
+
+
+    success = _verify_no_allocations();
+    if (!success) {
+        X_FAILURE("(%zd, %zd, %zd) _verify_no_allocations() failed\n", iter.alloc, iter.align, iter.count);
+    } else if (total_size != X_MAXIMUM_LONG_LIVED_BYTE_COUNT) {
+        X_FAILURE("(%zd, %zd) expected 8k of long-lived memory available, got %zd\n", iter.alloc, iter.align, total_size);
+        success = false;
+    } else {
+
+        if (verbose) {
+            X_DBGP("**********************************************************");
+            X_DBGP("TEST CASE: %zd bytes, %zd alignment, %zd count", iter.alloc, iter.align, iter.count);
+        }
+
+        // Hard-coded that total available long-lived memory is 8k ... checked above
+        for (size_t i = 0; success && (i < iter.count); ++i) {
+            if (verbose) {
+                printf("\n");
+                BigBuffer_DebugDumpCurrentState(true);
+            }
+            void * allocation = BigBuffer_AllocateLongLived(iter.alloc, iter.align, BP_BIG_BUFFER_OWNER_SELFTEST);
+            if (allocation == NULL) {
+                X_FAILURE("(%zd, %zd) Unable to allocate long-lived buffer %zd\n", iter.alloc, iter.align, i);
+                success = false;
+                break; // out of allocation for loop `i` ...
+            }
+            allocations[i] = allocation;
+        }
+    }
+
+    // All available memory (for given alignment) should have been allocated.
+    // Verify this...
+    if (success) {
+        size_t remaining_available = BigBuffer_GetAvailableLongLivedMemory(iter.align);
+        if (remaining_available != 0) {
+            X_FAILURE("(%zd, %zd, %zd) Expected no additional allocations available, got %zd\n", iter.alloc, iter.align, iter.count, remaining_available);
+            success = false;
+        }
+    }
+
+    // Free all allocations
+    for (size_t i = 0; i < count_of(allocations); ++i) {
+        size_t idx = reversed_free_order ? (count_of(allocations) - 1u - i) : i;
+        BigBuffer_FreeLongLived(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
+    }
+
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("(%zd, %zd, %zd) _verify_no_allocations() failed\n", iter.alloc, iter.align, iter.count);
+        }
+    }
+    return success;
+}
+
+static bool _test_longlived_allocations_iterations(bool reversed_free_order) {
 
     X_FN_ENTRY();
     bool success = true;
@@ -129,68 +199,16 @@ static bool _test_longlived_allocations_1(bool reversed_free_order) {
         allocation_iteration_t iter = iterations[j];
         assert(iter.count <= count_of(allocations));
 
-        for (; iter.align <= (128u*1024); iter.count >> 1, iter.align << 1) {
+        for (; iter.align <= (32u*1024); iter.align <<= 1) {
+            if (iter.align > iter.alloc) {
+                iter.count >>= 1;
+            }
             if (iter.count == 0) {
-                // special case for over-8k allocation alignment
+                // special case for when exceed available memory space
                 // because the long-lived allocations can be up to 128k aligned (even if only 8k size)
                 iter.count = 1;
             }
-
-            success = _verify_no_allocations();
-            if (!success) {
-                X_FAILURE("(%zd, %zd) _verify_no_allocations() failed\n", iter.alloc, iter.align);
-                break; // out of iteration adjustment loop
-            }
-
-            const size_t total_size = BigBuffer_GetAvailableLongLivedMemory(iter.align);
-            if (total_size != 8192u) {
-                X_FAILURE("(%zd, %zd) expected 8k of long-lived memory available, got %zd\n", iter.alloc, iter.align, total_size);
-                BigBuffer_DebugDumpCurrentState(true); printf("\n");
-                success = false;
-                break; // out of iteration adjustment loop
-            }
-
-            // clear allocations array
-            memset(allocations, 0, sizeof(allocations));
-
-            // Hard-coded that total available long-lived memory is 8k ... checked above
-            for (size_t i = 0; success && (i < iter.count); ++i) {
-
-                void * allocation = BigBuffer_AllocateLongLived(iter.alloc, iter.align, BP_BIG_BUFFER_OWNER_SELFTEST);
-                if (allocation == NULL) {
-                    X_FAILURE("(%zd, %zd) Unable to allocate long-lived buffer %zd\n", iter.alloc, iter.align, i);
-                    BigBuffer_DebugDumpCurrentState(true); printf("\n");
-                    success = false;
-                    break; // out of allocation for loop `i` ...
-                }
-                allocations[i] = allocation;
-            }
-
-            // All available memory (for given alignment) should have been allocated.
-            // Verify this...
-            if (success) {
-                size_t remaining_available = BigBuffer_GetAvailableLongLivedMemory(iter.align);
-                if (remaining_available != 0) {
-                    X_FAILURE("(%zd, %zd) Expected no additional allocations available, got %zd\n", iter.alloc, iter.align, remaining_available);
-                    BigBuffer_DebugDumpCurrentState(true); printf("\n");
-                    success = false;
-                }
-            }
-
-            // free all allocations so can test the next iteration variation
-            for (size_t i = 0; i < count_of(allocations); ++i) {
-                int idx = reversed_free_order ? (count_of(allocations) - 1 - j) : j;
-                BigBuffer_FreeLongLived(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
-            }
-
-            if (success) {
-                success = _verify_no_allocations();
-                if (!success) {
-                    X_FAILURE("(%zd, %zd) _verify_no_allocations() failed\n", iter.alloc, iter.align);
-                    break; // out of iteration adjustment loop
-                }
-            }
-
+            success = _test_longlived_allocations_iterations_impl(reversed_free_order, iter);
             // if successful, print a one-line "SUCCESS" message ... helps anchor last successful test in output
             if (success) {
                 X_SUCCESS("LL_Alloc1(%s %4zd @ %6zd alignment, %zd count\n", reversed_free_order ? "true): " : "false):" , iter.alloc, iter.align, iter.count);
@@ -238,7 +256,7 @@ static bool _test_longlived_allocations_3(bool reversed_free_order) {
 
 static const bool_test_t bool_tests[] = {
     X_BOOL_TEST(_test_temporary_allocations_1),
-    X_BOOL_TEST(_test_longlived_allocations_1),
+    X_BOOL_TEST(_test_longlived_allocations_iterations),
 };
 
 static bool _dispatch(void)

--- a/commands/global/bigbuffer_test.c
+++ b/commands/global/bigbuffer_test.c
@@ -40,22 +40,23 @@ static bool _test_temporary_allocations_1(bool reversed_free_order) {
 
     if (success) {
         success = _ensure_no_allocations();
-        BigBuffer_DebugDumpCurrentState(true);
     }
 
-    // up to 32 allocations, and 138k available to allocate
+    // up to 32 allocations, and 136k available to allocate
     // 32 * 4k = 128k in "spacer" allocations
-    // This leaves 10k for the other 32 allocations
-    // 10k / 32 = 320 bytes per allocation
+    // This leaves 8k for the other 32 allocations
+    // 8k / 32 = 256 bytes per allocation
     for (int i = 0; success && (i < 32); ++i) {
+        BigBuffer_DebugDumpCurrentState(false); printf("\n");
         void* spacer = BigBuffer_AllocateTemporary(4096, 1, BP_BIG_BUFFER_OWNER_SELFTEST);
         if (spacer == NULL) {
-            X_DBGP("ERROR: Failed to allocate temporary buffer idx %d / 32\n", i);
+            X_DBGP("ERROR: Failed to allocate spacer buffer idx %d / 32\n", i);
             BigBuffer_DebugDumpCurrentState(true); printf("\n");
             success = false;
             break; // out of for loop ...
         }
         allocations[i] = BigBuffer_AllocateTemporary(320, 1, BP_BIG_BUFFER_OWNER_SELFTEST);
+        // allocations[i] = BigBuffer_AllocateTemporary(256, 1, BP_BIG_BUFFER_OWNER_SELFTEST);
         if (allocations[i] == NULL) {
             X_DBGP("ERROR: Failed to allocate temporary buffer idx %d / 32\n", i);
             BigBuffer_DebugDumpCurrentState(true); printf("\n");
@@ -63,14 +64,15 @@ static bool _test_temporary_allocations_1(bool reversed_free_order) {
             break; // out of for loop ...
         }
         BigBuffer_FreeTemporary(spacer, BP_BIG_BUFFER_OWNER_SELFTEST);
-        BigBuffer_DebugDumpCurrentState(true); printf("\n");
     }
+    BigBuffer_DebugDumpCurrentState(true);
+
     for (int j = 0; j < 32; ++j) {
         int idx = reversed_free_order ? (31 - j) : j;
         BigBuffer_FreeTemporary(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
     }
-
     BigBuffer_DebugDumpCurrentState(true); printf("\n");
+
     if (success) {
         success = _ensure_no_allocations();
     }

--- a/commands/global/bigbuffer_test.h
+++ b/commands/global/bigbuffer_test.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "../../opt_args.h"
+
+void bigbuff_test_handler(command_result_t *res);

--- a/commands/global/dummy.c
+++ b/commands/global/dummy.c
@@ -54,7 +54,7 @@ static const struct ui_help_options options[]=
     {0,"-f",T_HELP_DUMMY_FILE_FLAG}, //-f flag, a file name string    
 };
 
-void dummy_handler(struct command_result *res)
+void dummy_handler(command_result_t *res)
 {
     uint32_t value; //somewhere to keep an integer value
     char file[13]; //somewhere to keep a string value (8.3 filename + 0x00 = 13 characters max)
@@ -248,10 +248,10 @@ void dummy_handler(struct command_result *res)
         printf("Hint: use the rm %s to delete\r\n", file);
     }
 
-    //bonus: you might notice we are handed a struct of type command_result from the command parser
+    //bonus: you might notice we are handed a struct of type command_result_t from the command parser
     // this is a way to return errors and other (future) data
     //I'm not sure it actually does anything right now, but it's there for future use
-    //command_result.error=true; //set the error flag
+    //command_result_t.error=true; //set the error flag
 
     //to set an error back to the command line parser and indicate an error for chaining purposes (; || &&)
     //system_config.error=true; //set the error flag

--- a/commands/global/dummy.h
+++ b/commands/global/dummy.h
@@ -1,1 +1,1 @@
-void dummy_handler(struct command_result *res);
+void dummy_handler(command_result_t *res);

--- a/commands/global/i_info.c
+++ b/commands/global/i_info.c
@@ -90,9 +90,10 @@ void i_info_handler(struct command_result *res){
 	//config file loaded
 	printf("\r\n%s%s:%s %s\r\n", ui_term_color_info(), t[T_CONFIG_FILE], ui_term_color_reset(), system_config.config_loaded_from_file?t[T_LOADED]:t[T_NOT_DETECTED]);
 
-	if(system_config.big_buffer_owner!=BP_BIG_BUFFER_NONE){
-		printf("%sBig buffer allocated to:%s #%d\r\n", ui_term_color_info(), ui_term_color_reset(), system_config.big_buffer_owner);
-	}
+	// TODO: Expose API for statistics on BigBuffer usage
+	// if(system_config.big_buffer_owner!=BP_BIG_BUFFER_OWNER_NONE){
+	// 	printf("%sBig buffer allocated to:%s #%d\r\n", ui_term_color_info(), ui_term_color_reset(), system_config.big_buffer_owner);
+	// }
 
 
 	// Installed modes

--- a/display/scope.c
+++ b/display/scope.c
@@ -235,7 +235,7 @@ uint32_t scope_setup(void)
 {
 	uint8_t *x;
 	
-	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_SCOPE);
+	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_OWNER_SCOPE);
 	if (!x) {
 		printf("couldn't allocate %d bytes, scope mode broken\r\n", MALLOC_SIZE);
 		return 0;
@@ -249,7 +249,7 @@ uint32_t scope_setup_exc(void)
 {
 	uint8_t *x;
 	
-	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_SCOPE);
+	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_OWNER_SCOPE);
 	if (!x)
 		return 0;
 	fb = x;

--- a/displays.h
+++ b/displays.h
@@ -21,8 +21,8 @@ typedef struct _display
 	void (*display_settings)(void);		// display settings 
 	void (*display_help)(void);			// display protocol specific help
 	char display_name[10];				// friendly name (promptname)
-	uint32_t (*display_command)(struct command_result *result); // per mode command parser - ignored if 0
-	void (*display_lcd_update)(uint32_t flags);	// replacement for ui_lcd_update if non-0
+	uint32_t (*display_command)(struct command_result *result); // per mode command parser - ignored if null
+	void (*display_lcd_update)(uint32_t flags);	// replacement for ui_lcd_update if non-null
 } _display;
 
 extern struct _display displays[MAXDISPLAY];

--- a/opt_args.h
+++ b/opt_args.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define MAX_COMMAND_LENGTH 9
 
 typedef struct command_result {
@@ -8,7 +10,7 @@ typedef struct command_result {
 	bool default_value;
 	bool error;
     bool help_flag;
-} command_result;
+} command_result_t;
 
 struct _command_struct
 {

--- a/pirate.c
+++ b/pirate.c
@@ -14,6 +14,7 @@
 #include "pirate/rgb.h"
 #include "pirate/shift.h"
 #include "pirate/bio.h"
+#include "pirate/mem.h"
 #include "pirate/button.h"
 #include "pirate/storage.h"
 #include "pirate/lcd.h"
@@ -62,14 +63,18 @@ int64_t ui_term_screensaver_enable(alarm_id_t id, void *user_data){
 
 int main(){
     char c;
-    
-    uint8_t bp_rev=mcu_detect_revision();
+
+    // init big buffer memory pool
+    BigBuffer_Initialize();
+
+    uint8_t bp_rev = mcu_detect_revision();
+
 
     //init buffered IO pins
     bio_init(); 
 
     // setup SPI0 for on board peripherals
-    uint baud=spi_init(BP_SPI_PORT, BP_SPI_HIGH_SPEED);
+    uint baud = spi_init(BP_SPI_PORT, BP_SPI_HIGH_SPEED);
     gpio_set_function(BP_SPI_CDI, GPIO_FUNC_SPI);
     gpio_set_function(BP_SPI_CLK, GPIO_FUNC_SPI);
     gpio_set_function(BP_SPI_CDO, GPIO_FUNC_SPI);
@@ -182,7 +187,7 @@ int main(){
     //test for PCB revision
     //must be done after shift register setup
     // if firmware mismatch, turn all LEDs red
-    if(bp_rev!=BP5_REV){ //
+    if (bp_rev != BP5_REV) {
         //printf("Error: PCB revision does not match firmware. Expected %d, found %d.\r\n", BP5_REV, mcu_detect_revision());
         rgb_irq_enable(false);
         while(true){ 

--- a/pirate.c
+++ b/pirate.c
@@ -52,8 +52,6 @@
 
 static mutex_t spi_mutex;
 
-uint8_t reserve_for_future_mode_specific_allocations[10 * 1024] = {0};
-
 void core1_entry(void);
 
 int64_t ui_term_screensaver_enable(alarm_id_t id, void *user_data){
@@ -66,10 +64,6 @@ int main(){
     char c;
     
     uint8_t bp_rev=mcu_detect_revision();
-
-    reserve_for_future_mode_specific_allocations[1] = 99;
-    reserve_for_future_mode_specific_allocations[2] = reserve_for_future_mode_specific_allocations[1];
-    reserve_for_future_mode_specific_allocations[1] = reserve_for_future_mode_specific_allocations[2];
 
     //init buffered IO pins
     bio_init(); 

--- a/pirate.h
+++ b/pirate.h
@@ -51,8 +51,6 @@
 
 #define OPTARG_STRING_LEN 20
 
-#define BIG_BUFFER_SIZE (128 * 1024)
-
 // include platform
 #ifndef BP5_REV
     #error "No /platform/ file included in pirate.h"

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -37,8 +37,11 @@ static uint8_t s_BigBufMemory[BIG_BUFFER_SIZE] __attribute__((aligned(BIG_BUFFER
 static uint8_t s_ReservedForAllocationTracking[1024u];
 static big_buffer_state_t s_State = {0};
 
+static void SortAllocationTrackingData(void) {
+    // Sort the allocation tracking data by allocated address.
+    return;
+}
 
-// TODO: track allocations as well....
 void DumpGeneralStateHeader(void) {
     return;
 }
@@ -54,6 +57,7 @@ void DumpAllocationInstance(big_buffer_allocation_instance_t* alloc_state) { // 
 void DumpFullMemoryState(void) {
     DumpGeneralStateHeader();
     DumpGeneralState(&s_State.general);
+    SortAllocationTrackingData();
     DumpAllocationInstanceHeader();
     for (size_t j = 0; j < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++j) {
         if (s_State.allocation[j].result != 0u) {
@@ -89,11 +93,14 @@ static bool        s_BigBufInitialized         = false;
 
 /* Big Buffer Memory Layout:
    (high)  __BIG_BUFFER_END__    -> Pointer just past the end of Big Buffer
-   (... )  ...                   -> Long-lived allocations, if any
-   (... )  s_BigBufHighWaterMark -> Pointer just past the last unallocated memory, or equal to low water mark if all memory allocated
-   (... )  ...                   -> Unallocated memory ... could be allocated from top (small) or bottom (aligned)
+   (... )  ...                   -> Long-lived allocations (if any)
+   (... )  s_BigBufHighWaterMark -> Pointer just past the last unallocated memory,
+                                    or equal to low water mark if all memory allocated
+   (... )  ...                   -> Unallocated memory ...
+                                    Long-lived allocations grow from top
+                                    while temporary allocations grow from bottom
    (... )  s_BigBufLowWaterMark  -> Pointer to the first unused byte of memory
-   (... )  ...                   -> Large (>1k), or high-alignment requirement (1k+) allocated memory
+   (... )  ...                   -> Temporary memory allocations
    (low )  __BIG_BUFFER_START__  -> Guaranteed to be 32k aligned
 */
 

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -320,6 +320,10 @@ void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment,
         printf("BB_AllocTemp: too many allocations\n");
         return NULL;
     }
+    if (countOfBytes == 0) {
+        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
+        return NULL;
+    }
 
     // exit early if the request number of bytes is larger than what's left
     // N.B. It might still not fit due to alignment requirements ... checked later.
@@ -382,6 +386,10 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
         printf("BB_AllocLongLived: too many allocations\n");
         return NULL;
     }
+    if (countOfBytes == 0) {
+        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
+        return NULL;
+    }
 
     // limit lower bound of the allocation
     uintptr_t lower_limit = s_State.long_lived_limit;
@@ -431,9 +439,8 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
         assert(false); // BigBuffer_Initialize() must be called before attempting to free memory
         return NULL;
     }
-    if (p == 0u) {
+    if (p == 0u) { // permit the free'ing of a nullptr ...
         printf("BB_Free: NULL pointer\n");
-        assert(false); // NULL pointers are not valid
         return NULL;
     }
     if (p < s_State.buffer) {

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -6,35 +6,172 @@
  */
 // Modified by Ian Lesnet 18 Dec 2023 for Bus Pirate 5
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // memset()
+#include <stdint.h> // uint32_t, uintptr_t, ...
 #include "pico/stdlib.h"
 #include "pirate.h"
 #include "pirate/mem.h"
-#include <stdlib.h>
 #include "system_config.h"
 
-// private variables
-static uint8_t mem_buffer[BIG_BUFFER_SIZE] __attribute__((aligned(32768))); // 128k ... this is 50% of the total RAM!
-static bool allocated = false;
+// 138k ... 128k contiguous / 32k aligned required by current LA due to DMA engine configuration
+#define BIG_BUFFER_SIZE (138 * 1024) 
+static uint8_t s_BigBufMemory[BIG_BUFFER_SIZE] __attribute__((aligned(32768))); 
 
-// public function definitions
-uint8_t *mem_alloc(size_t size, uint32_t owner)
-{
-    if (!allocated && size <= sizeof(mem_buffer)) {
-        allocated = true;
-        system_config.big_buffer_owner=owner;
-        return mem_buffer;
+
+
+static uint8_t * s_BigBuf                = NULL; // cannot use until initialized
+static size_t    s_BigBufSize            = 0u;    // cannot use until initialized
+static uint8_t * s_BigBufHighWaterMark   = NULL; // cannot use until initialized
+static uint8_t * s_BigBufLowWaterMark    = NULL; // cannot use until initialized
+static size_t    s_BigBufAllocationCount = 0u;
+
+/* Big Buffer Memory Layout:
+   (high)  __BIG_BUFFER_END__    -> Pointer just past the end of Big Buffer
+   (... )  ...                   -> Allocated memory, if any
+   (... )  s_BigBufHighWaterMark -> Pointer just past the last free memory
+   (... )  ...                   -> Unused memory ... could be allocated from top (small) or bottom (aligned)
+   (... )  s_BigBufLowWaterMark  -> Pointer to the first unused byte of memory
+   (... )  ...                   -> Large (>1k), or high-alignment requirement (1k+) allocated memory
+   (low )  __BIG_BUFFER_START__  -> Guaranteed to be 32k aligned
+*/
+
+void BigBuffer_Initialize(void) {
+    if (s_BigBufAllocationCount != 0u) {
+        assert(false); // prior allocation is still outstanding?
     }
-    else 
-    {
-        printf("Error: the big buffer is already allocated to #%d", system_config.big_buffer_owner);
+
+    s_BigBuf                = (uint8_t *)s_BigBufMemory;
+    s_BigBufSize            = count_of(s_BigBufMemory);
+    s_BigBufHighWaterMark   = (uint8_t *)s_BigBufMemory + s_BigBufSize;
+    s_BigBufLowWaterMark    = (uint8_t *)s_BigBufMemory;
+    s_BigBufAllocationCount = 0u;
+
+    memset(s_BigBufMemory, 0xAA, s_BigBufSize);
+}
+void BigBuffer_Finalize(void) {
+    if (s_BigBufAllocationCount != 0u) {
+        assert(false); // prior allocation is still outstanding?
+    }
+    // clear all the pointers to prevent accidental use after finalization
+    s_BigBuf                = NULL;
+    s_BigBufSize            = 0;
+    s_BigBufHighWaterMark   = NULL;
+    s_BigBufLowWaterMark    = NULL;
+    s_BigBufAllocationCount = 0;
+}
+
+/// @brief Allocates a block of memory from the Big Buffer
+/// @param elementCount Number of elements to be allocated
+/// @param elementSize Size of each element (e.g., sizeof(T))
+/// @param alignment Alignment required for the allocation (e.g., _Alignof(T))
+/// @param owner_tag A debugging helper ... allocations can be tracked by owner
+void* BigBuffer_calloc(size_t elementCount, size_t elementSize, size_t alignment, uint32_t owner_tag) {
+    if (s_BigBuf == NULL) {
+        assert(false); // BigBuffer_Initialize() must be called before BigBuffer_calloc()
         return NULL;
+    }
+    if ((alignment & (alignment - 1)) != 0u) {
+        assert(false); // alignment must be a power of 2
+        return NULL;
+    }
+    if (elementCount == 0 || elementSize == 0) {
+        assert(false); // calloc is undefined for zero elements or zero size
+        return NULL;
+    }
+    if (alignment == 0) {
+        alignment = 1; // fixup common API error
+    }
+    if (elementCount > (SIZE_MAX / elementSize)) {
+        // calculating total size would overflow
+        return NULL;
+    }
+    size_t totalRequestedBytes = elementCount * elementSize;
+    // exit early if the request number of bytes is larger than what's left
+    // Note: it might still not fit due to alignment requirements ... checked later.
+    if (totalRequestedBytes > (size_t)(s_BigBufHighWaterMark - s_BigBufLowWaterMark)) {
+        return NULL;
+    }
+
+    // Are we allocating from the bottom (large alignment) or from the top (small alignment)?
+    bool allocateFromBottom = (alignment >= 1024) || (totalRequestedBytes >= 1024);
+    uint8_t * result =
+        allocateFromBottom ?
+        s_BigBufLowWaterMark :
+        s_BigBufHighWaterMark - totalRequestedBytes;
+
+    // If result pointer is NOT already aligned, adjust it.
+    size_t alignmentMask = alignment - 1;
+    if (((size_t)result & alignmentMask) != 0) {
+        if (allocateFromBottom) {
+            // Allocation must be moved to larger address
+            result = (uint8_t*)( ((size_t)result + alignment) & ~alignmentMask );
+            if ((size_t)s_BigBufHighWaterMark - (size_t)result < totalRequestedBytes) {
+                // insufficient space to allocate, due to alignment requirement
+                return NULL;
+            }
+        } else {
+            // Allocation must be moved to smaller address
+            result = (uint8_t*)( (size_t)result & ~alignmentMask );
+            if (result < s_BigBufLowWaterMark) {
+                // insufficient space to allocate, due to alignment requirement
+                return NULL;
+            }
+        }
+    }
+
+    // result now points to a valid, aligned, unallocated memory block of appropriate size.
+    // update high/low water marks, and return the buffer.
+    if (allocateFromBottom) {
+        s_BigBufLowWaterMark = result + totalRequestedBytes;
+    } else {
+        s_BigBufHighWaterMark = result;
+    }
+
+    // finally, zero the memory before returning it.
+    memset(result, 0, totalRequestedBytes);
+    ++s_BigBufAllocationCount;
+    return result;
+}
+
+/// @brief Frees a block of memory that was allocated from the Big Buffer
+/// @param ptr Pointer to the memory block to be free'd.
+/// @note At least initially, the memory is not returned for re-use.
+/// @todo Allow the most-recent allocated memory to actually be free'd.
+///       This will likely require a more complex allocation scheme:
+///       Maybe just keep two arrays of what was allocated?
+///       Only allow the most recent large and most recent small allocations
+///       to be free'd (which then makes a new prior allocation able to be free'd)?
+///       Thus, so long as order of free() is exact inverse of alloc(), this
+///       would allow reverting to initial state?
+void BigBuffer_free(void* ptr, uint32_t owner_tag) {
+    // at a minimum, assert that the pointer is somewhere within the Big Buffer space
+    // NOTE: Technically, comparisons of pointers is undefined behavior in C.
+    if ((uintptr_t)ptr < (uintptr_t)s_BigBuf) {
+        assert(false); // ptr is before the start of the Big Buffer
+    }
+    else if ((uintptr_t)ptr >= (uintptr_t)s_BigBufHighWaterMark) {
+        assert(false); // ptr is after the end of the Big Buffer
+    }
+    // TODO: when tracking allocations, validate owner_tag matches (or parameter is zero)
+    // else if (owner_tag shows a mismatch)
+    // TODO: when tracking allocations, validate that ptr was allocated by BigBuffer_calloc()
+    // else if (not a pointer allocated by BigBuffer_calloc())
+    else {
+        --s_BigBufAllocationCount;
     }
 }
 
+// TODO: replace the below API with BigBuffer_xxxx() API.
+uint8_t *mem_alloc(size_t size, uint32_t owner)
+{
+    return BigBuffer_calloc(size, 1u, 1u, owner);
+}
 void mem_free(uint8_t *ptr)
 {
-    if (ptr == mem_buffer) {
-        allocated = false;
-        system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
-    }
+    BigBuffer_free(ptr, 0);
+    // mem_alloc()/mem_free() only allowed a single allocation.
+    // To match existing behavior, reset the memory pool when
+    // any allocation is free()'d by this API.
+    BigBuffer_Initialize();
 }

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -28,7 +28,22 @@
 #include "pirate/mem.h"
 #include "system_config.h"
 
-#define DEBUG_BIGBUFFER
+
+#define DEBUG_BB_MASK_NONE       (0x00u)
+#define DEBUG_BB_MASK_FATAL      (0x01u) // fatal errors, such as memory corruption; Focus is on incorrect use of API
+#define DEBUG_BB_MASK_INVARIANTS (0x02u) // internal inconsistency checks failed; Also fatal, but focus is internal coding errors
+#define DEBUG_BB_MASK_FAILURE    (0x04u) // non-fatal API edge cases that are non-success paths (e.g., allocation request when hit limit of allocations, etc.)
+#define DEBUG_BB_MASK_VERBOSE    (0x08u) // verbose messages
+#define DEBUG_BB_MASK_DUMP       (0x10u) // for APIs that dump internal state
+#define DEBUG_BB_MASK_API_ENTRY  (0x80u)
+#define DEBUG_BB_MASK_API_EXIT   (0x40u)
+#define DEBUG_BIGBUFFER ( DEBUG_BB_MASK_FATAL | DEBUG_BB_MASK_INVARIANTS | DEBUG_BB_MASK_FAILURE | DEBUG_BB_MASK_DUMP )
+//#define DEBUG_BIGBUFFER DEBUG_BB_MASK_NONE
+
+
+
+// #define DEBUG_BIGBUFFER_API_ENTRY // define to enable API entry messages
+// #define DEBUG_BIGBUFFER_API_EXIT  // define to enable API exit messages
 
 // 136k ... 128k contiguous / 32k aligned required by current LA due to DMA engine configuration
 // Plus an extra 8k that are generally safe for long-term allocations
@@ -39,46 +54,62 @@
 #define BIG_BUFFER_ALIGNMENT_KB        ( 32u)
 #define BIG_BUFFER_SIZE ((BIG_BUFFER_TEMPORARY_BUFFER_KB + BIG_BUFFER_LONGLIVED_BUFFER_KB) * 1024u)
 
-// TODO: define DEBUG_BIGBUFFER to bitmask, to enable specific types of output at compilation
-#if defined(DEBUG_BIGBUFFER)
-    #define X_FN_ENTRY(fmt, ...)
-    #define X_FN_EXIT(fmt, ...)
+#if 1 // debug output macros
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_API_ENTRY)
+        #define X_API_ENTRY(fmt, ...) printf("BB @ %3d: >>>>> %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_API_ENTRY(fmt, ...)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_API_EXIT)
+        #define X_API_EXIT(fmt, ...)  printf("BB @ %3d: <<<<< %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_API_EXIT(fmt, ...)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_FATAL)
+        #define X_FATAL(fmt, ...)                                               \
+            do {                                                                \
+                printf("BB @ %3d: *FATAL* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+                BigBuffer_DebugDumpCurrentState(true);                          \
+                assert(false);                                                  \
+            } while (1)
+    #else
+        #define X_FATAL(fmt, ...)     assert(false)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_INVARIANTS)
 
-    // #define X_FN_ENTRY(fmt, ...) printf("BB @ %3d: >>>>> %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
-    // #define X_FN_EXIT(fmt, ...)  printf("BB @ %3d: <<<<< %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
-    #define X_DBGP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
-    #define X_SUCCESS(fmt, ...)  printf("BB @ %3d: SUCCESS " fmt "\n", __LINE__, ##__VA_ARGS__)
-    #define X_FAILURE(fmt, ...)  printf("BB @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__)
+        #define X_CHECK_INVARIANTS()                                                                                         \
+            do {                                                                                                             \
+                big_buffer_invariant_error_flags_t error_flags = BigBuffer_InvariantsFailed();                               \
+                static_assert(BIG_BUFFER_INVARIANT_NONE == 0);                                                               \
+                while (error_flags != 0) {                                                                                   \
+                    printf("BB @ %3d: *FATAL* Invariant failed from %s:%s:%d\n", error_flags, __FILE__, __func__, __LINE__); \
+                    BigBuffer_DebugDumpCurrentState(true);                                                                   \
+                    assert(false);                                                                                           \
+                }                                                                                                            \
+            } while (0)
 
-    #define X_CHECK_INVARIANTS()                                                                                         \
-        do {                                                                                                             \
-            big_buffer_invariant_error_flags_t error_flags = BigBuffer_InvariantsFailed();                               \
-            static_assert(BIG_BUFFER_INVARIANT_NONE == 0);                                                               \
-            while (error_flags != 0) {                                                                                   \
-                printf("BB @ %3d: *FATAL* Invariant failed from %s:%s:%d\n", error_flags, __FILE__, __func__, __LINE__); \
-                BigBuffer_DebugDumpCurrentState(true);                                                                   \
-                assert(false);                                                                                           \
-            }                                                                                                            \
-        } while (0)
+    #else
+        #define X_CHECK_INVARIANTS()
+    #endif
 
-    #define X_FATAL(fmt, ...)                                               \
-        do {                                                                \
-            printf("BB @ %3d: *FATAL* " fmt "\n", __LINE__, ##__VA_ARGS__); \
-            BigBuffer_DebugDumpCurrentState(true);                          \
-            assert(false);                                                  \
-        } while (1)
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_FAILURE) // failure messages
+        #define X_FAILURE(fmt, ...)  printf("BB @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_FAILURE(fmt, ...)
+    #endif
 
-#else
-    #define X_FN_ENTRY(fmt, ...)
-    #define X_FN_EXIT(fmt, ...)
-    #define X_DBGP(fmt, ...)
-    #define X_SUCCESS(fmt, ...)
-    #define X_FAILURE(fmt, ...)
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_VERBOSE) // verbose messages
+        #define X_DBGP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_DBGP(fmt, ...)
+    #endif
 
-    #define X_CHECK_INVARIANTS()
-    #define X_FATAL(fmt, ...) assert(false)
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_DUMP) // dump messages
+        #define X_DUMP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_DUMP(fmt, ...)
+    #endif
 #endif
-
 
 typedef enum _big_buffer_invariant_error_flags {
     BIG_BUFFER_INVARIANT_NONE = 0,
@@ -202,14 +233,14 @@ static void SortAllocationTrackingData(void) {
 }
 
 static void DumpGeneralStateHeader(void) {
-    printf("\n");
-    printf("BB: Buffer*  | TotalSize | HighWater | LowWater | TmpCnt | LongCnt\n");
-    printf("    ---------|-----------|-----------|----------|--------|--------\n");
-    //intf("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. |   .xx. |    .xx.\n");
+    X_DUMP("");
+    X_DUMP("BB: Buffer*  | TotalSize | HighWater | LowWater | TmpCnt | LongCnt");
+    X_DUMP("    ---------|-----------|-----------|----------|--------|--------");
+    //DUMP("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. |   .xx. |    .xx.");
     return;
 }
 static void DumpGeneralState(const big_buffer_general_state_t * general_state) {
-    printf("BB: %08x |  %08x |  %08x | %08x |   %04x |    %04x\n",
+    X_DUMP("BB: %08x |  %08x |  %08x | %08x |   %04x |    %04x\n",
            general_state->buffer,
            general_state->total_size,
            general_state->high_watermark,
@@ -220,13 +251,13 @@ static void DumpGeneralState(const big_buffer_general_state_t * general_state) {
     return;
 }
 static void DumpAllocationInstanceHeader(void) {
-    printf("    ------------------------------------------------------\n");
-    printf("    Buffer*  |  Req_Size | Req_Align | OwnerTag | Type\n");
-    //intf("    ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
+    X_DUMP("    ------------------------------------------------------\n");
+    X_DUMP("    Buffer*  |  Req_Size | Req_Align | OwnerTag | Type\n");
+    //DUMP("    ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
     return;
 }
 static void DumpAllocationInstance(const big_buffer_allocation_instance_t* alloc_state) {
-    printf(
+    X_DUMP(
         "    %08x |  %08x |  %08x | %08x | %4s\n",
         alloc_state->result,
         alloc_state->requested_size,
@@ -245,20 +276,16 @@ static size_t FindUnusedTrackingEntryIndex(void) {
             return i;
         }
     }
-    do { // Should never reach this point ... loop infinitely, dumping state every 5 seconds
-        assert(false);
-        sleep_ms(5000);
-        BigBuffer_DebugDumpCurrentState(true);
-    } while (1);
+    X_FATAL("BB: call to find unused tracking entry index when all tracking data full\n");
 }
 
 
 
 void BigBuffer_Initialize(void) {
-    X_FN_ENTRY("");
+    X_API_ENTRY("");
 
     X_CHECK_INVARIANTS();
-    printf("BB: Init()\n");
+    X_DBGP("BB: Init()\n");
     if (s_BigBufInitialized) {
         assert(false); // should only call this once
     } else {
@@ -271,7 +298,7 @@ void BigBuffer_Initialize(void) {
         s_State.temp_allocations_count       = 0u;
         s_State.long_lived_allocations_count = 0u;
 
-        printf("BB: BB @ %p, size %zu, high %p, low %p\n",
+        X_DBGP("BB: BB @ %p, size %zu, high %p, low %p\n",
             s_State.buffer, s_State.total_size, s_State.high_watermark, s_State.low_watermark
             );
         memset(s_BigBufMemory, 0xAA, s_State.total_size);
@@ -282,11 +309,11 @@ void BigBuffer_Initialize(void) {
         s_BigBufInitialized = true;
     }
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("");
+    X_API_EXIT("");
 }
 
 void BigBuffer_VerifyNoTemporaryAllocations(void) {
-    X_FN_ENTRY("");
+    X_API_ENTRY("");
 
     if (!s_BigBufInitialized) {
         assert(false); // this is recoverable in this instance, but still violates the API contract
@@ -295,7 +322,7 @@ void BigBuffer_VerifyNoTemporaryAllocations(void) {
     X_CHECK_INVARIANTS();
     assert(s_State.temp_allocations_count == 0);
     // TODO: also verify no allocation tracking data lists a temporary allocation?
-    X_FN_EXIT("");
+    X_API_EXIT("");
 }
 // TODO: macro to call BigBuffer_InvariantsFailed() and assert if non-zero result
 //       this will simplify compiling this to nothing on release builds, and allow file / func / line numbers
@@ -340,7 +367,7 @@ static uintptr_t BigBuffer_DetermineNewHighWaterMark(void) {
 }
 
 void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
-    X_FN_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_API_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
     X_CHECK_INVARIANTS();
 
     uintptr_t result = 0;
@@ -351,21 +378,21 @@ void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment,
 
 
     if (!s_BigBufInitialized) {
-        printf("BB_AllocTemp: big buffer is not initialized?\n");
+        X_FATAL("BB_AllocTemp: big buffer is not initialized?\n");
         assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
     } else if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_AllocTemp: alignment (%#zx) must be a power of 2\n", requiredAlignment);
+        X_FATAL("BB_AllocTemp: alignment (%#zx) must be a power of 2\n", requiredAlignment);
         assert(false); // alignment must be a power of 2
     } else if (requiredAlignment > 128u * 1024u) {
-        printf("BB_AllocLongLived: required (%#zx) alignment too large\n", requiredAlignment);
+        X_FAILURE("BB_AllocTemp: required (%#zx) alignment too large\n", requiredAlignment);
     } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
-        printf("BB_AllocTemp: too many allocations\n");
+        X_FAILURE("BB_AllocTemp: too many allocations\n");
     } else if (countOfBytes == 0) {
-        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
+        X_DBGP("BB_AllocTemp: returning NULL for zero-byte allocation request");
     } else if (countOfBytes > s_State.high_watermark - s_State.low_watermark) {
         // exit early if the request number of bytes is larger than what's left
         // N.B. It might still not fit due to alignment requirements ... checked later.
-        printf("BB_AllocTemp: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - s_State.low_watermark);
+        X_DBGP("BB_AllocTemp: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - s_State.low_watermark);
     } else {
         // allocate temporary buffers from the lower end of the address space
         result = s_State.low_watermark;
@@ -373,7 +400,7 @@ void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment,
             // adjust the allocation so that it's properly aligned ... move result to larger address
             result = (result + requiredAlignment) & ~alignmentMask;
             if (s_State.high_watermark - result < countOfBytes) {
-                printf("BB_AllocTemp: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                X_DBGP("BB_AllocTemp: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
                 result = 0;
             }
         }
@@ -396,11 +423,11 @@ void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment,
     }
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
+    X_API_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
     return (void*)result;
 }
 void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
-    X_FN_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_API_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
     X_CHECK_INVARIANTS();
 
     uintptr_t result = 0;
@@ -415,28 +442,28 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
     }
 
     if (!s_BigBufInitialized) {
-        printf("BB_AllocLongLived: big buffer is not initialized?\n");
+        X_FATAL("BB_AllocLongLived: big buffer is not initialized?\n");
         assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
     } else if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_AllocLongLived: alignment (%#zx) must be a power of 2\n", requiredAlignment);
+        X_FATAL("BB_AllocLongLived: alignment (%#zx) must be a power of 2\n", requiredAlignment);
         assert(false); // alignment must be a power of 2
     } else if (requiredAlignment > 128u * 1024u) {
-        printf("BB_AllocLongLived: required alignment (%#zx) too large\n", requiredAlignment);
+        X_FAILURE("BB_AllocLongLived: required alignment (%#zx) too large\n", requiredAlignment);
     } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
-        printf("BB_AllocLongLived: too many allocations\n");
+        X_FAILURE("BB_AllocLongLived: too many allocations\n");
     } else if (countOfBytes == 0) {
-        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
+        X_DBGP("BB_AllocTemp: returning NULL for zero-byte allocation request");
     } else if (countOfBytes > s_State.high_watermark - lower_limit) {
         // exit early if the request number of bytes is larger than what's left
         // N.B. It might still not fit due to alignment requirements ... checked later.
-        printf("BB_AllocLongLived: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - lower_limit);
+        X_DBGP("BB_AllocLongLived: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - lower_limit);
     } else {
         result = s_State.high_watermark - countOfBytes;
         if ((result & alignmentMask) != 0u) {
             // adjust the allocation so that it's properly aligned ... move result to SMALLER address
             result = result & ~alignmentMask;
             if (lower_limit > result) {
-                printf("BB_AllocLongLived: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                X_DBGP("BB_AllocLongLived: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
                 result = 0;
             }
         }
@@ -458,29 +485,26 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
         memset((void*)result, 0, countOfBytes);
     }
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
+    X_API_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
     return (void*)result;
 }
 
 static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_buffer_owner_t owner) {
 
     if (!s_BigBufInitialized) {
-        printf("BB_Free: big buffer is not initialized?\n");
-        assert(false); // BigBuffer_Initialize() must be called before attempting to free memory
+        X_FATAL("BB_Free: big buffer is not initialized?\n");
         return NULL;
     }
     if (p == 0u) { // permit the free'ing of a nullptr ...
-        //printf("BB_Free: NULL pointer\n");
+        X_DBGP("BB_Free: NULL pointer\n");
         return NULL;
     }
     if (p < s_State.buffer) {
-        printf("BB_Free: pointer %#010zx is before the start of the Big Buffer %#010zx\n", p, s_State.buffer);
-        assert(false); // ptr is before the start of the Big Buffer
+        X_FATAL("BB_Free: pointer %#010zx is before the start of the Big Buffer %#010zx\n", p, s_State.buffer);
         return NULL;
     }
     if (p >= (s_State.total_size + s_State.buffer)) {
-        printf("BB_Free: pointer %#010zx is after the end of the Big Buffer %#010zx\n", p, s_State.buffer + s_State.total_size);
-        assert(false); // ptr is after the end of the Big Buffer
+        X_FATAL("BB_Free: pointer %#010zx is after the end of the Big Buffer %#010zx\n", p, s_State.buffer + s_State.total_size);
         return NULL;
     }
 
@@ -493,13 +517,11 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
         }
     }
     if (allocated == NULL) {
-        printf("BB_Free: pointer %#010zx was not allocated from BigBuffer (%#010zx .. %#010zx)\n", p, s_State.buffer, s_State.buffer + s_State.total_size);
-        assert(false); // ptr was not allocated by BigBuffer
+        X_FATAL("BB_Free: pointer %#010zx was not allocated from BigBuffer (%#010zx .. %#010zx)\n", p, s_State.buffer, s_State.buffer + s_State.total_size);
         return NULL;
     }
     if (allocated->owner_tag != owner) {
-        printf("BB_Free: owner tag mismatch: point %#010zx allocated by %d, free attempted by %d\n", p, allocated->owner_tag, owner);
-        assert(false); // owner tag mismatch
+        X_FATAL("BB_Free: owner tag mismatch: point %#010zx allocated by %d, free attempted by %d\n", p, allocated->owner_tag, owner);
         return NULL;
     }
 
@@ -507,14 +529,14 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
     return allocated;
 }
 void BigBuffer_FreeTemporary(const void * ptr, big_buffer_owner_t owner) {
-    X_FN_ENTRY("(%p, %d)", ptr, owner);
+    X_API_ENTRY("(%p, %d)", ptr, owner);
     X_CHECK_INVARIANTS();
 
     big_buffer_allocation_instance_t* allocation = BigBuffer_FreeCommon((uintptr_t)ptr, owner);
     if (allocation == NULL) {
         // already asserted in BigBuffer_FreeCommon(), or was free'ing NULL
     } else if (allocation->was_long_lived_allocation) {
-        printf("BB_FreeTemp: pointer %#010zx was allocated as long-lived allocation.\n");
+        X_FATAL("BB_FreeTemp: pointer %#010zx was allocated as long-lived allocation.\n");
         assert(false); // ptr was not a temporary allocation
     } else {
         // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
@@ -525,18 +547,18 @@ void BigBuffer_FreeTemporary(const void * ptr, big_buffer_owner_t owner) {
     }
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p, %d)", ptr, owner);
+    X_API_EXIT("(%p, %d)", ptr, owner);
     return;
 }
 void BigBuffer_FreeLongLived(const void * ptr, big_buffer_owner_t owner) {
-    X_FN_ENTRY("(%p, %d)", ptr, owner);
+    X_API_ENTRY("(%p, %d)", ptr, owner);
     X_CHECK_INVARIANTS();
 
     big_buffer_allocation_instance_t* allocation = BigBuffer_FreeCommon((uintptr_t)ptr, owner);
     if (allocation == NULL) {
         // already asserted in BigBuffer_FreeCommon(), or was free'ing NULL
     } else if (!allocation->was_long_lived_allocation) {
-        printf("BB_FreeLongLived: pointer %#010zx was allocated as temporary allocation.\n");
+        X_FATAL("BB_FreeLongLived: pointer %#010zx was allocated as temporary allocation.\n");
         assert(false); // ptr was not a long-lived allocation
     } else {
         // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
@@ -547,12 +569,12 @@ void BigBuffer_FreeLongLived(const void * ptr, big_buffer_owner_t owner) {
     }
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p, %d)", ptr, owner);
+    X_API_EXIT("(%p, %d)", ptr, owner);
     return;
 }
 
 void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out ) {
-    X_FN_ENTRY("(%p)", general_state_out);
+    X_API_ENTRY("(%p)", general_state_out);
     X_CHECK_INVARIANTS();
 
     static_assert(sizeof(s_State) == sizeof(big_buffer_general_state_t));
@@ -561,11 +583,11 @@ void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_ou
     memcpy(general_state_out, &s_State, sizeof(big_buffer_general_state_t));
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p)", general_state_out);
+    X_API_EXIT("(%p)", general_state_out);
     return;
 }
 void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out ) {
-    X_FN_ENTRY("(%p)", state_out);
+    X_API_ENTRY("(%p)", state_out);
     X_CHECK_INVARIANTS();
 
     static_assert(sizeof(s_State) == sizeof(state_out->general));
@@ -576,21 +598,21 @@ void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out ) {
     memcpy(&(state_out->allocation[0]), &(s_Allocation[0]), sizeof(state_out->allocation));
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p)", state_out);
+    X_API_EXIT("(%p)", state_out);
     return;
 }
 void BigBuffer_DebugDumpSummary(const big_buffer_general_state_t * state) {
-    X_FN_ENTRY("(%p)", state);
+    X_API_ENTRY("(%p)", state);
     X_CHECK_INVARIANTS();
 
     DumpGeneralStateHeader();
     DumpGeneralState(state);
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p)", state);
+    X_API_EXIT("(%p)", state);
 }
 void BigBuffer_DebugDumpState(const big_buffer_state_t * state) {
-    X_FN_ENTRY("(%p)", state);
+    X_API_ENTRY("(%p)", state);
     X_CHECK_INVARIANTS();
 
     DumpGeneralStateHeader();
@@ -602,10 +624,10 @@ void BigBuffer_DebugDumpState(const big_buffer_state_t * state) {
         }
     }
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%p)", state);
+    X_API_EXIT("(%p)", state);
 }
 void BigBuffer_DebugDumpCurrentState(bool verbose) {
-    X_FN_ENTRY("(%s)", verbose ? "true" : "false");
+    X_API_ENTRY("(%s)", verbose ? "true" : "false");
     X_CHECK_INVARIANTS();
 
     DumpGeneralStateHeader();
@@ -620,11 +642,11 @@ void BigBuffer_DebugDumpCurrentState(bool verbose) {
         }
     }
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%s)", verbose ? "true" : "false");
+    X_API_EXIT("(%s)", verbose ? "true" : "false");
 }
 
 size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment) {
-    X_FN_ENTRY("(%zu)", requiredAlignment);
+    X_API_ENTRY("(%zu)", requiredAlignment);
     X_CHECK_INVARIANTS();
 
     size_t result = 0u;
@@ -632,21 +654,20 @@ size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment) {
     uintptr_t aligned_lower = (s_State.low_watermark + (requiredAlignment - 1)) & (~alignmentMask);
 
     if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
-        assert(false); // alignment must be a power of 2
+        X_FATAL("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
     } else if (aligned_lower >= s_State.high_watermark) {
-        printf("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        X_DBGP("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
         result = 0u;
     } else {
         result = s_State.high_watermark - aligned_lower;
     }
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
+    X_API_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
     return result;
 }
 size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
-    X_FN_ENTRY("(%zu)", requiredAlignment);
+    X_API_ENTRY("(%zu)", requiredAlignment);
     X_CHECK_INVARIANTS();
 
     size_t result; // leave uninitialized to ensure each path sets the value (compiler error if used w/o being set)
@@ -659,18 +680,17 @@ size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
 
 
     if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
-        assert(false); // alignment must be a power of 2
+        X_FATAL("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
         result = 0u;
     } else if (aligned_lower >= s_State.high_watermark) {
-        printf("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        X_DBGP("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
         result = 0u;
     } else {
         result = s_State.high_watermark - aligned_lower;
     }
 
     X_CHECK_INVARIANTS();
-    X_FN_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
+    X_API_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
     return result;
 }
 
@@ -681,22 +701,22 @@ size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
 static big_buffer_owner_t legacy_owner = BP_BIG_BUFFER_OWNER_NONE;
 uint8_t *mem_alloc(size_t size, big_buffer_owner_t owner)
 {
-    X_FN_ENTRY("(%zu, %d)", size, owner);
+    X_API_ENTRY("(%zu, %d)", size, owner);
 
     uint8_t * result = BigBuffer_AllocateTemporary(size, 1u, owner);
     if (result != NULL) {
         legacy_owner = owner;
     }
 
-    X_FN_EXIT("(%zu, %d) -> %p", size, owner, result);
+    X_API_EXIT("(%zu, %d) -> %p", size, owner, result);
     return result;
 }
 void mem_free(uint8_t const * ptr)
 {
-    X_FN_ENTRY("(%p)", ptr);
+    X_API_ENTRY("(%p)", ptr);
 
     BigBuffer_FreeTemporary(ptr, legacy_owner);
     BigBuffer_VerifyNoTemporaryAllocations();
 
-    X_FN_EXIT("(%p)", ptr);
+    X_API_EXIT("(%p)", ptr);
 }

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -82,7 +82,6 @@ size_t FindUnusedTrackingEntryIndex(void) {
 
 
 // uintptr_t allows cleaner addition/subtraction between pointers
-static uint16_t    s_BigBufLongLivedAllocCount = 0u;
 static bool        s_BigBufInitialized         = false;
 
 /* Big Buffer Memory Layout:
@@ -106,13 +105,13 @@ void BigBuffer_Initialize(void) {
         return;
     }
 
-    s_State.buffer                 = (uintptr_t)s_BigBufMemory;
-    s_State.total_size             = count_of(s_BigBufMemory);
-    s_State.high_watermark         = s_State.buffer + s_State.total_size;
-    s_State.low_watermark          = s_State.buffer;
-    s_State.long_lived_limit       = s_State.high_watermark - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u);
-    s_State.temp_allocations_count = 0u;
-    s_BigBufLongLivedAllocCount    = 0u;
+    s_State.buffer                       = (uintptr_t)s_BigBufMemory;
+    s_State.total_size                   = count_of(s_BigBufMemory);
+    s_State.high_watermark               = s_State.buffer + s_State.total_size;
+    s_State.low_watermark                = s_State.buffer;
+    s_State.long_lived_limit             = s_State.high_watermark - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u);
+    s_State.temp_allocations_count       = 0u;
+    s_State.long_lived_allocations_count = 0u;
 
     printf("BB: BB @ %p, size %zu, high %p, low %p\n",
            s_State.buffer, s_State.total_size, s_State.high_watermark, s_State.low_watermark
@@ -180,20 +179,21 @@ big_buffer_invariant_error_flags_t BigBuffer_InvariantsFailed(void) {
             }
         }
         // if neither short nor long-lived allocations...
-        if ((s_State.temp_allocations_count == 0) && (s_BigBufLongLivedAllocCount == 0)) {
+        if ((s_State.temp_allocations_count       == 0) &&
+            (s_State.long_lived_allocations_count == 0)  ) {
             // high water mark should point to end of big buffer
             if (s_State.high_watermark != s_State.buffer + s_State.total_size) {
                 result_flags |= BIG_BUFFER_INVARIANT_HIGH_WATERMARK_WITH_NO_ALLOCS;
             }
         }
     } else {
-        if((s_State.buffer                 != 0u) ||
-           (s_State.total_size             != 0u) ||
-           (s_State.high_watermark         != 0u) ||
-           (s_State.low_watermark          != 0u) ||
-           (s_State.long_lived_limit       != 0u) ||
-           (s_State.temp_allocations_count != 0u) ||
-           (s_BigBufLongLivedAllocCount    != 0u)  ) {
+        if((s_State.buffer                       != 0u) ||
+           (s_State.total_size                   != 0u) ||
+           (s_State.high_watermark               != 0u) ||
+           (s_State.low_watermark                != 0u) ||
+           (s_State.long_lived_limit             != 0u) ||
+           (s_State.temp_allocations_count       != 0u) ||
+           (s_State.long_lived_allocations_count != 0u)  ) {
             result_flags |= BIG_BUFFER_INVARIANT_UNINITIALIZED_BUT_STORING_VALUES;
         }
     }
@@ -241,7 +241,7 @@ uintptr_t BigBuffer_DetermineNewHighWaterMark(void) {
             new_high_water_mark = start_of_allocation;
         }
     }
-    assert(allocations_found == s_BigBufLongLivedAllocCount);
+    assert(allocations_found == s_State.long_lived_allocations_count);
     return new_high_water_mark;
 }
 
@@ -265,7 +265,7 @@ void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment,
         printf("BB_AllocLongLived: required alignment too large\n");
         return NULL;
     }
-    if (s_BigBufLongLivedAllocCount + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+    if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
         printf("BB_AllocTemp: too many allocations\n");
         return NULL;
     }
@@ -323,7 +323,7 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
         printf("BB_AllocLongLived: required alignment too large\n");
         return NULL;
     }
-    if (s_BigBufLongLivedAllocCount + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+    if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
         printf("BB_AllocLongLived: too many allocations\n");
         return NULL;
     }
@@ -353,7 +353,7 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
 
     // adjust tracking data
     s_State.high_watermark = result;
-    ++s_BigBufLongLivedAllocCount;
+    ++s_State.long_lived_allocations_count;
     size_t idx = FindUnusedTrackingEntryIndex();
     memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
     s_Allocation[idx].result = result;
@@ -448,7 +448,7 @@ void BigBuffer_FreeLongLived(void* ptr, big_buffer_owner_t owner) {
     // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
     // Then, scan all the allocations to find a new high water mark.
     memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
-    --s_BigBufLongLivedAllocCount;
+    --s_State.long_lived_allocations_count;
     s_State.high_watermark = BigBuffer_DetermineNewHighWaterMark();
 
     return;

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -160,25 +160,48 @@ static void SortAllocationTrackingData(void) {
 }
 
 static void DumpGeneralStateHeader(void) {
+    printf("BB: Buffer*  | TotalSize | HighWater | LowWater | TmpCnt | LongCnt\n");
+    printf("    ---------|-----------|-----------|----------|--------|--------\n");
+    //intf("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. |   .xx. |    .xx.\n");
     return;
 }
-static void DumpGeneralState(big_buffer_general_state_t * general_state) {
+static void DumpGeneralState(const big_buffer_general_state_t * general_state) {
+    printf("BB: %08x |  %08x |  %08x | %08x |   %04x |    %04x\n",
+           general_state->buffer,
+           general_state->total_size,
+           general_state->high_watermark,
+           general_state->low_watermark,
+           general_state->temp_allocations_count,
+           general_state->long_lived_allocations_count
+           );
     return;
 }
 static void DumpAllocationInstanceHeader(void) {
+    printf("BB: Buffer*  | Req_Size | Req_Align | OwnerTag | Type\n");
+    //intf("BB: ..xxxx.. | ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
     return;
 }
-static void DumpAllocationInstance(big_buffer_allocation_instance_t* alloc_state) { // TODO: type of this parameter TBD
+static void DumpAllocationInstance(const big_buffer_allocation_instance_t* alloc_state) {
+    printf(
+        "BB: %08x | %08x |  %08x | %08x | %4s\n",
+        alloc_state->result,
+        alloc_state->requested_size,
+        alloc_state->requested_alignment,
+        alloc_state->owner_tag,
+        (alloc_state->was_long_lived_allocation) ? "long" : "temp"
+        );
     return;
 }
 static void DumpFullMemoryState(void) {
     DumpGeneralStateHeader();
     DumpGeneralState(&s_State);
-    SortAllocationTrackingData();
-    DumpAllocationInstanceHeader();
-    for (size_t j = 0; j < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++j) {
-        if (s_Allocation[j].result != 0u) {
-            DumpAllocationInstance(&s_Allocation[j]);
+    if ((s_State.temp_allocations_count > 0) || (s_State.long_lived_allocations_count > 0)) {
+        SortAllocationTrackingData();
+        DumpAllocationInstanceHeader();
+        for (size_t j = 0; j < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++j) {
+            if (s_Allocation[j].result != 0u) {
+                DumpAllocationInstance(&s_Allocation[j]);
+            }
         }
     }
 }

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -28,6 +28,8 @@
 #include "pirate/mem.h"
 #include "system_config.h"
 
+#define DEBUG_BIGBUFFER
+
 // 136k ... 128k contiguous / 32k aligned required by current LA due to DMA engine configuration
 // Plus an extra 8k that are generally safe for long-term allocations
 // Plus an extra 2k for future tracking of allocations
@@ -36,8 +38,47 @@
 #define BIG_BUFFER_LONGLIVED_BUFFER_KB (  8u)
 #define BIG_BUFFER_ALIGNMENT_KB        ( 32u)
 #define BIG_BUFFER_SIZE ((BIG_BUFFER_TEMPORARY_BUFFER_KB + BIG_BUFFER_LONGLIVED_BUFFER_KB) * 1024u)
-// TODO: only enable this on DEBUG builds
-#define CHECK_BIGBUF_INVARIANTS() BigBuffer_VerifyInvariants(__FILE__, __func__, __LINE__)
+
+// TODO: define DEBUG_BIGBUFFER to bitmask, to enable specific types of output at compilation
+#if defined(DEBUG_BIGBUFFER)
+    #define X_FN_ENTRY(fmt, ...)
+    #define X_FN_EXIT(fmt, ...)
+
+    // #define X_FN_ENTRY(fmt, ...) printf("BB @ %3d: >>>>> %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    // #define X_FN_EXIT(fmt, ...)  printf("BB @ %3d: <<<<< %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #define X_DBGP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #define X_SUCCESS(fmt, ...)  printf("BB @ %3d: SUCCESS " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #define X_FAILURE(fmt, ...)  printf("BB @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__)
+
+    #define X_CHECK_INVARIANTS()                                                                                         \
+        do {                                                                                                             \
+            big_buffer_invariant_error_flags_t error_flags = BigBuffer_InvariantsFailed();                               \
+            static_assert(BIG_BUFFER_INVARIANT_NONE == 0);                                                               \
+            while (error_flags != 0) {                                                                                   \
+                printf("BB @ %3d: *FATAL* Invariant failed from %s:%s:%d\n", error_flags, __FILE__, __func__, __LINE__); \
+                BigBuffer_DebugDumpCurrentState(true);                                                                   \
+                assert(false);                                                                                           \
+            }                                                                                                            \
+        } while (0)
+
+    #define X_FATAL(fmt, ...)                                               \
+        do {                                                                \
+            printf("BB @ %3d: *FATAL* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+            BigBuffer_DebugDumpCurrentState(true);                          \
+            assert(false);                                                  \
+        } while (1)
+
+#else
+    #define X_FN_ENTRY(fmt, ...)
+    #define X_FN_EXIT(fmt, ...)
+    #define X_DBGP(fmt, ...)
+    #define X_SUCCESS(fmt, ...)
+    #define X_FAILURE(fmt, ...)
+
+    #define X_CHECK_INVARIANTS()
+    #define X_FATAL(fmt, ...) assert(false)
+#endif
+
 
 typedef enum _big_buffer_invariant_error_flags {
     BIG_BUFFER_INVARIANT_NONE = 0,
@@ -129,19 +170,6 @@ static big_buffer_invariant_error_flags_t BigBuffer_InvariantsFailed(void) {
     }
     return result_flags;
 }
-static void BigBuffer_VerifyInvariants(const char* file, const char* func, int line) {
-    big_buffer_invariant_error_flags_t error_flags = BigBuffer_InvariantsFailed();
-    static_assert(BIG_BUFFER_INVARIANT_NONE == 0);
-    if (error_flags != 0) {
-        // loop 3x to allow connection of a debugger, else printed message is lost
-        // if there was an `if (DebuggerConnected())` function, could have smarter behavior
-        for (int i = 0; i < 3; ++i) {
-            printf("BB Invariant failed: %#08x at %s:%s:%d\n", error_flags, file, func, line);
-            BigBuffer_DebugDumpCurrentState(true);
-            assert(false);
-        }
-    }
-}
 static void SortAllocationTrackingData(void) {
     // Only 32 maximum entries, so N*N algorithm is only 1024 iterations.
     // If max allocation count is increased, consider a more efficient sorting algorithm.
@@ -174,6 +202,7 @@ static void SortAllocationTrackingData(void) {
 }
 
 static void DumpGeneralStateHeader(void) {
+    printf("\n");
     printf("BB: Buffer*  | TotalSize | HighWater | LowWater | TmpCnt | LongCnt\n");
     printf("    ---------|-----------|-----------|----------|--------|--------\n");
     //intf("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. |   .xx. |    .xx.\n");
@@ -191,14 +220,14 @@ static void DumpGeneralState(const big_buffer_general_state_t * general_state) {
     return;
 }
 static void DumpAllocationInstanceHeader(void) {
-    printf("------------------------------------------------------\n");
-    printf("BB: Buffer*  |  Req_Size | Req_Align | OwnerTag | Type\n");
-    //intf("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
+    printf("    ------------------------------------------------------\n");
+    printf("    Buffer*  |  Req_Size | Req_Align | OwnerTag | Type\n");
+    //intf("    ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
     return;
 }
 static void DumpAllocationInstance(const big_buffer_allocation_instance_t* alloc_state) {
     printf(
-        "BB: %08x |  %08x |  %08x | %08x | %4s\n",
+        "    %08x |  %08x |  %08x | %08x | %4s\n",
         alloc_state->result,
         alloc_state->requested_size,
         alloc_state->requested_alignment,
@@ -226,41 +255,47 @@ static size_t FindUnusedTrackingEntryIndex(void) {
 
 
 void BigBuffer_Initialize(void) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("");
+
+    X_CHECK_INVARIANTS();
     printf("BB: Init()\n");
     if (s_BigBufInitialized) {
         assert(false); // should only call this once
-        return;
+    } else {
+        memset(&s_State, 0, sizeof(s_State));
+        s_State.buffer                       = (uintptr_t)s_BigBufMemory;
+        s_State.total_size                   = count_of(s_BigBufMemory);
+        s_State.high_watermark               = s_State.buffer + s_State.total_size;
+        s_State.low_watermark                = s_State.buffer;
+        s_State.long_lived_limit             = s_State.high_watermark - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u);
+        s_State.temp_allocations_count       = 0u;
+        s_State.long_lived_allocations_count = 0u;
+
+        printf("BB: BB @ %p, size %zu, high %p, low %p\n",
+            s_State.buffer, s_State.total_size, s_State.high_watermark, s_State.low_watermark
+            );
+        memset(s_BigBufMemory, 0xAA, s_State.total_size);
+
+        // Initialize memory tracking buffer also
+        memset(&s_Allocation[0], 0, sizeof(s_Allocation));
+
+        s_BigBufInitialized = true;
     }
-    memset(&s_State, 0, sizeof(s_State));
-    s_State.buffer                       = (uintptr_t)s_BigBufMemory;
-    s_State.total_size                   = count_of(s_BigBufMemory);
-    s_State.high_watermark               = s_State.buffer + s_State.total_size;
-    s_State.low_watermark                = s_State.buffer;
-    s_State.long_lived_limit             = s_State.high_watermark - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u);
-    s_State.temp_allocations_count       = 0u;
-    s_State.long_lived_allocations_count = 0u;
-
-    printf("BB: BB @ %p, size %zu, high %p, low %p\n",
-           s_State.buffer, s_State.total_size, s_State.high_watermark, s_State.low_watermark
-           );
-    memset(s_BigBufMemory, 0xAA, s_State.total_size);
-
-    // Initialize memory tracking buffer also
-    memset(&s_Allocation[0], 0, sizeof(s_Allocation));
-
-    s_BigBufInitialized = true;
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("");
 }
 
 void BigBuffer_VerifyNoTemporaryAllocations(void) {
+    X_FN_ENTRY("");
+
     if (!s_BigBufInitialized) {
         assert(false); // this is recoverable in this instance, but still violates the API contract
         BigBuffer_Initialize(); 
     }
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
     assert(s_State.temp_allocations_count == 0);
     // TODO: also verify no allocation tracking data lists a temporary allocation?
+    X_FN_EXIT("");
 }
 // TODO: macro to call BigBuffer_InvariantsFailed() and assert if non-zero result
 //       this will simplify compiling this to nothing on release builds, and allow file / func / line numbers
@@ -305,140 +340,125 @@ static uintptr_t BigBuffer_DetermineNewHighWaterMark(void) {
 }
 
 void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_CHECK_INVARIANTS();
 
+    uintptr_t result = 0;
+    if (requiredAlignment == 0) {
+        requiredAlignment = 1; // fixup common API error
+    }
     size_t alignmentMask = requiredAlignment - 1;
+
 
     if (!s_BigBufInitialized) {
         printf("BB_AllocTemp: big buffer is not initialized?\n");
         assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
-        return NULL;
-    }
-    if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_AllocTemp: alignment must be a power of 2\n");
+    } else if ((requiredAlignment & alignmentMask) != 0u) {
+        printf("BB_AllocTemp: alignment (%#zx) must be a power of 2\n", requiredAlignment);
         assert(false); // alignment must be a power of 2
-        return NULL;
-    }
-    if (requiredAlignment == 0) {
-        requiredAlignment = 1; // fixup common API error
-    }
-    if (requiredAlignment > 128 * 1024) {
-        printf("BB_AllocLongLived: required alignment too large\n");
-        return NULL;
-    }
-    if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+    } else if (requiredAlignment > 128u * 1024u) {
+        printf("BB_AllocLongLived: required (%#zx) alignment too large\n", requiredAlignment);
+    } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
         printf("BB_AllocTemp: too many allocations\n");
-        return NULL;
-    }
-    if (countOfBytes == 0) {
+    } else if (countOfBytes == 0) {
         printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
-        return NULL;
-    }
-
-    // exit early if the request number of bytes is larger than what's left
-    // N.B. It might still not fit due to alignment requirements ... checked later.
-    if (countOfBytes > s_State.high_watermark - s_State.low_watermark) {
-        printf("BB_AllocTemp: requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - s_State.low_watermark);
-        return NULL;
-    }
-    
-    // allocate temporary buffers from the lower end of the address space
-    uintptr_t result = s_State.low_watermark;
-    if ((result & alignmentMask) != 0u) {
-        // adjust the allocation so that it's properly aligned ... move result to larger address
-        result = (result + requiredAlignment) & ~alignmentMask;
-        if (s_State.high_watermark - result < countOfBytes) {
-            printf("BB_AllocTemp: insufficient space due to alignment requirement\n");
-            return NULL;
+    } else if (countOfBytes > s_State.high_watermark - s_State.low_watermark) {
+        // exit early if the request number of bytes is larger than what's left
+        // N.B. It might still not fit due to alignment requirements ... checked later.
+        printf("BB_AllocTemp: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - s_State.low_watermark);
+    } else {
+        // allocate temporary buffers from the lower end of the address space
+        result = s_State.low_watermark;
+        if ((result & alignmentMask) != 0u) {
+            // adjust the allocation so that it's properly aligned ... move result to larger address
+            result = (result + requiredAlignment) & ~alignmentMask;
+            if (s_State.high_watermark - result < countOfBytes) {
+                printf("BB_AllocTemp: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                result = 0;
+            }
         }
     }
 
-    // adjust tracking data
-    s_State.low_watermark = result + countOfBytes;
-    ++s_State.temp_allocations_count;
-    size_t idx = FindUnusedTrackingEntryIndex();
-    memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
-    s_Allocation[idx].result = result;
-    s_Allocation[idx].requested_size = countOfBytes;
-    s_Allocation[idx].requested_alignment = requiredAlignment;
-    s_Allocation[idx].owner_tag = owner;
-    s_Allocation[idx].was_long_lived_allocation = false;
+    if (result != 0) {
+        // adjust tracking data
+        s_State.low_watermark = result + countOfBytes;
+        ++s_State.temp_allocations_count;
+        size_t idx = FindUnusedTrackingEntryIndex();
+        memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
+        s_Allocation[idx].result = result;
+        s_Allocation[idx].requested_size = countOfBytes;
+        s_Allocation[idx].requested_alignment = requiredAlignment;
+        s_Allocation[idx].owner_tag = owner;
+        s_Allocation[idx].was_long_lived_allocation = false;
 
-    // finally, zero the memory before returning it.
-    memset((void*)result, 0, countOfBytes);
+        // finally, zero the memory before returning it.
+        memset((void*)result, 0, countOfBytes);
+    }
 
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
     return (void*)result;
 }
 void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_CHECK_INVARIANTS();
 
-    size_t alignmentMask = requiredAlignment - 1;
-
-    if (!s_BigBufInitialized) {
-        printf("BB_AllocLongLived: big buffer is not initialized?\n");
-        assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
-        return NULL;
-    }
-    if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_AllocLongLived: alignment must be a power of 2\n");
-        assert(false); // alignment must be a power of 2
-        return NULL;
-    }
+    uintptr_t result = 0;
     if (requiredAlignment == 0) {
         requiredAlignment = 1; // fixup common API error
     }
-    if (requiredAlignment > 128 * 1024) {
-        printf("BB_AllocLongLived: required alignment too large\n");
-        return NULL;
-    }
-    if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
-        printf("BB_AllocLongLived: too many allocations\n");
-        return NULL;
-    }
-    if (countOfBytes == 0) {
-        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
-        return NULL;
-    }
-
+    size_t alignmentMask = requiredAlignment - 1;
     // limit lower bound of the allocation
     uintptr_t lower_limit = s_State.long_lived_limit;
     if (s_State.low_watermark > lower_limit) {
         lower_limit = s_State.low_watermark;
     }
 
-    // exit early if the request number of bytes is larger than what's left
-    // N.B. It might still not fit due to alignment requirements ... checked later.
-    if (countOfBytes > s_State.high_watermark - lower_limit) {
-        printf("BB_AllocLongLived: requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - lower_limit);
-        return NULL;
-    }
-
-    uintptr_t result = s_State.high_watermark - countOfBytes;
-    if ((result & alignmentMask) != 0u) {
-        // adjust the allocation so that it's properly aligned ... move result to SMALLER address
-        result = result & ~alignmentMask;
-        if (lower_limit + countOfBytes > result) {
-            printf("BB_AllocLongLived: insufficient space due to alignment requirement\n");
-            return NULL;
+    if (!s_BigBufInitialized) {
+        printf("BB_AllocLongLived: big buffer is not initialized?\n");
+        assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
+    } else if ((requiredAlignment & alignmentMask) != 0u) {
+        printf("BB_AllocLongLived: alignment (%#zx) must be a power of 2\n", requiredAlignment);
+        assert(false); // alignment must be a power of 2
+    } else if (requiredAlignment > 128u * 1024u) {
+        printf("BB_AllocLongLived: required alignment (%#zx) too large\n", requiredAlignment);
+    } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+        printf("BB_AllocLongLived: too many allocations\n");
+    } else if (countOfBytes == 0) {
+        printf("BB_AllocTemp: returning NULL for zero-byte allocation request");
+    } else if (countOfBytes > s_State.high_watermark - lower_limit) {
+        // exit early if the request number of bytes is larger than what's left
+        // N.B. It might still not fit due to alignment requirements ... checked later.
+        printf("BB_AllocLongLived: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - lower_limit);
+    } else {
+        result = s_State.high_watermark - countOfBytes;
+        if ((result & alignmentMask) != 0u) {
+            // adjust the allocation so that it's properly aligned ... move result to SMALLER address
+            result = result & ~alignmentMask;
+            if (lower_limit > result) {
+                printf("BB_AllocLongLived: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                result = 0;
+            }
         }
     }
 
-    // adjust tracking data
-    s_State.high_watermark = result;
-    ++s_State.long_lived_allocations_count;
-    size_t idx = FindUnusedTrackingEntryIndex();
-    memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
-    s_Allocation[idx].result = result;
-    s_Allocation[idx].requested_size = countOfBytes;
-    s_Allocation[idx].requested_alignment = requiredAlignment;
-    s_Allocation[idx].owner_tag = owner;
-    s_Allocation[idx].was_long_lived_allocation = true;
+    if (result != 0u) {
+        // adjust tracking data
+        s_State.high_watermark = result;
+        ++s_State.long_lived_allocations_count;
+        size_t idx = FindUnusedTrackingEntryIndex();
+        memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
+        s_Allocation[idx].result = result;
+        s_Allocation[idx].requested_size = countOfBytes;
+        s_Allocation[idx].requested_alignment = requiredAlignment;
+        s_Allocation[idx].owner_tag = owner;
+        s_Allocation[idx].was_long_lived_allocation = true;
 
-    // finally, zero the memory before returning it.
-    memset((void*)result, 0, countOfBytes);
-
-    CHECK_BIGBUF_INVARIANTS();
+        // finally, zero the memory before returning it.
+        memset((void*)result, 0, countOfBytes);
+    }
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
     return (void*)result;
 }
 
@@ -454,12 +474,12 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
         return NULL;
     }
     if (p < s_State.buffer) {
-        printf("BB_Free: pointer is before the start of the Big Buffer\n");
+        printf("BB_Free: pointer %#010zx is before the start of the Big Buffer %#010zx\n", p, s_State.buffer);
         assert(false); // ptr is before the start of the Big Buffer
         return NULL;
     }
-    if ((p - s_State.buffer) >= s_State.total_size) {
-        printf("BB_Free: pointer is after the end of the Big Buffer\n");
+    if (p >= (s_State.total_size + s_State.buffer)) {
+        printf("BB_Free: pointer %#010zx is after the end of the Big Buffer %#010zx\n", p, s_State.buffer + s_State.total_size);
         assert(false); // ptr is after the end of the Big Buffer
         return NULL;
     }
@@ -473,12 +493,12 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
         }
     }
     if (allocated == NULL) {
-        printf("BB_Free: pointer was not allocated from BigBuffer\n");
+        printf("BB_Free: pointer %#010zx was not allocated from BigBuffer (%#010zx .. %#010zx)\n", p, s_State.buffer, s_State.buffer + s_State.total_size);
         assert(false); // ptr was not allocated by BigBuffer
         return NULL;
     }
     if (allocated->owner_tag != owner) {
-        printf("BB_Free: owner tag mismatch: allocated by %d, free attempt by %d\n", allocated->owner_tag, owner);
+        printf("BB_Free: owner tag mismatch: point %#010zx allocated by %d, free attempted by %d\n", p, allocated->owner_tag, owner);
         assert(false); // owner tag mismatch
         return NULL;
     }
@@ -487,74 +507,92 @@ static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_b
     return allocated;
 }
 void BigBuffer_FreeTemporary(const void * ptr, big_buffer_owner_t owner) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%p, %d)", ptr, owner);
+    X_CHECK_INVARIANTS();
 
     big_buffer_allocation_instance_t* allocation = BigBuffer_FreeCommon((uintptr_t)ptr, owner);
     if (allocation == NULL) {
         // already asserted in BigBuffer_FreeCommon(), or was free'ing NULL
-        return;
-    }
-    if (allocation->was_long_lived_allocation) {
-        printf("BB_FreeTemp: pointer was allocated as long-lived allocation.\n");
+    } else if (allocation->was_long_lived_allocation) {
+        printf("BB_FreeTemp: pointer %#010zx was allocated as long-lived allocation.\n");
         assert(false); // ptr was not a temporary allocation
-        return;
+    } else {
+        // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
+        // Then, scan all the allocations to find a new low water mark.
+        memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
+        --s_State.temp_allocations_count;
+        s_State.low_watermark = BigBuffer_DetermineNewLowWaterMark();
     }
 
-    // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
-    // Then, scan all the allocations to find a new low water mark.
-    memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
-    --s_State.temp_allocations_count;
-    s_State.low_watermark = BigBuffer_DetermineNewLowWaterMark();
-
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p, %d)", ptr, owner);
     return;
 }
 void BigBuffer_FreeLongLived(const void * ptr, big_buffer_owner_t owner) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%p, %d)", ptr, owner);
+    X_CHECK_INVARIANTS();
 
     big_buffer_allocation_instance_t* allocation = BigBuffer_FreeCommon((uintptr_t)ptr, owner);
     if (allocation == NULL) {
         // already asserted in BigBuffer_FreeCommon(), or was free'ing NULL
-        return;
-    }
-    if (!allocation->was_long_lived_allocation) {
-        printf("BB_FreeLongLived: pointer was allocated as temporary allocation.\n");
+    } else if (!allocation->was_long_lived_allocation) {
+        printf("BB_FreeLongLived: pointer %#010zx was allocated as temporary allocation.\n");
         assert(false); // ptr was not a long-lived allocation
-        return;
+    } else {
+        // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
+        // Then, scan all the allocations to find a new high water mark.
+        memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
+        --s_State.long_lived_allocations_count;
+        s_State.high_watermark = BigBuffer_DetermineNewHighWaterMark();
     }
 
-    // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
-    // Then, scan all the allocations to find a new high water mark.
-    memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
-    --s_State.long_lived_allocations_count;
-    s_State.high_watermark = BigBuffer_DetermineNewHighWaterMark();
-
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p, %d)", ptr, owner);
     return;
 }
 
-
 void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out ) {
+    X_FN_ENTRY("(%p)", general_state_out);
+    X_CHECK_INVARIANTS();
+
     static_assert(sizeof(s_State) == sizeof(big_buffer_general_state_t));
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
 
     memcpy(general_state_out, &s_State, sizeof(big_buffer_general_state_t));
+
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p)", general_state_out);
     return;
 }
 void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out ) {
+    X_FN_ENTRY("(%p)", state_out);
+    X_CHECK_INVARIANTS();
+
     static_assert(sizeof(s_State) == sizeof(state_out->general));
     static_assert(sizeof(s_Allocation) == sizeof(state_out->allocation));
-    CHECK_BIGBUF_INVARIANTS();
+    X_CHECK_INVARIANTS();
 
     memcpy(&(state_out->general), &s_State, sizeof(big_buffer_general_state_t));
     memcpy(&(state_out->allocation[0]), &(s_Allocation[0]), sizeof(state_out->allocation));
+
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p)", state_out);
     return;
 }
 void BigBuffer_DebugDumpSummary(const big_buffer_general_state_t * state) {
+    X_FN_ENTRY("(%p)", state);
+    X_CHECK_INVARIANTS();
+
     DumpGeneralStateHeader();
     DumpGeneralState(state);
+
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p)", state);
 }
 void BigBuffer_DebugDumpState(const big_buffer_state_t * state) {
+    X_FN_ENTRY("(%p)", state);
+    X_CHECK_INVARIANTS();
+
     DumpGeneralStateHeader();
     DumpGeneralState(&(state->general));
     DumpAllocationInstanceHeader();
@@ -563,8 +601,13 @@ void BigBuffer_DebugDumpState(const big_buffer_state_t * state) {
             DumpAllocationInstance(&(state->allocation[j]));
         }
     }
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%p)", state);
 }
 void BigBuffer_DebugDumpCurrentState(bool verbose) {
+    X_FN_ENTRY("(%s)", verbose ? "true" : "false");
+    X_CHECK_INVARIANTS();
+
     DumpGeneralStateHeader();
     DumpGeneralState(&s_State);
     if (verbose && ((s_State.temp_allocations_count > 0) || (s_State.long_lived_allocations_count > 0))) {
@@ -576,43 +619,58 @@ void BigBuffer_DebugDumpCurrentState(bool verbose) {
             }
         }
     }
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%s)", verbose ? "true" : "false");
 }
 
 size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%zu)", requiredAlignment);
+    X_CHECK_INVARIANTS();
 
+    size_t result = 0u;
     size_t alignmentMask = requiredAlignment - 1;
+    uintptr_t aligned_lower = (s_State.low_watermark + (requiredAlignment - 1)) & (~alignmentMask);
+
     if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_GetAvailableTempMemory: alignment must be a power of 2\n");
+        printf("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
         assert(false); // alignment must be a power of 2
-        return 0u;
+    } else if (aligned_lower >= s_State.high_watermark) {
+        printf("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        result = 0u;
+    } else {
+        result = s_State.high_watermark - aligned_lower;
     }
 
-    uintptr_t aligned_lower = (s_State.low_watermark + (requiredAlignment - 1)) & (~alignmentMask);
-    if (aligned_lower >= s_State.high_watermark) {
-        return 0u;
-    }
-    size_t result = s_State.high_watermark - aligned_lower;
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
     return result;
 }
 size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
-    CHECK_BIGBUF_INVARIANTS();
+    X_FN_ENTRY("(%zu)", requiredAlignment);
+    X_CHECK_INVARIANTS();
 
+    size_t result; // leave uninitialized to ensure each path sets the value (compiler error if used w/o being set)
     size_t alignmentMask = requiredAlignment - 1;
-    if ((requiredAlignment & alignmentMask) != 0u) {
-        printf("BB_GetAvailableTempMemory: alignment must be a power of 2\n");
-        assert(false); // alignment must be a power of 2
-        return 0u;
-    }
     uintptr_t lower = s_State.long_lived_limit;
     if (s_State.low_watermark > lower) {
         lower = s_State.low_watermark;
     }
     uintptr_t aligned_lower = (lower + (requiredAlignment - 1)) & (~alignmentMask);
-    if (aligned_lower >= s_State.high_watermark) {
-        return 0u;
+
+
+    if ((requiredAlignment & alignmentMask) != 0u) {
+        printf("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
+        assert(false); // alignment must be a power of 2
+        result = 0u;
+    } else if (aligned_lower >= s_State.high_watermark) {
+        printf("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        result = 0u;
+    } else {
+        result = s_State.high_watermark - aligned_lower;
     }
-    size_t result = s_State.high_watermark - aligned_lower;
+
+    X_CHECK_INVARIANTS();
+    X_FN_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
     return result;
 }
 
@@ -623,14 +681,22 @@ size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
 static big_buffer_owner_t legacy_owner = BP_BIG_BUFFER_OWNER_NONE;
 uint8_t *mem_alloc(size_t size, big_buffer_owner_t owner)
 {
+    X_FN_ENTRY("(%zu, %d)", size, owner);
+
     uint8_t * result = BigBuffer_AllocateTemporary(size, 1u, owner);
     if (result != NULL) {
         legacy_owner = owner;
     }
+
+    X_FN_EXIT("(%zu, %d) -> %p", size, owner, result);
     return result;
 }
 void mem_free(uint8_t const * ptr)
 {
+    X_FN_ENTRY("(%p)", ptr);
+
     BigBuffer_FreeTemporary(ptr, legacy_owner);
     BigBuffer_VerifyNoTemporaryAllocations();
+
+    X_FN_EXIT("(%p)", ptr);
 }

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -33,6 +33,8 @@ static_assert(sizeof(big_buffer_owner_t) <= 4);
 static_assert(MAXIMUM_BP_BIG_BUFFER_OWNER <= 0x10000);
 
 typedef struct _big_buffer_general_state {
+    // uintptr_t allows cleaner addition/subtraction between pointers
+    static_assert(sizeof(uintptr_t) >= sizeof(size_t));
     uintptr_t buffer;
     size_t    total_size;
     uintptr_t high_watermark; // end of allocatable memory

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -38,7 +38,7 @@ typedef struct _big_buffer_general_state {
     uintptr_t high_watermark; // end of allocatable memory
     uintptr_t low_watermark;
     uintptr_t long_lived_limit;
-    uint16_t  temporary_allocations_count;
+    uint16_t  temp_allocations_count;
     uint16_t  long_lived_allocations_count;
 } big_buffer_general_state_t;
 

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -60,12 +60,6 @@ typedef struct _big_buffer_state {
 	big_buffer_allocation_instance_t allocation[MAXIMUM_SUPPORTED_ALLOCATION_COUNT];
 } big_buffer_state_t;
 
-
-
-
-
-
-
 /// @brief Initializes the BigBuffer module.
 /// @details Must be called before any other BigBuffer API.
 /// @note Called during system init, so in some respects this is an implementation detail.
@@ -100,6 +94,17 @@ void BigBuffer_FreeTemporary(void* ptr, big_buffer_owner_t owner);
 ///       more difficult to catch / debug / track down.
 void BigBuffer_FreeLongLived(void* ptr, big_buffer_owner_t owner);
 
+/// @brief How many bytes of temporary memory are available with a given alignment?
+size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment);
+
+/// @brief How many bytes of long-lived memory are available with a given alignment?
+size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment);
+
+////////////////////////////////////////////////////////////////////////////////
+// Debug APIs ... not really intended for general use, but may be useful during
+//                development / debugging.
+////////////////////////////////////////////////////////////////////////////////
+
 
 /// @brief provide statistics on current BigBuffer usage
 /// @details Provides overview of BigBuffer state (high / low water marks, etc.)
@@ -118,24 +123,34 @@ bool BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_ou
 ///       interactive display of information.
 bool BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
 
-
-/// @brief How many bytes of temporary memory are available?
-size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment);
-
-/// @brief How many bytes of long-lived memory are available?
-size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment);
+// End of debug APIs
+////////////////////////////////////////////////////////////////////////////////
 
 
+////////////////////////////////////////////////////////////////////////////////
+// LEGACY APIs ... these are deprecated and will soon be removed
+//
+// Stage 0: define the new APIs (above)
+// Stage 1: migrate all code to use the new APIs
+// Stage 2: mark the functions with deprecated attribute
+// Stage 3: wait appropriate time for braches to be updated
+// Stage 4: remove the deprecated functions entirely
 
+#define DEPRECATE_MEM_ALLOC
+//#define DEPRECATE_MEM_ALLOC __attribute__((deprecated))
 
 /// @brief Attempts to allocate a nand page buffer.
 /// @return Pointer to the buffer if available, NULL if not available
 /// @note Return value should always be checked against null.
 /// @note Max size: SPI_NAND_PAGE_SIZE + SPI_NAND_OOB_SIZE
-uint8_t *mem_alloc(size_t size, big_buffer_owner_t owner);
-
+uint8_t* mem_alloc(size_t size, big_buffer_owner_t owner) DEPRECATE_MEM_ALLOC;
 /// @brief Frees the allocated nand page buffer
 /// @param ptr pointer to the nand page buffer
-void mem_free(uint8_t *ptr);
+void     mem_free(uint8_t *ptr)                           DEPRECATE_MEM_ALLOC;
+
+// End of legacy memory allocation APIs
+////////////////////////////////////////////////////////////////////////////////
+
+
 
 #endif // __MEM_H

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -123,6 +123,15 @@ bool BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_ou
 ///       interactive display of information.
 bool BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
 
+/// @brief Prints the current state of the BigBuffer module
+/// @details This is intended for debugging purposes.  It will print the
+///          current internal `big_buffer_general_state_t`.  If the `verbose`
+///          parameter is true, it will also print all currently allocated
+///          memory allocations (one allocation per line).
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+void BigBuffer_DebugDumpCurrentState(bool verbose);
+
 // End of debug APIs
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -145,8 +145,10 @@ void BigBuffer_DebugDumpCurrentState(bool verbose);
 // Stage 3: wait appropriate time for braches to be updated
 // Stage 4: remove the deprecated functions entirely
 
-#define DEPRECATE_MEM_ALLOC
-//#define DEPRECATE_MEM_ALLOC __attribute__((deprecated))
+//#define DEPRECATE_MEM_ALLOC
+//#define DEPRECATE_MEM_FREE
+#define DEPRECATE_MEM_ALLOC __attribute__((deprecated("use BigBuffer_AllocateTemporary() instead")))
+#define DEPRECATE_MEM_FREE __attribute__((deprecated("use BigBuffer_FreeTemporary() instead")))
 
 /// @brief Attempts to allocate a nand page buffer.
 /// @return Pointer to the buffer if available, NULL if not available
@@ -155,7 +157,7 @@ void BigBuffer_DebugDumpCurrentState(bool verbose);
 uint8_t* mem_alloc(size_t size, big_buffer_owner_t owner) DEPRECATE_MEM_ALLOC;
 /// @brief Frees the allocated nand page buffer
 /// @param ptr pointer to the nand page buffer
-void     mem_free(uint8_t *ptr)                           DEPRECATE_MEM_ALLOC;
+void     mem_free(uint8_t *ptr)                           DEPRECATE_MEM_FREE;
 
 // End of legacy memory allocation APIs
 ////////////////////////////////////////////////////////////////////////////////

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -23,10 +23,10 @@
 /// @brief Unique tag to indicate the owner of a big buffer allocation.
 typedef enum _big_buffer_owners {
 	BP_BIG_BUFFER_OWNER_NONE=0,
+    BP_BIG_BUFFER_OWNER_SELFTEST,
 	BP_BIG_BUFFER_OWNER_SCOPE,
 	BP_BIG_BUFFER_OWNER_LA,
 	BP_BIG_BUFFER_OWNER_DISKFORMAT,
-    BP_BIG_BUFFER_OWNER_SELFTEST,
 	MAXIMUM_BP_BIG_BUFFER_OWNER,
 } big_buffer_owner_t;
 
@@ -88,12 +88,12 @@ void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment,
 /// @brief Frees a buffer previously allocated by `BigBuffer_AllocateTemporary()`.
 /// @note The owner must match ... this helps avoid a class of bugs that are otherwise
 ///       more difficult to catch / debug / track down.
-void BigBuffer_FreeTemporary(void* ptr, big_buffer_owner_t owner);
+void BigBuffer_FreeTemporary(const void * ptr, big_buffer_owner_t owner);
 
 /// @brief Frees a buffer previously allocated by `BigBuffer_AllocateLongLived()`.
 /// @note The owner must match ... this helps avoid a class of bugs that are otherwise
 ///       more difficult to catch / debug / track down.
-void BigBuffer_FreeLongLived(void* ptr, big_buffer_owner_t owner);
+void BigBuffer_FreeLongLived(const void * ptr, big_buffer_owner_t owner);
 
 /// @brief How many bytes of temporary memory are available with a given alignment?
 size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment);
@@ -111,7 +111,7 @@ size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment);
 /// @details Provides overview of BigBuffer state (high / low water marks, etc.)
 /// @note This API is /NOT/ performance-critical, as it is intended for
 ///       interactive display of information.
-bool BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out );
+void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out );
 
 /// @brief provide detailed information on current BigBuffer usage
 /// @details The goal of this API is to help troubleshoot memory usage issues.
@@ -125,7 +125,10 @@ bool BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_ou
 ///
 /// @note This API is /NOT/ performance-critical, as it is intended for
 ///       interactive display of information.
-bool BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
+void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
+
+void BigBuffer_DebugDumpSummary(const big_buffer_general_state_t * state);
+void BigBuffer_DebugDumpState(const big_buffer_state_t * state);
 
 /// @brief Prints the current state of the BigBuffer module
 /// @details This is intended for debugging purposes.  It will print the
@@ -157,7 +160,7 @@ void BigBuffer_DebugDumpCurrentState(bool verbose);
 uint8_t* mem_alloc(size_t size, big_buffer_owner_t owner) __attribute__((deprecated("use BigBuffer_AllocateTemporary() instead")));
 /// @brief Frees the allocated nand page buffer
 /// @param ptr pointer to the nand page buffer
-void     mem_free(uint8_t *ptr)                           __attribute__((deprecated("use BigBuffer_FreeTemporary() instead")));
+void     mem_free(const uint8_t * ptr)                    __attribute__((deprecated("use BigBuffer_FreeTemporary() instead")));
 
 // End of legacy memory allocation APIs
 ////////////////////////////////////////////////////////////////////////////////

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -20,18 +20,117 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum big_buffer_owners{
-	BP_BIG_BUFFER_NONE=0,
-	BP_BIG_BUFFER_SCOPE,
-	BP_BIG_BUFFER_LA,
-	BP_BIG_BUFFER_DISKFORMAT,
-};
+typedef enum _big_buffer_owners {
+	BP_BIG_BUFFER_OWNER_NONE=0,
+	BP_BIG_BUFFER_OWNER_SCOPE,
+	BP_BIG_BUFFER_OWNER_LA,
+	BP_BIG_BUFFER_OWNER_DISKFORMAT,
+
+	MAXIMUM_BP_BIG_BUFFER_OWNER,
+} big_buffer_owner_t;
+static_assert(sizeof(big_buffer_owner_t) <= 4);
+// Ensures 16-bits or less; Allows to overload value stored in tracking structure
+static_assert(MAXIMUM_BP_BIG_BUFFER_OWNER <= 0x10000);
+
+typedef struct _big_buffer_general_state {
+    uintptr_t buffer;
+    size_t    total_size;
+    uintptr_t high_watermark; // end of allocatable memory
+    uintptr_t low_watermark;
+    uintptr_t long_lived_limit;
+    uint16_t  temporary_allocations_count;
+    uint16_t  long_lived_allocations_count;
+} big_buffer_general_state_t;
+
+typedef struct _big_buffer_allocation_instance {
+    uintptr_t   result;
+    size_t      requested_size;
+    size_t      requested_alignment;
+    uint32_t    owner_tag : 16; // big_buffer_owner_t ... limited to 16-bits
+	uint32_t    was_long_lived_allocation : 1;
+	uint32_t    : 15; // rfu
+} big_buffer_allocation_instance_t;
+
+#define MAXIMUM_SUPPORTED_ALLOCATION_COUNT 32
+
+typedef struct _big_buffer_state {
+	big_buffer_general_state_t general;
+	big_buffer_allocation_instance_t allocation[MAXIMUM_SUPPORTED_ALLOCATION_COUNT];
+} big_buffer_state_t;
+
+
+
+
+
+
+
+/// @brief Initializes the BigBuffer module.
+/// @details Must be called before any other BigBuffer API.
+/// @note Called during system init, so in some respects this is an implementation detail.
+void BigBuffer_Initialize(void);
+
+/// @brief Verifies that all /temporary/ allocations have been freed,
+///        and that state matches expectations.
+/// @note it is expected that all temporary allocations have been freed
+///       prior to calling this API.  This is STRONGLY recommended before
+///       initializing a new mode to help avoid bugs that are essentially
+///       impossible to debug (dangling pointers --> memory corruption).
+void BigBuffer_VerifyNoTemporaryAllocations(void);
+
+/// @brief Allocates temporary buffer of the specified size and alignment.
+/// @note The memory returned by this API /MUST/ be released prior to calling
+///       BigBuffer_PartialReset().
+void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner);
+
+/// @brief Allocates a long-lived buffer of the specified size and alignment, if possible.
+/// @details The memory returned by this API is /NOT/ required to be released prior to
+///          calling BigBuffer_PartialReset().
+/// @note Total long-lived buffer space is currently limited to 8k.
+void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner);
+
+/// @brief Frees a buffer previously allocated by `BigBuffer_AllocateTemporary()`.
+/// @note The owner must match ... this helps avoid a class of bugs that are otherwise
+///       more difficult to catch / debug / track down.
+void BigBuffer_FreeTemporary(void* ptr, big_buffer_owner_t owner);
+
+/// @brief Frees a buffer previously allocated by `BigBuffer_AllocateLongLived()`.
+/// @note The owner must match ... this helps avoid a class of bugs that are otherwise
+///       more difficult to catch / debug / track down.
+void BigBuffer_FreeLongLived(void* ptr, big_buffer_owner_t owner);
+
+
+/// @brief provide statistics on current BigBuffer usage
+/// @details Provides overview of BigBuffer state (high / low water marks, etc.)
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+bool BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out );
+
+/// @brief provide detailed information on current BigBuffer usage
+/// @details The goal of this API is to help troubleshoot memory usage issues.
+///          Example question and answer:
+///          Why is this mode failing to initialize?
+///          The mode requires 130k buffer, which reaches into the long-lived
+///          allocation space, but the entire 8k of the long-lived buffer is
+///          allocated by XXXX.
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+bool BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
+
+
+/// @brief How many bytes of temporary memory are available?
+size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment);
+
+/// @brief How many bytes of long-lived memory are available?
+size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment);
+
+
+
 
 /// @brief Attempts to allocate a nand page buffer.
 /// @return Pointer to the buffer if available, NULL if not available
 /// @note Return value should always be checked against null.
 /// @note Max size: SPI_NAND_PAGE_SIZE + SPI_NAND_OOB_SIZE
-uint8_t *mem_alloc(size_t size, uint32_t owner);
+uint8_t *mem_alloc(size_t size, big_buffer_owner_t owner);
 
 /// @brief Frees the allocated nand page buffer
 /// @param ptr pointer to the nand page buffer

--- a/pirate/memmap_buspirate5.ld
+++ b/pirate/memmap_buspirate5.ld
@@ -196,7 +196,7 @@ SECTIONS
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     .bss  : {
-        . = ALIGN(4);
+        . = ALIGN(32K);
         __bss_start__ = .;
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
         *(COMMON)

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -124,13 +124,15 @@ bool storage_detect(void){
 
 uint8_t storage_format(void) {
     FRESULT fr;     /* FatFs return code */
-    uint8_t *work_buffer = mem_alloc(FF_MAX_SS, BP_BIG_BUFFER_OWNER_DISKFORMAT);
+    uint8_t *work_buffer = BigBuffer_AllocateTemporary(FF_MAX_SS, 4, BP_BIG_BUFFER_OWNER_DISKFORMAT);
     if (!work_buffer) {
         return FR_NOT_ENOUGH_CORE;
     }
+
     fr = f_mkfs("", 0, work_buffer, FF_MAX_SS);
-    mem_free(work_buffer);
-    if(fr == FR_OK){
+    BigBuffer_FreeTemporary(work_buffer, BP_BIG_BUFFER_OWNER_DISKFORMAT);
+
+    if (fr == FR_OK) {
         fr = f_setlabel("Bus_Pirate5");
     }
     return fr;

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -124,7 +124,7 @@ bool storage_detect(void){
 
 uint8_t storage_format(void) {
     FRESULT fr;     /* FatFs return code */
-    uint8_t *work_buffer = mem_alloc(FF_MAX_SS, BP_BIG_BUFFER_DISKFORMAT);
+    uint8_t *work_buffer = mem_alloc(FF_MAX_SS, BP_BIG_BUFFER_OWNER_DISKFORMAT);
     if (!work_buffer) {
         return FR_NOT_ENOUGH_CORE;
     }

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -122,9 +122,7 @@ bool storage_detect(void){
     return true;
 }
 
-uint8_t storage_format(void){
-    static_assert(FF_MAX_SS <= BIG_BUFFER_SIZE, "BIG_BUFFER_SIZE must be at least FF_MAX_SS for this allocation to succeed.");
-
+uint8_t storage_format(void) {
     FRESULT fr;     /* FatFs return code */
     uint8_t *work_buffer = mem_alloc(FF_MAX_SS, BP_BIG_BUFFER_DISKFORMAT);
     if (!work_buffer) {

--- a/system_config.c
+++ b/system_config.c
@@ -107,8 +107,6 @@ void system_init(void)
 	system_config.clkport=0;
 	system_config.clkpin=0;
 
-	system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
-
 	system_config.rts=0;
 }
 


### PR DESCRIPTION
# NOT TESTED


### Ready for Review:

Review of the Alpha APIv2 would be helpful.  It can be found in `mem.h`.  Feedback will define the quality of the final result.

Alpha APIv2 now exposes an API that enables up to 8k in persistent allocations, and multiple temporary allocations, while retaining the legacy 128k buffer (and its alignment, etc.).

### Info

This **_should_** just work compatibly via the old API.  Not tested yet ...this is just for early feedback.   Names (e.g., "Temporary" vs. "long-lived" allocations) are preliminary ... suggestions welcome, or we might end up with them.

Key features:
* Multiple "temporary" allocations allowed.  The purpose here is, when entering a mode, the mode may perform mode-specific allocations, which otherwise would be `static` (and thus always using RAM, even when the mode is not being used).
* When the mode exits, it is expected that the mode will free all the temporary allocations it has made.  Thus, when the mode exist, there should be zero temporary allocations remaining.
* Separate "long-lived" allocations allowed.  The purpose here is to allow a smaller set of buffers to be allocated, which are not mode-specific, but where there is value in not having the RAM always allocated.  Up to 8k is reserved for these long-lived allocations.
* Built-in API to validate that all temporary allocations have been released
* Exposure of significant (but simplified) internal state to allow reasoning about what occurs and why.

Helpful hints:
* A mode should allocate its temporary memory based on alignment requirements, requesting the allocation with the highest alignment requirement first.
* Memory buffers should be free'd in the reverse order of allocation.   Things will still work if memory is free'd in a different order, but there is currently no attempt to allocate from "holes" in the allocated memory.


<hr/><details><summary>Post v1</summary><p/>

Although not exposed yet, the new API allows multiple allocations, and re-initialization of the BigBuffer state.

This **_should_** just work compatibly via the old API.  Not tested yet ...this is just for early feedback.

Summary of changes other than `pirate/mem.c`:
* `pirate.c` -- Remove previously reserved 10k buffer
* `pirate.h` -- Remove global declaration of big buffer's size (can be API if required later)
* `pirate/memmap_buspirate5.ld` -- although not a functional change, be explicit about the need for 32k alignment of `.bss`
* `pirate/storage.c` -- Remove static assert

Summary of changes within `pirate/mem.c`:
* Big buffer is now 138k (128k + 10k) to allow for fuller allocation capability / tracking metadata.
* Primary focus is on allocation of buffers of at least 1k size (and with alignment requirements)
* Initially, just allocate large buffers from the lower side, and smaller buffers from the upper side, meeting in the middle

Later, maybe store a 128-bit map (representing 1k chunks) of what's allocated, or other tracked method to allow `free()` to be robust.

</details>


<hr/>