### PR TITLE
Define new BigBuffer_...() APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,139 +50,284 @@ set(bp5_common
 
         # commands
         commands.h commands.c
-        commands/global/w_psu.h commands/global/w_psu.c
-        commands/global/p_pullups.h commands/global/p_pullups.c
-        commands/global/cmd_mcu.h commands/global/cmd_mcu.c
-        commands/global/l_bitorder.h commands/global/l_bitorder.c
-        commands/global/cmd_convert.h commands/global/cmd_convert.c
-        commands/global/pause.h commands/global/pause.c
-        commands/global/h_help.h commands/global/h_help.c
-        commands/global/cmd_selftest.h commands/global/cmd_selftest.c
-        commands/global/a_auxio.h commands/global/a_auxio.c
-        commands/global/dummy.c commands/global/dummy.h
-        commands/global/disk.c commands/global/disk.h
-        commands/global/v_adc.c commands/global/v_adc.h
-        commands/global/i_info.c commands/global/i_info.h
-        commands/global/pwm.c commands/global/pwm.h
-        commands/global/freq.c commands/global/freq.h
-        commands/global/macro.c commands/global/macro.h
-        commands/global/script.c commands/global/script.h
-        commands/global/tutorial.c commands/global/tutorial.h
-        commands/global/button_scr.c commands/global/button_scr.h
-        commands/global/smps.c commands/global/smps.h
-        commands/global/cls.h commands/global/cls.c  
-        commands/global/cmd_binmode.h commands/global/cmd_binmode.c
+        commands/global/w_psu.h
+        commands/global/w_psu.c
+        commands/global/p_pullups.h
+        commands/global/p_pullups.c
+        commands/global/cmd_mcu.h
+        commands/global/cmd_mcu.c
+        commands/global/l_bitorder.h
+        commands/global/l_bitorder.c
+        commands/global/cmd_convert.h
+        commands/global/cmd_convert.c
+        commands/global/pause.h
+        commands/global/pause.c
+        commands/global/h_help.h
+        commands/global/h_help.c
+        commands/global/cmd_selftest.h
+        commands/global/cmd_selftest.c
+        commands/global/a_auxio.h
+        commands/global/a_auxio.c
+        commands/global/dummy.c
+        commands/global/dummy.h
+        commands/global/disk.c
+        commands/global/disk.h
+        commands/global/v_adc.c
+        commands/global/v_adc.h
+        commands/global/i_info.c
+        commands/global/i_info.h
+        commands/global/pwm.c
+        commands/global/pwm.h
+        commands/global/freq.c
+        commands/global/freq.h
+        commands/global/macro.c
+        commands/global/macro.h
+        commands/global/script.c
+        commands/global/script.h
+        commands/global/tutorial.c
+        commands/global/tutorial.h
+        commands/global/button_scr.c
+        commands/global/button_scr.h
+        commands/global/bigbuffer_test.c
+        commands/global/bigbuffer_test.h
+
+        commands/global/smps.c
+        commands/global/smps.h
+        commands/global/cls.h
+        commands/global/cls.c
+        commands/global/cmd_binmode.h
+        commands/global/cmd_binmode.c
+
         # HiZ
-        mode/hiz.h mode/hiz.c
+        mode/hiz.h
+        mode/hiz.c
+        
         # 1Wire
-        mode/hw1wire.h mode/hw1wire.c
-        pirate/hw1wire_pio.h pirate/hw1wire_pio.c
-        commands/1wire/scan.h commands/1wire/scan.c
-        commands/1wire/demos.h commands/1wire/demos.c
+        mode/hw1wire.h
+        mode/hw1wire.c
+        pirate/hw1wire_pio.h
+        pirate/hw1wire_pio.c
+        commands/1wire/scan.h
+        commands/1wire/scan.c
+        commands/1wire/demos.h
+        commands/1wire/demos.c
 
         # UART
-        mode/hwuart.h mode/hwuart.c
-        pirate/hwuart_pio.h pirate/hwuart_pio.c
-        commands/uart/nmea.c commands/uart/nmea.h
-        commands/uart/bridge.h commands/uart/bridge.c
-        commands/uart/simcard.h commands/uart/simcard.c
-        lib/minmea/minmea.h lib/minmea/minmea.c lib/minmea/gps.h lib/minmea/gps.c
-        commands/uart/monitor.h commands/uart/monitor.c
+        mode/hwuart.h
+        mode/hwuart.c
+        pirate/hwuart_pio.h
+        pirate/hwuart_pio.c
+        commands/uart/nmea.c
+        commands/uart/nmea.h
+        commands/uart/bridge.h
+        commands/uart/bridge.c
+        commands/uart/simcard.h
+        commands/uart/simcard.c
+        commands/uart/monitor.h
+        commands/uart/monitor.c
+        lib/minmea/minmea.h
+        lib/minmea/minmea.c
+        lib/minmea/gps.h
+        lib/minmea/gps.c
 
         # Half duplex UART
-        mode/hwhduart.h mode/hwhduart.c
-        commands/hdplxuart/bridge.c commands/hdplxuart/bridge.h
+        mode/hwhduart.h
+        mode/hwhduart.c
+        commands/hdplxuart/bridge.c
+        commands/hdplxuart/bridge.h
 
         # I2C 
-        mode/hwi2c.c mode/hwi2c.h
-        pirate/hwi2c_pio.c pirate/hwi2c_pio.h
-        commands/i2c/scan.h commands/i2c/scan.c
-        commands/i2c/demos.h commands/i2c/demos.c
+        mode/hwi2c.c
+        mode/hwi2c.h
+        pirate/hwi2c_pio.c
+        pirate/hwi2c_pio.h
+        commands/i2c/scan.h
+        commands/i2c/scan.c
+        commands/i2c/demos.h
+        commands/i2c/demos.c
         lib/i2c_address_list/dev_i2c_addresses.h
-        lib/ms5611/ms5611.c lib/ms5611/ms5611.h lib/tsl2561/driver_tsl2561.c lib/tsl2561/driver_tsl2561.h
+        lib/ms5611/ms5611.c
+        lib/ms5611/ms5611.h
+        lib/tsl2561/driver_tsl2561.c
+        lib/tsl2561/driver_tsl2561.h
 
         # SPI
-        mode/hwspi.c mode/hwspi.h
-        pirate/hwspi.c pirate/hwspi.h
-        commands/spi/flash.c commands/spi/flash.h commands/spi/spiflash.h commands/spi/spiflash.c
-        commands/spi/sniff.c commands/spi/sniff.h
-        lib/sfud/inc/sfud.h lib/sfud/inc/sfud.c lib/sfud/inc/sfud_cfg.h lib/sfud/inc/sfud_def.h
-        lib/sfud/inc/sfud_flash_def.h lib/sfud/inc/sfud_port.c lib/sfud/inc/sfud_sfdp.c
+        mode/hwspi.c
+        mode/hwspi.h
+        pirate/hwspi.c
+        pirate/hwspi.h
+        commands/spi/flash.c
+        commands/spi/flash.h
+        commands/spi/spiflash.h
+        commands/spi/spiflash.c
+        commands/spi/sniff.c
+        commands/spi/sniff.h
+        lib/sfud/inc/sfud.h
+        lib/sfud/inc/sfud.c
+        lib/sfud/inc/sfud_cfg.h
+        lib/sfud/inc/sfud_def.h
+        lib/sfud/inc/sfud_flash_def.h
+        lib/sfud/inc/sfud_port.c
+        lib/sfud/inc/sfud_sfdp.c
 
         # 2WIRE
-        mode/hw2wire.h mode/hw2wire.c
-        pirate/hw2wire_pio.h pirate/hw2wire_pio.c
-        commands/2wire/sle4442.c commands/2wire/sle4442.h
+        mode/hw2wire.h
+        mode/hw2wire.c
+        pirate/hw2wire_pio.h
+        pirate/hw2wire_pio.c
+        commands/2wire/sle4442.c
+        commands/2wire/sle4442.h
 
         # LED
-        mode/hwled.c mode/hwled.h
+        mode/hwled.c
+        mode/hwled.h
 
         # DIO
-        mode/dio.h mode/dio.c
+        mode/dio.h
+        mode/dio.c
 
         # DUMMY MODE
-        mode/dummy1.c mode/dummy1.h
+        mode/dummy1.c
+        mode/dummy1.h
 
         # UI
-        ui/ui_button.c ui/ui_button.h
-        ui/ui_cmdln.c ui/ui_cmdln.h
-        ui/ui_process.h ui/ui_process.c
+        ui/ui_button.c
+        ui/ui_button.h
+        ui/ui_cmdln.c
+        ui/ui_cmdln.h
+        ui/ui_process.h
+        ui/ui_process.c
         ui/ui_flags.h
-        ui/ui_parse.c ui/ui_parse.h
-        ui/ui_prompt.h ui/ui_prompt.c
-        ui/ui_mode.c ui/ui_mode.h
-        ui/ui_display.c ui/ui_display.h
-        ui/ui_info.h ui/ui_info.c
-        ui/ui_format.c ui/ui_format.c
-        ui/ui_init.c ui/ui_init.h
-        ui/ui_const.h ui/ui_const.c
-        ui/ui_config.h ui/ui_config.c
-        ui/ui_help.c ui/ui_help.h
-        ui/ui_term.c ui/ui_term.h
-        ui/ui_statusbar.c ui/ui_statusbar.h
-        debug.c debug.h
+        ui/ui_parse.c
+        ui/ui_parse.h
+        ui/ui_prompt.h
+        ui/ui_prompt.c
+        ui/ui_mode.c
+        ui/ui_mode.h
+        ui/ui_display.c
+        ui/ui_display.h
+        ui/ui_info.h
+        ui/ui_info.c
+        ui/ui_format.c
+        ui/ui_format.c
+        ui/ui_init.c
+        ui/ui_init.h
+        ui/ui_const.h
+        ui/ui_const.c
+        ui/ui_config.h
+        ui/ui_config.c
+        ui/ui_help.c
+        ui/ui_help.h
+        ui/ui_term.c
+        ui/ui_term.h
+        ui/ui_statusbar.c
+        ui/ui_statusbar.h
+        debug.c
+        debug.h
 
         # JSON parser for saved settings
-        mjson/mjson.h mjson/mjson.c
+        mjson/mjson.h
+        mjson/mjson.c
 
         # syntax and commands
-        syntax.h syntax.c syntax_struct.h
-        opt_args.h command_attributes.h bytecode.h
+        syntax.h
+        syntax.c
+        syntax_struct.h
+        opt_args.h
+        command_attributes.h
+        bytecode.h
 
         # FATfs
-        fatfs/diskio.c fatfs/diskio.h fatfs/ff.c fatfs/ff.h fatfs/ffconf.h fatfs/ffsystem.c fatfs/ffunicode.c
+        fatfs/diskio.c
+        fatfs/diskio.h
+        fatfs/ff.c
+        fatfs/ff.h
+        fatfs/ffconf.h
+        fatfs/ffsystem.c
+        fatfs/ffunicode.c
 
         # translations
-        translation/base.h translation/base.c
-        translation/en-us.h translation/zh-cn.h translation/pl-pl.h
+        translation/base.h
+        translation/base.c
+        translation/en-us.h
+        translation/zh-cn.h
+        translation/pl-pl.h
 
         # binary mode
-        binmode/binmodes.c binmode/binmodes.h binmode/binio.c binmode/binio.h  
-        binmode/binio_helpers.c binmode/binio_helpers.h
-        mode/binloopback.c mode/binloopback.h
-        binmode/logicanalyzer.h binmode/logicanalyzer.c binmode/sump.c binmode/sump.h
-        binmode/dirtyproto.c binmode/dirtyproto.h
-        lib/arduino-ch32v003-swio/arduino_ch32v003.c lib/arduino-ch32v003-swio/arduino_ch32v003.h
-        lib/arduino-ch32v003-swio/swio.h lib/arduino-ch32v003-swio/swio.c     
-        lib/picorvd/picoswio.c lib/picorvd/picoswio.h lib/picorvd/debug_defines.h
+        binmode/binmodes.c
+        binmode/binmodes.h
+        binmode/binio.c
+        binmode/binio.h
+        binmode/binio_helpers.c
+        binmode/binio_helpers.h
+        mode/binloopback.c
+        mode/binloopback.h
+        binmode/logicanalyzer.h
+        binmode/logicanalyzer.c
+        binmode/sump.c
+        binmode/sump.h
+        binmode/dirtyproto.c
+        binmode/dirtyproto.h
+        lib/arduino-ch32v003-swio/arduino_ch32v003.c
+        lib/arduino-ch32v003-swio/arduino_ch32v003.h
+        lib/arduino-ch32v003-swio/swio.h
+        lib/arduino-ch32v003-swio/swio.c
+        lib/picorvd/picoswio.c
+        lib/picorvd/picoswio.h
+        lib/picorvd/debug_defines.h
+
 
         # displays
-        displays.c displays.h display/default.c display/default.h
-        ui/ui_lcd.c ui/ui_lcd.h display/scope.h display/scope.c
-        font/font.h font/hunter-14pt-19h15w.h font/hunter-12pt-16h13w.h font/hunter-20pt-21h21w.h
-        font/hunter-23pt-24h24w.h font/background.h font/background_image_v4.h
+        displays.c
+        displays.h
+        display/default.c
+        display/default.h
+        ui/ui_lcd.c
+        ui/ui_lcd.h
+        display/scope.h
+        display/scope.c
+        font/font.h
+        font/hunter-14pt-19h15w.h
+        font/hunter-12pt-16h13w.h
+        font/hunter-20pt-21h21w.h
+        font/hunter-23pt-24h24w.h
+        font/background.h
+        font/background_image_v4.h
 
         # USB
-        queue.c queue.h
-        usb_tx.c usb_tx.h usb_rx.c usb_rx.h
-        msc_disk.c msc_disk.h usb_descriptors.c
+        queue.c
+        queue.h
+        usb_tx.c
+        usb_tx.h
+        usb_rx.c
+        usb_rx.h
+        msc_disk.c
+        msc_disk.h
+        usb_descriptors.c
 )
 set(bp5_rev10
-        platform/bpi-rev10.h platform/bpi-rev10.c 
-        #nand flash management and dhara
-        dhara/bytes.h dhara/error.c dhara/error.h dhara/journal.c dhara/journal.h dhara/map.c dhara/map.h dhara/nand.c dhara/nand.h
-        nand/nand_ftl_diskio.c nand/nand_ftl_diskio.h nand/spi.c nand/spi.h nand/spi_nand.c nand/spi_nand.h 
-        nand/sys_time.c nand/sys_time.h
+        platform/bpi-rev10.h
+        platform/bpi-rev10.c
+
+        # nand flash management and dhara
+        dhara/bytes.h
+        dhara/error.c
+        dhara/error.h
+        dhara/journal.c
+        dhara/journal.h
+        dhara/map.c
+        dhara/map.h
+        dhara/nand.c
+        dhara/nand.h
+
+        nand/nand_ftl_diskio.c
+        nand/nand_ftl_diskio.h
+        nand/spi.c
+        nand/spi.h
+        nand/spi_nand.c
+        nand/spi_nand.h
+        nand/sys_time.c
+        nand/sys_time.h
 )
 
 add_executable(bus_pirate5_rev8

--- a/commands.c
+++ b/commands.c
@@ -33,6 +33,7 @@
 #include "commands/global/script.h"
 #include "commands/global/tutorial.h"
 #include "commands/global/button_scr.h"
+#include "commands/global/bigbuffer_test.h"
 #include "commands/global/smps.h"
 #include "commands/global/cls.h"
 #include "binmode/logicanalyzer.h"
@@ -87,6 +88,7 @@ const struct _command_struct commands[]=
     {"cls", true, &ui_display_clear, 0x00},
     {"smps", true, &smps_handler, 0x00},
     {"binmode", true, &cmd_binmode_handler, 0x00},
+    {"bb_test", true, &bigbuff_test_handler, 0x00},
 };
 
 const uint32_t commands_count=count_of(commands);

--- a/commands/global/bigbuffer_test.c
+++ b/commands/global/bigbuffer_test.c
@@ -1,0 +1,536 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "pico/stdlib.h"
+#include "pirate.h"
+#include "bigbuffer_test.h"
+#include "pirate/mem.h"
+
+
+#define DEBUG_BBTEST_MASK_NONE       0x00u
+#define DEBUG_BBTEST_MASK_FAILURE    0x01u
+#define DEBUG_BBTEST_MASK_FAIL_STATE 0x02u
+#define DEBUG_BBTEST_MASK_SUCCESS    0x10u
+#define DEBUG_BBTEST_MASK_VERBOSE    0x20u
+#define DEBUG_BBTEST_MASK_FN_ENTRY   0x40u
+#define DEBUG_BBTEST_MASK_FN_EXIT    0x80u
+
+#define DEBUG_BBTEST ( DEBUG_BBTEST_MASK_FAILURE | DEBUG_BBTEST_MASK_FAIL_STATE | DEBUG_BBTEST_MASK_SUCCESS )
+
+#if 1 // debug output macros
+
+    #if defined(DEBUG_BBTEST) && (DEBUG_BBTEST & DEBUG_BBTEST_MASK_FN_ENTRY)
+        #define X_FN_ENTRY(fmt, ...) printf("bb_tst @ %3d: >>>>> %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_FN_ENTRY(fmt, ...)
+    #endif
+    #if defined(DEBUG_BBTEST) && (DEBUG_BBTEST & DEBUG_BBTEST_MASK_FN_EXIT)
+        #define X_FN_EXIT(fmt, ...)  printf("bb_tst @ %3d: <<<<< %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_FN_EXIT(fmt, ...)
+    #endif
+    #if defined(DEBUG_BBTEST) && (DEBUG_BBTEST & DEBUG_BBTEST_MASK_VERBOSE)
+        #define X_DBGP(fmt, ...)    printf("bb_tst @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_DBGP(fmt, ...)
+    #endif
+    #if defined(DEBUG_BBTEST) && (DEBUG_BBTEST & DEBUG_BBTEST_MASK_FAILURE)
+        #if (DEBUG_BBTEST & DEBUG_BBTEST_MASK_FAIL_STATE)
+            #define X_FAILURE(fmt, ...)                                              \
+                do {                                                                     \
+                    printf("bb_tst @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+                    BigBuffer_DebugDumpCurrentState(true); printf("\n");                 \
+                } while (0);
+        #else
+            #define X_FAILURE(fmt, ...)                                              \
+                do {                                                                     \
+                    printf("bb_tst @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+                } while (0);
+        #endif
+    #else
+        #define X_FAILURE(fmt, ...)
+    #endif
+    #if defined(DEBUG_BBTEST) && (DEBUG_BBTEST & DEBUG_BBTEST_MASK_SUCCESS)
+        #define X_SUCCESS(fmt, ...) printf("bb_tst @ %3d: SUCCESS " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_SUCCESS(fmt, ...)
+    #endif
+
+    #define X_TMP(fmt, ...) printf("bb_tst @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+
+#endif
+
+// define function pointer that matches the signature of _test_temporary_allocations_1
+typedef bool (*bool_parameter_test_fn_t)(bool reversed_free_order);
+// define function pointer that matches the signature of BigBuffer_AllocateTemporary / BigBuffer_AllocateLongLived
+typedef void * (*alloc_fn_t)(size_t, size_t, big_buffer_owner_t);
+
+typedef struct _allocation_iteration_t {
+    size_t alloc; // how many bytes to allocate
+    size_t align; // required alignment
+    size_t count; // how many to allocate
+    uintptr_t from_long_lived : 1; // if true, allocate from long-lived memory
+    uintptr_t expect_failure  : 1; // if true, expect this to fail
+    uintptr_t : ((sizeof(uintptr_t)*8) - 2); // explicitly RFU
+} allocation_iteration_t;
+
+typedef struct _bool_test_t {
+    bool_parameter_test_fn_t test_fn;
+    const char * fn_name;
+} bool_test_t;
+#define X_BOOL_TEST(fn) { .test_fn = fn, .fn_name = #fn }
+
+
+
+#define X_MAXIMUM_ALLOCATION_COUNT (32u)
+#define X_MAXIMUM_LONG_LIVED_BYTE_COUNT (8u * 1024u)
+
+
+static bool _verify_no_allocations(void) {
+    bool success = true;
+
+    big_buffer_general_state_t state = {0};
+    BigBuffer_DebugGetStatistics(&state);
+    if (state.temp_allocations_count != 0) {
+        X_FAILURE("Temp allocations not freed");
+        success = false;
+    }
+    if (state.long_lived_allocations_count != 0) {
+        X_FAILURE("Long-lived allocations not freed");
+        success = false;
+    }
+    return success;
+}
+
+static bool _test_temporary_allocations_1(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = true;
+    void * allocations[32] = {NULL};
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("_verify_no_allocations() failed at function entry");
+        }
+    }
+
+    // up to 32 allocations, and 136k available to allocate
+    // 31 * 4k = 124k in "spacer" allocations
+    // This leaves 12k for the other 32 allocations
+    // 12k / 32 = 256+128 bytes per allocation
+    for (int i = 0; success && (i < 32); ++i) {
+
+        void* spacer = NULL;
+        if (i != 31) {
+            spacer = BigBuffer_AllocateTemporary(4096, 1, BP_BIG_BUFFER_OWNER_SELFTEST);
+            if (spacer == NULL) {
+                X_FAILURE("Unable to allocate spacer buffer idx %d / 32", i);
+                BigBuffer_DebugDumpCurrentState(true); printf("\n");
+                success = false;
+                break; // out of for loop ...
+            }
+        }
+        allocations[i] = BigBuffer_AllocateTemporary(384, 1, BP_BIG_BUFFER_OWNER_SELFTEST);
+        if (allocations[i] == NULL) {
+            X_FAILURE("Unable to allocate temporary buffer idx %d / 32", i);
+            BigBuffer_DebugDumpCurrentState(true); printf("\n");
+            success = false;
+            break; // out of for loop ...
+        }
+
+        BigBuffer_Free(spacer, BP_BIG_BUFFER_OWNER_SELFTEST);
+    }
+
+    for (int j = 0; j < 32; ++j) {
+        int idx = reversed_free_order ? (31 - j) : j;
+        BigBuffer_Free(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
+    }
+
+    if (success) {
+        success = _verify_no_allocations();
+    }
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_longlived_allocations_iterations_impl(bool reversed_free_order, allocation_iteration_t iter) {
+
+    bool success = true;
+
+    const size_t total_size = BigBuffer_GetAvailableLongLivedMemory(iter.align);
+    void * allocations[X_MAXIMUM_ALLOCATION_COUNT] = {NULL};
+
+
+    success = _verify_no_allocations();
+    if (!success) {
+        X_FAILURE("(%zd, %zd, %zd) _verify_no_allocations() failed", iter.alloc, iter.align, iter.count);
+    } else if (total_size != X_MAXIMUM_LONG_LIVED_BYTE_COUNT) {
+        X_FAILURE("(%zd, %zd) expected 8k of long-lived memory available, got %zd", iter.alloc, iter.align, total_size);
+        success = false;
+    } else {
+
+        // Hard-coded that total available long-lived memory is 8k ... checked above
+        for (size_t i = 0; success && (i < iter.count); ++i) {
+            void * allocation = BigBuffer_AllocateLongLived(iter.alloc, iter.align, BP_BIG_BUFFER_OWNER_SELFTEST);
+            if (allocation == NULL) {
+                X_FAILURE("(%zd, %zd) Unable to allocate long-lived buffer %zd", iter.alloc, iter.align, i);
+                success = false;
+                break; // out of allocation for loop `i` ...
+            }
+            allocations[i] = allocation;
+        }
+    }
+
+    // All available memory (for given alignment) should have been allocated.
+    // Verify this...
+    if (success) {
+        size_t remaining_available = BigBuffer_GetAvailableLongLivedMemory(iter.align);
+        if (remaining_available != 0) {
+            X_FAILURE("(%zd, %zd, %zd) Expected no additional allocations available, got %zd", iter.alloc, iter.align, iter.count, remaining_available);
+            success = false;
+        }
+    }
+
+    // Free all allocations
+    for (size_t i = 0; i < count_of(allocations); ++i) {
+        size_t idx = reversed_free_order ? (count_of(allocations) - 1u - i) : i;
+        BigBuffer_Free(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
+    }
+
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("(%zd, %zd, %zd) _verify_no_allocations() failed", iter.alloc, iter.align, iter.count);
+        }
+    }
+    return success;
+}
+static bool _test_longlived_allocations_iterations(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = true;
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("_verify_no_allocations() failed at function entry");
+        }
+    }
+
+    static const allocation_iteration_t iterations[] = {
+        {  256u,    1u, 32u, true },
+        {  512u,    1u, 16u, true },
+        { 1024u,    1u,  8u, true },
+        { 2048u,    1u,  4u, true },
+        { 4096u,    1u,  2u, true },
+        { 8192u,    1u,  1u, true },
+    };
+    void * allocations[32u] = {NULL};
+
+    for (size_t j = 0; success && (j < count_of(iterations)); ++j) {
+
+        allocation_iteration_t iter = iterations[j];
+        assert(iter.count <= count_of(allocations));
+
+        for (; iter.align <= (32u*1024); iter.align <<= 1) {
+            if (iter.align > iter.alloc) {
+                iter.count >>= 1;
+            }
+            if (iter.count == 0) {
+                // special case for when exceed available memory space
+                // because the long-lived allocations can be up to 128k aligned (even if only 8k size)
+                iter.count = 1;
+            }
+            success = _test_longlived_allocations_iterations_impl(reversed_free_order, iter);
+            // if successful, print a one-line "SUCCESS" message ... helps anchor last successful test in output
+            if (success) {
+                X_SUCCESS("LL_Alloc1(%s %4zd @ %6zd alignment, %zd count", reversed_free_order ? "true): " : "false):" , iter.alloc, iter.align, iter.count);
+            }
+        } // next alignment / count
+
+        // end of all alignments possible for this iteration....
+    }
+    
+    if (success) {
+        X_SUCCESS("LL_Alloc1(%s)   <----", reversed_free_order ? "true" : "false");
+    } else {
+        X_FAILURE("LL_Alloc1(%s)   <----", reversed_free_order ? "true" : "false");
+    }
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_allocation_iterations(const allocation_iteration_t * iterations, size_t iter_count, bool reversed_free_order) {
+    X_FN_ENTRY("(%p, %zd, %s)", iterations, iter_count, reversed_free_order ? "true" : "false");
+
+    void * allocations[X_MAXIMUM_ALLOCATION_COUNT] = {NULL}; // could be a VLA, but reduces portability
+    size_t used_allocations = 0u;
+
+    bool success = true;
+    if (iter_count > X_MAXIMUM_ALLOCATION_COUNT) {
+        X_FAILURE("count %zd exceeds maximum of %d", iter_count, X_MAXIMUM_ALLOCATION_COUNT);
+        success = false;
+    } else if ((iterations == NULL) && (iter_count != 0u)) {
+        X_FAILURE("non-zero count %zd with NULL iterations", iter_count);
+        success = false;
+    }
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("ERROR: _verify_no_allocations() failed at function entry\n");
+        }
+    }
+
+    for (size_t row = 0; success && (row < iter_count); ++row) {
+
+        const allocation_iteration_t * iter = &iterations[row];
+        alloc_fn_t xalloc = iter->from_long_lived ? BigBuffer_AllocateLongLived : BigBuffer_AllocateTemporary;
+        for (size_t x = 0; success && (x < iter->count); ++x) {
+            if ((!iter->expect_failure) && (used_allocations >= X_MAXIMUM_ALLOCATION_COUNT)) {
+                X_FAILURE("Exceeded maximum of %zd tracked allocations", X_MAXIMUM_ALLOCATION_COUNT);
+                success = false;
+                break; // out of 'x' for loop ...
+            }
+            void * tmp = xalloc(iter->alloc, iter->align, BP_BIG_BUFFER_OWNER_SELFTEST);
+            if ((iter->expect_failure) && (tmp != NULL)) {
+                X_FAILURE("Alloc Iter Row %zd, alloc %zd/%zd: Success when expected failure", row, x, iter->count);
+                BigBuffer_Free(tmp, BP_BIG_BUFFER_OWNER_SELFTEST); // have to free it, else would leak memory b/c not guaranteed to have space to store it
+                success = false;
+                break; // out of 'x' for loop ...
+            } else if ((!iter->expect_failure) && (tmp == NULL)) {
+                X_FAILURE("Alloc Iter Row %zd, alloc %zd/%zd: Failed when expected success", row, x, iter->count);
+                success = false;
+                break; // out of 'x' for loop ...
+            } else if (!iter->expect_failure) {
+                allocations[used_allocations] = tmp;
+                ++used_allocations;
+            }
+        }
+
+    }
+
+    // free all allocations
+    for (size_t j = 0; j < X_MAXIMUM_ALLOCATION_COUNT; ++j) {
+        size_t idx = reversed_free_order ? (X_MAXIMUM_ALLOCATION_COUNT - 1u - j) : j;
+        BigBuffer_Free(allocations[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
+    }
+
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("ERROR: _verify_no_allocations() failed at function exit\n");
+        }
+    }
+    X_FN_EXIT("(%p, %zd, %s) --> %s", iterations, iter_count, reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+
+/// @brief Test alternating allocations from long-lived and temporary memory pools
+/// @details Allocates total of 132k as temporary memory (128k + 4k into long-lived space)
+///          and 4k as long-lived memory.  Allocations alternate between temporary pool
+///          and long-lived pools.  Verifies that all memory has been fully allocated.
+static const allocation_iteration_t iterations_1[] = {
+    { .alloc = 1024u * 126u, .align = 1024u * 32u, .count = 1, .from_long_lived = false, .expect_failure = false }, //   0..125
+    { .alloc = 1024u *   3u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = false }, // 133..135
+    { .alloc = 1024u *   1u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = false }, // 126..126
+    { .alloc = 1024u *   1u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = false }, // 132..132
+    { .alloc = 1024u *   5u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = false }, // 127..131
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = true  }, // all memory already allocated
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = true  }, // all memory already allocated
+};
+
+/// @brief Allocates all temporary memory, then all long-lived memory.
+/// @details Verifies test framework can allocate multiple times per row.
+///          Allocates 4x 32k buffers from temporary memory (similar to how scope might allocate).
+///          Then allocates 8x 1k buffers from long-lived memory, before verifying all memory is allocated.
+static const allocation_iteration_t iterations_2[] = {
+    { .alloc = 1024u *  32u, .align = 1024u * 32u, .count = 4, .from_long_lived = false, .expect_failure = false }, //   0..127
+    { .alloc = 1024u *   1u, .align = 1024u *  1u, .count = 8, .from_long_lived = true,  .expect_failure = false }, // 128..135
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = true  }, // all memory already allocated
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = true  }, // all memory already allocated
+};
+/// @brief Allocates irregular (prime number) bytes of memory with various alignments.
+/// @details This test verifies three properties:
+///          1. allocations remain properly aligned, even when gaps are necessary
+///          2. allocation of last bytes of memory (unaligned) can be from TEMPORARY memory
+///          3. allocations of small amounts of memory (which would fit into the gaps) fail
+///             when the two watermarks meet ... i.e. this is a specialized allocator, not
+///             a fully featured heap.
+static const allocation_iteration_t iterations_3[] = {
+    { .alloc =         257u, .align =        256u, .count = 2, .from_long_lived = false, .expect_failure = false }, //   0..  0
+    { .alloc = 1024u *   1u, .align = 1024u *  1u, .count = 4, .from_long_lived = true,  .expect_failure = false }, // 132..135
+    { .alloc =        2039u, .align = 1024u * 32u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  32.. 33
+    { .alloc =        8181u, .align = 1024u *  2u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  34.. 41
+    { .alloc =       44497u, .align = 1024u *  4u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  44.. 87
+    { .alloc =       44497u, .align = 1024u *  4u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  88..131
+    { .alloc =         559u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = false }, //      131 (leftovers above the 44497u ... )
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = true  }, // watermarks met, so all memory already allocated even though gaps exist
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = true  }, // watermarks met, so all memory already allocated even though gaps exist
+};
+/// @brief Allocates irregular (prime number) bytes of memory with various alignments.
+/// @details This test verifies three properties:
+///          1. allocations remain properly aligned, even when gaps are necessary
+///          2. allocation of last bytes of memory (unaligned) can be from LONG-LIVED memory
+///          3. allocations of small amounts of memory (which would fit into the gaps) fail
+///             when the two watermarks meet ... i.e. this is a specialized allocator, not
+///             a fully featured heap.
+static const allocation_iteration_t iterations_4[] = { // Same as above, except leftovers allocated as long-lived
+    { .alloc =         257u, .align =        256u, .count = 2, .from_long_lived = false, .expect_failure = false }, //   0..  0
+    { .alloc = 1024u *   1u, .align = 1024u *  1u, .count = 4, .from_long_lived = true,  .expect_failure = false }, // 132..135
+    { .alloc =        2039u, .align = 1024u * 32u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  32.. 33
+    { .alloc =        8181u, .align = 1024u *  2u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  34.. 41
+    { .alloc =       44497u, .align = 1024u *  4u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  44.. 87
+    { .alloc =       44497u, .align = 1024u *  4u, .count = 1, .from_long_lived = false, .expect_failure = false }, //  88..131
+    { .alloc =         559u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = false }, //      131 (leftovers above the 44497u ... )
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = true,  .expect_failure = true  }, // watermarks met, so all memory already allocated even though gaps exist
+    { .alloc =           1u, .align =          1u, .count = 1, .from_long_lived = false, .expect_failure = true  }, // watermarks met, so all memory already allocated even though gaps exist
+};
+
+static bool _test_mixed_allocations_1a(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = true;
+    if (success) {
+        success = _verify_no_allocations();
+        if (!success) {
+            X_FAILURE("ERROR: _verify_no_allocations() failed at function entry\n");
+        }
+    }
+
+    // N.B. - this function presumes .count == 1 for each index
+    void * p[count_of(iterations_1)] = {NULL};
+
+    for (size_t i = 0; success && (i < count_of(iterations_1)); ++i) {
+        const allocation_iteration_t * iter = &iterations_1[i];
+        if (iter->from_long_lived) {
+            p[i] = BigBuffer_AllocateLongLived(iter->alloc, iter->align, BP_BIG_BUFFER_OWNER_SELFTEST);
+        } else {
+            p[i] = BigBuffer_AllocateTemporary(iter->alloc, iter->align, BP_BIG_BUFFER_OWNER_SELFTEST);
+        }
+        if (iter->expect_failure) {
+            if (p[i] != NULL) {
+                X_FAILURE("Expected allocation failure for iteration %zd", i);
+                success = false;
+                break; // out of for loop ...
+            }
+        } else {
+            if (p[i] == NULL) {
+                X_FAILURE("Unexpected allocation failure for iteration %zd", i);
+                success = false;
+                break; // out of for loop ...
+            }
+        }
+    }
+
+    // reset state by free'ing all the allocations 
+    for (size_t i = 0; i < count_of(iterations_1); ++i) {
+        size_t idx = reversed_free_order ? (count_of(iterations_1) - 1u - i) : i;
+        BigBuffer_Free(p[idx], BP_BIG_BUFFER_OWNER_SELFTEST);
+        p[idx] = NULL;
+    }
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_mixed_allocations_1b(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = _test_allocation_iterations(iterations_1, count_of(iterations_1), reversed_free_order);
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_mixed_allocations_2(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = _test_allocation_iterations(iterations_2, count_of(iterations_2), reversed_free_order);
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_mixed_allocations_3(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = _test_allocation_iterations(iterations_3, count_of(iterations_3), reversed_free_order);
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+static bool _test_mixed_allocations_4(bool reversed_free_order) {
+    X_FN_ENTRY("(%s)", reversed_free_order ? "true" : "false");
+
+    bool success = _test_allocation_iterations(iterations_4, count_of(iterations_4), reversed_free_order);
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+
+static const bool_test_t bool_tests[] = {
+    X_BOOL_TEST(_test_temporary_allocations_1),
+    X_BOOL_TEST(_test_longlived_allocations_iterations),
+    X_BOOL_TEST(_test_mixed_allocations_1a),
+    X_BOOL_TEST(_test_mixed_allocations_1b),
+    X_BOOL_TEST(_test_mixed_allocations_2),
+    X_BOOL_TEST(_test_mixed_allocations_3),
+    X_BOOL_TEST(_test_mixed_allocations_4),
+};
+
+static bool _dispatch(void)
+{
+    bool success = true;
+    X_FN_ENTRY("");
+
+    if (success) {
+        success = _verify_no_allocations();
+        if (success) {
+            X_DBGP();
+            X_DBGP("Initial State:");
+            BigBuffer_DebugDumpCurrentState(true);
+            X_DBGP();
+        }
+    }
+    
+    for (size_t idx = 0; idx < count_of(bool_tests); ++idx) {
+        const bool_test_t * t = &bool_tests[idx];
+        if (success) {
+            success = t->test_fn(true);
+            if (success) {
+                X_SUCCESS("%s(%s)", t->fn_name, "true");
+            } else {
+                X_FAILURE("%s(%s)", t->fn_name, "true");
+            }
+        }
+        if (success) {
+            success = t->test_fn(false);
+            if (success) {
+                X_SUCCESS("%s(%s)", t->fn_name, "false");
+            } else {
+                X_FAILURE("%s(%s)", t->fn_name, "false");
+            }
+        }
+    }
+
+    X_FN_EXIT("(%s) --> %s", reversed_free_order ? "true" : "false", success ? "true" : "false");
+    return success;
+}
+
+
+
+
+void bigbuff_test_handler(command_result_t *res_out)
+{
+    X_FN_ENTRY("()");
+
+    // This function is called when the user types the command "bigbuff_test"
+    // It is a simple test function that exercises the big buffer allocation
+    // and free functions, specifically focusing on ensuring edge cases are
+    // handled.
+    memset(res_out, 0, sizeof(command_result_t));
+    bool success = _dispatch();
+    res_out->success = success;
+    res_out->error   = !success;
+
+    X_FN_EXIT("() --> %s", success ? "true" : "false");
+    return;
+}
+
+

--- a/commands/global/bigbuffer_test.h
+++ b/commands/global/bigbuffer_test.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "../../opt_args.h"
+
+void bigbuff_test_handler(command_result_t *res);

--- a/commands/global/dummy.c
+++ b/commands/global/dummy.c
@@ -54,7 +54,7 @@ static const struct ui_help_options options[]=
     {0,"-f",T_HELP_DUMMY_FILE_FLAG}, //-f flag, a file name string    
 };
 
-void dummy_handler(struct command_result *res)
+void dummy_handler(command_result_t *res)
 {
     uint32_t value; //somewhere to keep an integer value
     char file[13]; //somewhere to keep a string value (8.3 filename + 0x00 = 13 characters max)
@@ -248,10 +248,10 @@ void dummy_handler(struct command_result *res)
         printf("Hint: use the rm %s to delete\r\n", file);
     }
 
-    //bonus: you might notice we are handed a struct of type command_result from the command parser
+    //bonus: you might notice we are handed a struct of type command_result_t from the command parser
     // this is a way to return errors and other (future) data
     //I'm not sure it actually does anything right now, but it's there for future use
-    //command_result.error=true; //set the error flag
+    //command_result_t.error=true; //set the error flag
 
     //to set an error back to the command line parser and indicate an error for chaining purposes (; || &&)
     //system_config.error=true; //set the error flag

--- a/commands/global/dummy.h
+++ b/commands/global/dummy.h
@@ -1,1 +1,1 @@
-void dummy_handler(struct command_result *res);
+void dummy_handler(command_result_t *res);

--- a/commands/global/i_info.c
+++ b/commands/global/i_info.c
@@ -90,9 +90,10 @@ void i_info_handler(struct command_result *res){
 	//config file loaded
 	printf("\r\n%s%s:%s %s\r\n", ui_term_color_info(), t[T_CONFIG_FILE], ui_term_color_reset(), system_config.config_loaded_from_file?t[T_LOADED]:t[T_NOT_DETECTED]);
 
-	if(system_config.big_buffer_owner!=BP_BIG_BUFFER_NONE){
-		printf("%sBig buffer allocated to:%s #%d\r\n", ui_term_color_info(), ui_term_color_reset(), system_config.big_buffer_owner);
-	}
+	// TODO: Expose API for statistics on BigBuffer usage
+	// if(system_config.big_buffer_owner!=BP_BIG_BUFFER_OWNER_NONE){
+	// 	printf("%sBig buffer allocated to:%s #%d\r\n", ui_term_color_info(), ui_term_color_reset(), system_config.big_buffer_owner);
+	// }
 
 
 	// Installed modes

--- a/display/scope.c
+++ b/display/scope.c
@@ -84,7 +84,7 @@ static uint8_t scope_stopped = 1;
 static uint8_t scope_subsystem_stopped = 1;
 volatile uint8_t scope_running = 0;
 static volatile uint8_t scope_stop_waiting = 0;
-static unsigned char *fb=0;
+static unsigned char *fb=0; // framebuffer ... allocated when mode is entered
 typedef enum { SMODE_ONCE, SMODE_NORMAL, SMODE_AUTO } SCOPE_MODE;
 static SCOPE_MODE scope_mode=SMODE_ONCE;
 typedef enum { TRIGGER_POS, TRIGGER_NEG, TRIGGER_NONE, TRIGGER_BOTH } TRIGGER_TYPE;
@@ -198,8 +198,8 @@ void scope_cleanup(void)
 		scope_shutdown(1);
 	}
 	scope_subsystem_stopped = 1;
-	mem_free(fb);
-	fb = 0;
+	BigBuffer_Free(fb, BP_BIG_BUFFER_OWNER_SCOPE);
+	fb = NULL;
 	capture_buffer = 0;
 	display_buffer = 0;
 	display = 0;
@@ -233,25 +233,23 @@ void scope_periodic(void)
 
 uint32_t scope_setup(void)
 {
-	uint8_t *x;
-	
-	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_SCOPE);
+	uint8_t * x = BigBuffer_AllocateTemporary(MALLOC_SIZE, 4, BP_BIG_BUFFER_OWNER_SCOPE);
 	if (!x) {
 		printf("couldn't allocate %d bytes, scope mode broken\r\n", MALLOC_SIZE);
 		return 0;
 	}
-	mem_free(x);
+	BigBuffer_Free(x, BP_BIG_BUFFER_OWNER_SCOPE);
 	display = 1;
 	return 1;
 }
 
 uint32_t scope_setup_exc(void)
 {
-	uint8_t *x;
-	
-	x = mem_alloc(MALLOC_SIZE, BP_BIG_BUFFER_SCOPE);
-	if (!x)
+	uint8_t * x = BigBuffer_AllocateTemporary(MALLOC_SIZE, 4, BP_BIG_BUFFER_OWNER_SCOPE);
+	if (!x) {
+		printf("couldn't allocate %d bytes, scope mode broken\r\n", MALLOC_SIZE);
 		return 0;
+	}
 	fb = x;
 	display_buffer =          (uint16_t *)&x[VS*HS/2]; // 2 byte aligned
 	capture_buffer = (volatile uint16_t *)&x[VS*HS/2+2*BUFFERS*CAPTURE_DEPTH]; // 2 byte aligned

--- a/displays.h
+++ b/displays.h
@@ -21,8 +21,8 @@ typedef struct _display
 	void (*display_settings)(void);		// display settings 
 	void (*display_help)(void);			// display protocol specific help
 	char display_name[10];				// friendly name (promptname)
-	uint32_t (*display_command)(struct command_result *result); // per mode command parser - ignored if 0
-	void (*display_lcd_update)(uint32_t flags);	// replacement for ui_lcd_update if non-0
+	uint32_t (*display_command)(struct command_result *result); // per mode command parser - ignored if null
+	void (*display_lcd_update)(uint32_t flags);	// replacement for ui_lcd_update if non-null
 } _display;
 
 extern struct _display displays[MAXDISPLAY];

--- a/opt_args.h
+++ b/opt_args.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define MAX_COMMAND_LENGTH 10
 
 typedef struct command_result {
@@ -8,7 +10,7 @@ typedef struct command_result {
 	bool default_value;
 	bool error;
     bool help_flag;
-} command_result;
+} command_result_t;
 
 struct _command_struct
 {

--- a/pirate.h
+++ b/pirate.h
@@ -49,8 +49,6 @@
 //#define		DISPLAY_USE_HD44780	// is always enabled
 //#define		DISPLAY_USE_ST7735
 
-#define BIG_BUFFER_SIZE (128 * 1024)
-
 // include platform
 #ifndef BP5_REV
     #error "No /platform/ file included in pirate.h"

--- a/pirate/mem.c
+++ b/pirate/mem.c
@@ -1,40 +1,702 @@
 /**
  * @file		mem.c
- * @author		Andrew Loebs
+ * @author		Henry Gabryjelski
  * @brief		Implementation file of the memory management module
- *
- */
+ * @details     Big Buffer Memory Layout:
+ *              ( high )  __BIG_BUFFER_END__     -> Pointer just past the end of Big Buffer
+ *              ( ...  )  ...                    -> Long-lived allocations (if any)
+ *              ( v--^ )  s_State.high_watermark -> Pointer just past the last unallocated
+ *                                                  memory, equal to low water mark if all
+ *                                                  all memory allocated, or __BIG_BUFFER_END__
+ *                                                  -8k (long-lived allocations)
+ *              ( ...  )  ...                    -> Unallocated memory ...
+ *                                                Long-lived allocations grow from top
+ *                                                while temporary allocations grow from bottom
+ *              ( v--^ )  s_State.low_watermark  -> Pointer to the first unused byte of memory
+ *              ( ...  )  ...                    -> Temporary memory allocations
+ *              ( low  )  __BIG_BUFFER_START__   -> Guaranteed to be 32k aligned
+ **/
+
+
 // Modified by Ian Lesnet 18 Dec 2023 for Bus Pirate 5
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // memset()
+#include <stdint.h> // uint32_t, uintptr_t, ...
 #include "pico/stdlib.h"
 #include "pirate.h"
 #include "pirate/mem.h"
-#include <stdlib.h>
 #include "system_config.h"
 
-// private variables
-static uint8_t mem_buffer[BIG_BUFFER_SIZE] __attribute__((aligned(32768))); // 128k ... this is 50% of the total RAM!
-static bool allocated = false;
 
-// public function definitions
-uint8_t *mem_alloc(size_t size, uint32_t owner)
-{
-    if (!allocated && size <= sizeof(mem_buffer)) {
-        allocated = true;
-        system_config.big_buffer_owner=owner;
-        return mem_buffer;
+#define DEBUG_BB_MASK_NONE       (0x00u)
+#define DEBUG_BB_MASK_FATAL      (0x01u) // fatal errors, such as memory corruption; Focus is on incorrect use of API
+#define DEBUG_BB_MASK_INVARIANTS (0x02u) // internal inconsistency checks failed; Also fatal, but focus is internal coding errors
+#define DEBUG_BB_MASK_FAILURE    (0x04u) // non-fatal API edge cases that are non-success paths (e.g., allocation request when hit limit of allocations, etc.)
+#define DEBUG_BB_MASK_VERBOSE    (0x08u) // verbose messages
+#define DEBUG_BB_MASK_DUMP       (0x10u) // for APIs that dump internal state
+#define DEBUG_BB_MASK_API_ENTRY  (0x80u)
+#define DEBUG_BB_MASK_API_EXIT   (0x40u)
+#define DEBUG_BIGBUFFER ( DEBUG_BB_MASK_FATAL | DEBUG_BB_MASK_INVARIANTS | DEBUG_BB_MASK_FAILURE | DEBUG_BB_MASK_DUMP )
+//#define DEBUG_BIGBUFFER DEBUG_BB_MASK_NONE
+
+
+
+// #define DEBUG_BIGBUFFER_API_ENTRY // define to enable API entry messages
+// #define DEBUG_BIGBUFFER_API_EXIT  // define to enable API exit messages
+
+// 136k ... 128k contiguous / 32k aligned required by current LA due to DMA engine configuration
+// Plus an extra 8k that are generally safe for long-term allocations
+// Plus an extra 2k for future tracking of allocations
+
+#define BIG_BUFFER_TEMPORARY_BUFFER_KB (128u)
+#define BIG_BUFFER_LONGLIVED_BUFFER_KB (  8u)
+#define BIG_BUFFER_ALIGNMENT_KB        ( 32u)
+#define BIG_BUFFER_SIZE ((BIG_BUFFER_TEMPORARY_BUFFER_KB + BIG_BUFFER_LONGLIVED_BUFFER_KB) * 1024u)
+
+#if 1 // debug output macros
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_API_ENTRY)
+        #define X_API_ENTRY(fmt, ...) printf("BB @ %3d: >>>>> %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_API_ENTRY(fmt, ...)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_API_EXIT)
+        #define X_API_EXIT(fmt, ...)  printf("BB @ %3d: <<<<< %s" fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
+    #else
+        #define X_API_EXIT(fmt, ...)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_FATAL)
+        #define X_FATAL(fmt, ...)                                               \
+            do {                                                                \
+                printf("BB @ %3d: *FATAL* " fmt "\n", __LINE__, ##__VA_ARGS__); \
+                BigBuffer_DebugDumpCurrentState(true);                          \
+                assert(false);                                                  \
+            } while (1)
+    #else
+        #define X_FATAL(fmt, ...)     assert(false)
+    #endif
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_INVARIANTS)
+
+        #define X_CHECK_INVARIANTS()                                                                                         \
+            do {                                                                                                             \
+                big_buffer_invariant_error_flags_t error_flags = BigBuffer_InvariantsFailed();                               \
+                static_assert(BIG_BUFFER_INVARIANT_NONE == 0);                                                               \
+                while (error_flags != 0) {                                                                                   \
+                    printf("BB @ %3d: *FATAL* Invariant failed from %s:%s:%d\n", error_flags, __FILE__, __func__, __LINE__); \
+                    BigBuffer_DebugDumpCurrentState(true);                                                                   \
+                    assert(false);                                                                                           \
+                }                                                                                                            \
+            } while (0)
+
+    #else
+        #define X_CHECK_INVARIANTS()
+    #endif
+
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_FAILURE) // failure messages
+        #define X_FAILURE(fmt, ...)  printf("BB @ %3d: *FAILED* " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_FAILURE(fmt, ...)
+    #endif
+
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_VERBOSE) // verbose messages
+        #define X_DBGP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_DBGP(fmt, ...)
+    #endif
+
+    #if defined(DEBUG_BIGBUFFER) && (DEBUG_BIGBUFFER & DEBUG_BB_MASK_DUMP) // dump messages
+        #define X_DUMP(fmt, ...)     printf("BB @ %3d: " fmt "\n", __LINE__, ##__VA_ARGS__)
+    #else
+        #define X_DUMP(fmt, ...)
+    #endif
+#endif
+
+typedef enum _big_buffer_invariant_error_flags {
+    BIG_BUFFER_INVARIANT_NONE = 0,
+    BIG_BUFFER_INVARIANT_CONSTANT_BIGBUF_POINTER           = 0x0001,
+    BIG_BUFFER_INVARIANT_CONSTANT_BIGBUF_SIZE              = 0x0002,
+    BIG_BUFFER_INVARIANT_CONSTANT_LONGTERM_MARKER          = 0x0004,
+    BIG_BUFFER_INVARIANT_WATERMARKS_CROSSED                = 0x0008,
+    BIG_BUFFER_INVARIANT_LOW_WATERMARK_VALUE_TOO_LOW       = 0x0010,
+    BIG_BUFFER_INVARIANT_LOW_WATERMARK_VALUE_TOO_HIGH      = 0x0020,
+    BIG_BUFFER_INVARIANT_HIGH_WATERMARK_VALUE_TOO_LOW      = 0x0040,
+    BIG_BUFFER_INVARIANT_HIGH_WATERMARK_VALUE_TOO_HIGH     = 0x0080,
+
+    BIG_BUFFER_INVARIANT_LOW_WATERMARK_AT_ZERO_TEMP_ALLOCS = 0x0100,
+    BIG_BUFFER_INVARIANT_HIGH_WATERMARK_WITH_NO_ALLOCS     = 0x0200,
+
+    BIG_BUFFER_INVARIANT_UNINITIALIZED_BUT_STORING_VALUES  = 0x8000,
+} big_buffer_invariant_error_flags_t;
+
+
+// Why?  Currently, the way the LA DMA works, it requires 4x 32k-aligned, contiguously allocated buffers.
+// AKA: a 128k contiguous, 32k-aligned buffer
+static_assert(BIG_BUFFER_TEMPORARY_BUFFER_KB >= 128u, "BigBuffer size must be at least 128k for LA DMA architecture");
+static_assert(BIG_BUFFER_ALIGNMENT_KB        >=  32u, "BigBuffer alignment must be at least 32k for LA DMA architecture");
+
+static uint8_t s_BigBufMemory[BIG_BUFFER_SIZE] __attribute__((aligned(BIG_BUFFER_ALIGNMENT_KB * 1024u))); 
+
+
+static bool s_BigBufInitialized = false;
+static uint8_t s_ReservedForFutureAllocationTracking[1024u];
+static big_buffer_general_state_t s_State = {0};
+static big_buffer_allocation_instance_t s_Allocation[MAXIMUM_SUPPORTED_ALLOCATION_COUNT] = {0};
+
+
+static big_buffer_invariant_error_flags_t BigBuffer_InvariantsFailed(void) {
+    uint32_t result_flags = 0u;
+    if (s_BigBufInitialized) {
+        // constant values
+        if (s_State.buffer != (uintptr_t)(s_BigBufMemory)) {
+            result_flags |= BIG_BUFFER_INVARIANT_CONSTANT_BIGBUF_POINTER;
+        }
+        if (s_State.total_size != count_of(s_BigBufMemory)) {
+            result_flags |= BIG_BUFFER_INVARIANT_CONSTANT_BIGBUF_SIZE;
+        }
+        if (s_State.long_lived_limit != s_State.buffer + s_State.total_size - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u)) {
+            result_flags |= BIG_BUFFER_INVARIANT_CONSTANT_LONGTERM_MARKER;
+        }
+
+        // Verify reasonable values for high/low watermarks
+        if (s_State.low_watermark < s_State.buffer) {
+            result_flags |= BIG_BUFFER_INVARIANT_LOW_WATERMARK_VALUE_TOO_LOW;
+        }
+        if (s_State.low_watermark > s_State.buffer + s_State.total_size) {
+            result_flags |= BIG_BUFFER_INVARIANT_LOW_WATERMARK_VALUE_TOO_HIGH;
+        }
+        if (s_State.high_watermark < s_State.long_lived_limit) {
+            result_flags |= BIG_BUFFER_INVARIANT_HIGH_WATERMARK_VALUE_TOO_LOW;
+        }
+        if (s_State.high_watermark > s_State.buffer + s_State.total_size) {
+            result_flags |= BIG_BUFFER_INVARIANT_HIGH_WATERMARK_VALUE_TOO_HIGH;
+        }
+        if (s_State.low_watermark > s_State.high_watermark) {
+            result_flags |= BIG_BUFFER_INVARIANT_WATERMARKS_CROSSED;
+        }
+        // if there are no temporary allocations...
+        if (s_State.temp_allocations_count == 0) {
+            // then low water mark should always point to start of big buffer
+            if (s_State.low_watermark != s_State.buffer) {
+                result_flags |= BIG_BUFFER_INVARIANT_LOW_WATERMARK_AT_ZERO_TEMP_ALLOCS;
+            }
+        }
+        // if neither short nor long-lived allocations...
+        if ((s_State.temp_allocations_count       == 0) &&
+            (s_State.long_lived_allocations_count == 0)  ) {
+            // high water mark should point to end of big buffer
+            if (s_State.high_watermark != s_State.buffer + s_State.total_size) {
+                result_flags |= BIG_BUFFER_INVARIANT_HIGH_WATERMARK_WITH_NO_ALLOCS;
+            }
+        }
+    } else {
+        if((s_State.buffer                       != 0u) ||
+           (s_State.total_size                   != 0u) ||
+           (s_State.high_watermark               != 0u) ||
+           (s_State.low_watermark                != 0u) ||
+           (s_State.long_lived_limit             != 0u) ||
+           (s_State.temp_allocations_count       != 0u) ||
+           (s_State.long_lived_allocations_count != 0u)  ) {
+            result_flags |= BIG_BUFFER_INVARIANT_UNINITIALIZED_BUT_STORING_VALUES;
+        }
     }
-    else 
-    {
-        printf("Error: the big buffer is already allocated to #%d", system_config.big_buffer_owner);
-        return NULL;
+    return result_flags;
+}
+static void SortAllocationTrackingData(void) {
+    // Only 32 maximum entries, so N*N algorithm is only 1024 iterations.
+    // If max allocation count is increased, consider a more efficient sorting algorithm.
+    static_assert(MAXIMUM_SUPPORTED_ALLOCATION_COUNT <= 32);
+
+    for (size_t dest = 0; dest < MAXIMUM_SUPPORTED_ALLOCATION_COUNT - 1; ++dest) {
+        // find the smallest remaining non-null index
+        // Sort by allocated address ()
+        size_t smallest = dest;
+        for (size_t i = dest + 1; i < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++i) {
+            if (s_Allocation[i].result == 0u) {
+                // ignore NULL pointers (non-allocated)
+            } else if (s_Allocation[i].result > s_Allocation[smallest].result) {
+                // ignore because not a smaller address
+            } else if (s_Allocation[i].result < s_Allocation[smallest].result) {
+                smallest = i; // update smallest index because it's smaller
+            } else {
+                // two allocations at the same address should never happen ...
+                assert(false);
+            }
+        }
+        // swap the dest and smallest indices
+        if (smallest != dest) {
+            big_buffer_allocation_instance_t tmp = s_Allocation[dest];
+            s_Allocation[dest] = s_Allocation[smallest];
+            s_Allocation[smallest] = tmp;
+        }
     }
+    return;
 }
 
-void mem_free(uint8_t *ptr)
-{
-    if (ptr == mem_buffer) {
-        allocated = false;
-        system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
+static void DumpGeneralStateHeader(void) {
+    X_DUMP("");
+    X_DUMP("BB: Buffer*  | TotalSize | HighWater | LowWater | TmpCnt | LongCnt");
+    X_DUMP("    ---------|-----------|-----------|----------|--------|--------");
+    //DUMP("BB: ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. |   .xx. |    .xx.");
+    return;
+}
+static void DumpGeneralState(const big_buffer_general_state_t * general_state) {
+    X_DUMP("BB: %08x |  %08x |  %08x | %08x |   %04x |    %04x\n",
+           general_state->buffer,
+           general_state->total_size,
+           general_state->high_watermark,
+           general_state->low_watermark,
+           general_state->temp_allocations_count,
+           general_state->long_lived_allocations_count
+           );
+    return;
+}
+static void DumpAllocationInstanceHeader(void) {
+    X_DUMP("    ------------------------------------------------------\n");
+    X_DUMP("    Buffer*  |  Req_Size | Req_Align | OwnerTag | Type\n");
+    //DUMP("    ..xxxx.. |  ..xxxx.. |  ..xxxx.. | ..xxxx.. | .ss.\n");
+    return;
+}
+static void DumpAllocationInstance(const big_buffer_allocation_instance_t* alloc_state) {
+    X_DUMP(
+        "    %08x |  %08x |  %08x | %08x | %4s\n",
+        alloc_state->result,
+        alloc_state->requested_size,
+        alloc_state->requested_alignment,
+        alloc_state->owner_tag,
+        (alloc_state->was_long_lived_allocation) ? "long" : "temp"
+        );
+    return;
+}
+
+
+static size_t FindUnusedTrackingEntryIndex(void) {
+    // This should never fail, because successful allocations are limited to MAXIMUM_SUPPORTED_ALLOCATION_COUNT
+    for (size_t i = 0; i < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++i) {
+        if (s_Allocation[i].result == 0u) {
+            return i;
+        }
     }
+    X_FATAL("BB: call to find unused tracking entry index when all tracking data full\n");
+}
+
+
+
+void BigBuffer_Initialize(void) {
+    X_API_ENTRY("");
+
+    X_CHECK_INVARIANTS();
+    X_DBGP("BB: Init()\n");
+    if (s_BigBufInitialized) {
+        assert(false); // should only call this once
+    } else {
+        memset(&s_State, 0, sizeof(s_State));
+        s_State.buffer                       = (uintptr_t)s_BigBufMemory;
+        s_State.total_size                   = count_of(s_BigBufMemory);
+        s_State.high_watermark               = s_State.buffer + s_State.total_size;
+        s_State.low_watermark                = s_State.buffer;
+        s_State.long_lived_limit             = s_State.high_watermark - (BIG_BUFFER_LONGLIVED_BUFFER_KB * 1024u);
+        s_State.temp_allocations_count       = 0u;
+        s_State.long_lived_allocations_count = 0u;
+
+        X_DBGP("BB: BB @ %p, size %zu, high %p, low %p\n",
+            s_State.buffer, s_State.total_size, s_State.high_watermark, s_State.low_watermark
+            );
+        memset(s_BigBufMemory, 0xAA, s_State.total_size);
+
+        // Initialize memory tracking buffer also
+        memset(&s_Allocation[0], 0, sizeof(s_Allocation));
+
+        s_BigBufInitialized = true;
+    }
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("");
+}
+
+void BigBuffer_VerifyNoTemporaryAllocations(void) {
+    X_API_ENTRY("");
+
+    if (!s_BigBufInitialized) {
+        assert(false); // this is recoverable in this instance, but still violates the API contract
+        BigBuffer_Initialize(); 
+    }
+    X_CHECK_INVARIANTS();
+    assert(s_State.temp_allocations_count == 0);
+    // TODO: also verify no allocation tracking data lists a temporary allocation?
+    X_API_EXIT("");
+}
+// TODO: macro to call BigBuffer_InvariantsFailed() and assert if non-zero result
+//       this will simplify compiling this to nothing on release builds, and allow file / func / line numbers
+
+static uintptr_t BigBuffer_DetermineNewLowWaterMark(void) {
+    if (s_State.temp_allocations_count == 0) {
+        return s_State.buffer;
+    }
+    // find the highest address allocated to tracked temporary allocations
+    uint16_t allocations_found = 0u;
+    uintptr_t new_low_water_mark = 0u;
+    for (size_t i = 0; i < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++i) {
+        if (s_Allocation[i].result == 0u) continue;
+        if (s_Allocation[i].was_long_lived_allocation) continue;
+        ++allocations_found;
+        uintptr_t end_of_allocation = ((uintptr_t)s_Allocation[i].result) + s_Allocation[i].requested_size;
+        if (end_of_allocation > new_low_water_mark) {
+            new_low_water_mark = end_of_allocation;
+        }
+    }
+    assert(allocations_found == s_State.temp_allocations_count);
+    return new_low_water_mark;
+}
+static uintptr_t BigBuffer_DetermineNewHighWaterMark(void) {
+    if (s_State.long_lived_allocations_count == 0) {
+        return s_State.buffer + s_State.total_size;
+    }
+    // find the lowest address allocated to tracked long-lived allocations
+    uint16_t allocations_found = 0u;
+    uintptr_t new_high_water_mark = s_State.buffer + s_State.total_size; // highest value ... when no long-lived allocations
+    for (size_t i = 0; i < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++i) {
+        if (s_Allocation[i].result == 0u) continue;
+        if (!s_Allocation[i].was_long_lived_allocation) continue;
+        ++allocations_found;
+        uintptr_t start_of_allocation = (uintptr_t)(s_Allocation[i].result);
+        if (start_of_allocation < new_high_water_mark) {
+            new_high_water_mark = start_of_allocation;
+        }
+    }
+    assert(allocations_found == s_State.long_lived_allocations_count);
+    return new_high_water_mark;
+}
+
+void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
+    X_API_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_CHECK_INVARIANTS();
+
+    uintptr_t result = 0;
+    if (requiredAlignment == 0) {
+        requiredAlignment = 1; // fixup common API error
+    }
+    size_t alignmentMask = requiredAlignment - 1;
+
+
+    if (!s_BigBufInitialized) {
+        X_FATAL("BB_AllocTemp: big buffer is not initialized?\n");
+        assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
+    } else if ((requiredAlignment & alignmentMask) != 0u) {
+        X_FATAL("BB_AllocTemp: alignment (%#zx) must be a power of 2\n", requiredAlignment);
+        assert(false); // alignment must be a power of 2
+    } else if (requiredAlignment > 128u * 1024u) {
+        X_FAILURE("BB_AllocTemp: required (%#zx) alignment too large\n", requiredAlignment);
+    } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+        X_FAILURE("BB_AllocTemp: too many allocations\n");
+    } else if (countOfBytes == 0) {
+        X_DBGP("BB_AllocTemp: returning NULL for zero-byte allocation request");
+    } else if (countOfBytes > s_State.high_watermark - s_State.low_watermark) {
+        // exit early if the request number of bytes is larger than what's left
+        // N.B. It might still not fit due to alignment requirements ... checked later.
+        X_DBGP("BB_AllocTemp: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - s_State.low_watermark);
+    } else {
+        // allocate temporary buffers from the lower end of the address space
+        result = s_State.low_watermark;
+        if ((result & alignmentMask) != 0u) {
+            // adjust the allocation so that it's properly aligned ... move result to larger address
+            result = (result + requiredAlignment) & ~alignmentMask;
+            if (s_State.high_watermark - result < countOfBytes) {
+                X_DBGP("BB_AllocTemp: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                result = 0;
+            }
+        }
+    }
+
+    if (result != 0) {
+        // adjust tracking data
+        s_State.low_watermark = result + countOfBytes;
+        ++s_State.temp_allocations_count;
+        size_t idx = FindUnusedTrackingEntryIndex();
+        memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
+        s_Allocation[idx].result = result;
+        s_Allocation[idx].requested_size = countOfBytes;
+        s_Allocation[idx].requested_alignment = requiredAlignment;
+        s_Allocation[idx].owner_tag = owner;
+        s_Allocation[idx].was_long_lived_allocation = false;
+
+        // finally, zero the memory before returning it.
+        memset((void*)result, 0, countOfBytes);
+    }
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
+    return (void*)result;
+}
+void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner) {
+    X_API_ENTRY("(%zu, %zu, %d)", countOfBytes, requiredAlignment, owner);
+    X_CHECK_INVARIANTS();
+
+    uintptr_t result = 0;
+    if (requiredAlignment == 0) {
+        requiredAlignment = 1; // fixup common API error
+    }
+    size_t alignmentMask = requiredAlignment - 1;
+    // limit lower bound of the allocation
+    uintptr_t lower_limit = s_State.long_lived_limit;
+    if (s_State.low_watermark > lower_limit) {
+        lower_limit = s_State.low_watermark;
+    }
+
+    if (!s_BigBufInitialized) {
+        X_FATAL("BB_AllocLongLived: big buffer is not initialized?\n");
+        assert(false); // BigBuffer_Initialize() must be called before attempting to allocate memory
+    } else if ((requiredAlignment & alignmentMask) != 0u) {
+        X_FATAL("BB_AllocLongLived: alignment (%#zx) must be a power of 2\n", requiredAlignment);
+        assert(false); // alignment must be a power of 2
+    } else if (requiredAlignment > 128u * 1024u) {
+        X_FAILURE("BB_AllocLongLived: required alignment (%#zx) too large\n", requiredAlignment);
+    } else if (s_State.long_lived_allocations_count + s_State.temp_allocations_count >= MAXIMUM_SUPPORTED_ALLOCATION_COUNT) {
+        X_FAILURE("BB_AllocLongLived: too many allocations\n");
+    } else if (countOfBytes == 0) {
+        X_DBGP("BB_AllocTemp: returning NULL for zero-byte allocation request");
+    } else if (countOfBytes > s_State.high_watermark - lower_limit) {
+        // exit early if the request number of bytes is larger than what's left
+        // N.B. It might still not fit due to alignment requirements ... checked later.
+        X_DBGP("BB_AllocLongLived: returning NULL because requested %zu bytes > %zu bytes available\n", countOfBytes, s_State.high_watermark - lower_limit);
+    } else {
+        result = s_State.high_watermark - countOfBytes;
+        if ((result & alignmentMask) != 0u) {
+            // adjust the allocation so that it's properly aligned ... move result to SMALLER address
+            result = result & ~alignmentMask;
+            if (lower_limit > result) {
+                X_DBGP("BB_AllocLongLived: insufficient space due to alignment requirement (%#zx bytes @ %#zx align)\n", countOfBytes, requiredAlignment);
+                result = 0;
+            }
+        }
+    }
+
+    if (result != 0u) {
+        // adjust tracking data
+        s_State.high_watermark = result;
+        ++s_State.long_lived_allocations_count;
+        size_t idx = FindUnusedTrackingEntryIndex();
+        memset(&s_Allocation[idx], 0, sizeof(big_buffer_allocation_instance_t));
+        s_Allocation[idx].result = result;
+        s_Allocation[idx].requested_size = countOfBytes;
+        s_Allocation[idx].requested_alignment = requiredAlignment;
+        s_Allocation[idx].owner_tag = owner;
+        s_Allocation[idx].was_long_lived_allocation = true;
+
+        // finally, zero the memory before returning it.
+        memset((void*)result, 0, countOfBytes);
+    }
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%zu, %zu, %d) -> %zx", countOfBytes, requiredAlignment, owner, result);
+    return (void*)result;
+}
+
+static big_buffer_allocation_instance_t* BigBuffer_FreeCommon(uintptr_t p, big_buffer_owner_t owner) {
+
+    if (!s_BigBufInitialized) {
+        X_FATAL("BB_Free: big buffer is not initialized?\n");
+        return NULL;
+    }
+    if (p == 0u) { // permit the free'ing of a nullptr ...
+        X_DBGP("BB_Free: NULL pointer\n");
+        return NULL;
+    }
+    if (p < s_State.buffer) {
+        X_FATAL("BB_Free: pointer %#010zx is before the start of the Big Buffer %#010zx\n", p, s_State.buffer);
+        return NULL;
+    }
+    if (p >= (s_State.total_size + s_State.buffer)) {
+        X_FATAL("BB_Free: pointer %#010zx is after the end of the Big Buffer %#010zx\n", p, s_State.buffer + s_State.total_size);
+        return NULL;
+    }
+
+    // was this allocated at the given position?
+    big_buffer_allocation_instance_t* allocated = NULL;
+    for (size_t i = 0; i < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++i) {
+        if (s_Allocation[i].result == p) {
+            allocated = &s_Allocation[i];
+            break;
+        }
+    }
+    if (allocated == NULL) {
+        X_FATAL("BB_Free: pointer %#010zx was not allocated from BigBuffer (%#010zx .. %#010zx)\n", p, s_State.buffer, s_State.buffer + s_State.total_size);
+        return NULL;
+    }
+    if (allocated->owner_tag != owner) {
+        X_FATAL("BB_Free: owner tag mismatch: point %#010zx allocated by %d, free attempted by %d\n", p, allocated->owner_tag, owner);
+        return NULL;
+    }
+
+    // all checks passed.  do NOT modify tracking data here, as it depends on type of allocation
+    return allocated;
+}
+void BigBuffer_Free(const void * ptr, big_buffer_owner_t owner) {
+    X_API_ENTRY("(%p, %d)", ptr, owner);
+    X_CHECK_INVARIANTS();
+
+    big_buffer_allocation_instance_t* allocation = BigBuffer_FreeCommon((uintptr_t)ptr, owner);
+    if (allocation == NULL) {
+        // already asserted in BigBuffer_FreeCommon(), or was free'ing NULL
+    } else {
+        if (allocation->was_long_lived_allocation) {
+            --s_State.long_lived_allocations_count;
+        } else {
+            --s_State.temp_allocations_count;
+        }
+        // zero this one's tracking data, which free's the memory and prevents it from affecting calculation of new watermarks.
+        // Then, scan all the allocations to find a new high water mark.
+        memset(allocation, 0, sizeof(big_buffer_allocation_instance_t));
+        s_State.high_watermark = BigBuffer_DetermineNewHighWaterMark();
+        s_State.low_watermark = BigBuffer_DetermineNewLowWaterMark();
+    }
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%p, %d)", ptr, owner);
+    return;
+}
+
+void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out ) {
+    X_API_ENTRY("(%p)", general_state_out);
+    X_CHECK_INVARIANTS();
+
+    static_assert(sizeof(s_State) == sizeof(big_buffer_general_state_t));
+    X_CHECK_INVARIANTS();
+
+    memcpy(general_state_out, &s_State, sizeof(big_buffer_general_state_t));
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%p)", general_state_out);
+    return;
+}
+void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out ) {
+    X_API_ENTRY("(%p)", state_out);
+    X_CHECK_INVARIANTS();
+
+    static_assert(sizeof(s_State) == sizeof(state_out->general));
+    static_assert(sizeof(s_Allocation) == sizeof(state_out->allocation));
+    X_CHECK_INVARIANTS();
+
+    memcpy(&(state_out->general), &s_State, sizeof(big_buffer_general_state_t));
+    memcpy(&(state_out->allocation[0]), &(s_Allocation[0]), sizeof(state_out->allocation));
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%p)", state_out);
+    return;
+}
+void BigBuffer_DebugDumpSummary(const big_buffer_general_state_t * state) {
+    X_API_ENTRY("(%p)", state);
+    X_CHECK_INVARIANTS();
+
+    DumpGeneralStateHeader();
+    DumpGeneralState(state);
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%p)", state);
+}
+void BigBuffer_DebugDumpState(const big_buffer_state_t * state) {
+    X_API_ENTRY("(%p)", state);
+    X_CHECK_INVARIANTS();
+
+    DumpGeneralStateHeader();
+    DumpGeneralState(&(state->general));
+    DumpAllocationInstanceHeader();
+    for (size_t j = 0; j < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++j) {
+        if (state->allocation[j].result != 0u) {
+            DumpAllocationInstance(&(state->allocation[j]));
+        }
+    }
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%p)", state);
+}
+void BigBuffer_DebugDumpCurrentState(bool verbose) {
+    X_API_ENTRY("(%s)", verbose ? "true" : "false");
+    X_CHECK_INVARIANTS();
+
+    DumpGeneralStateHeader();
+    DumpGeneralState(&s_State);
+    if (verbose && ((s_State.temp_allocations_count > 0) || (s_State.long_lived_allocations_count > 0))) {
+        SortAllocationTrackingData();
+        DumpAllocationInstanceHeader();
+        for (size_t j = 0; j < MAXIMUM_SUPPORTED_ALLOCATION_COUNT; ++j) {
+            if (s_Allocation[j].result != 0u) {
+                DumpAllocationInstance(&s_Allocation[j]);
+            }
+        }
+    }
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%s)", verbose ? "true" : "false");
+}
+
+size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment) {
+    X_API_ENTRY("(%zu)", requiredAlignment);
+    X_CHECK_INVARIANTS();
+
+    size_t result = 0u;
+    size_t alignmentMask = requiredAlignment - 1;
+    uintptr_t aligned_lower = (s_State.low_watermark + (requiredAlignment - 1)) & (~alignmentMask);
+
+    if ((requiredAlignment & alignmentMask) != 0u) {
+        X_FATAL("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
+    } else if (aligned_lower >= s_State.high_watermark) {
+        X_DBGP("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        result = 0u;
+    } else {
+        result = s_State.high_watermark - aligned_lower;
+    }
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
+    return result;
+}
+size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment) {
+    X_API_ENTRY("(%zu)", requiredAlignment);
+    X_CHECK_INVARIANTS();
+
+    size_t result; // leave uninitialized to ensure each path sets the value (compiler error if used w/o being set)
+    size_t alignmentMask = requiredAlignment - 1;
+    uintptr_t lower = s_State.long_lived_limit;
+    if (s_State.low_watermark > lower) {
+        lower = s_State.low_watermark;
+    }
+    uintptr_t aligned_lower = (lower + (requiredAlignment - 1)) & (~alignmentMask);
+
+
+    if ((requiredAlignment & alignmentMask) != 0u) {
+        X_FATAL("BB_GetAvailableTempMemory(%#zx): alignment must be a power of 2\n", requiredAlignment);
+        result = 0u;
+    } else if (aligned_lower >= s_State.high_watermark) {
+        X_DBGP("BB_GetAvailableTempMemory(%#zx): aligned_lower (%#zx) >= high_watermark (%#zx)\n", requiredAlignment, aligned_lower, s_State.high_watermark);
+        result = 0u;
+    } else {
+        result = s_State.high_watermark - aligned_lower;
+    }
+
+    X_CHECK_INVARIANTS();
+    X_API_EXIT("(%zu) -> %zu (%zx)", requiredAlignment, result, result);
+    return result;
+}
+
+
+
+// /////////////////////////////////////////////////////////////////////////////
+// TODO: replace the below API with BigBuffer_xxxx() API.
+static big_buffer_owner_t legacy_owner = BP_BIG_BUFFER_OWNER_NONE;
+uint8_t *mem_alloc(size_t size, big_buffer_owner_t owner)
+{
+    X_API_ENTRY("(%zu, %d)", size, owner);
+
+    uint8_t * result = BigBuffer_AllocateTemporary(size, 1u, owner);
+    if (result != NULL) {
+        legacy_owner = owner;
+    }
+
+    X_API_EXIT("(%zu, %d) -> %p", size, owner, result);
+    return result;
+}
+void mem_free(uint8_t const * ptr)
+{
+    X_API_ENTRY("(%p)", ptr);
+
+    BigBuffer_Free(ptr, legacy_owner);
+    BigBuffer_VerifyNoTemporaryAllocations();
+
+    X_API_EXIT("(%p)", ptr);
 }

--- a/pirate/mem.h
+++ b/pirate/mem.h
@@ -20,21 +20,147 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum big_buffer_owners{
-	BP_BIG_BUFFER_NONE=0,
-	BP_BIG_BUFFER_SCOPE,
-	BP_BIG_BUFFER_LA,
-	BP_BIG_BUFFER_DISKFORMAT,
-};
+/// @brief Unique tag to indicate the owner of a big buffer allocation.
+typedef enum _big_buffer_owners {
+	BP_BIG_BUFFER_OWNER_NONE=0,
+    BP_BIG_BUFFER_OWNER_SELFTEST,
+	BP_BIG_BUFFER_OWNER_SCOPE,
+	BP_BIG_BUFFER_OWNER_LA,
+	BP_BIG_BUFFER_OWNER_DISKFORMAT,
+	MAXIMUM_BP_BIG_BUFFER_OWNER,
+} big_buffer_owner_t;
+
+// Ensures 16-bits or less; Allows to overload the value stored in tracking structure
+static_assert(MAXIMUM_BP_BIG_BUFFER_OWNER <= 0x10000);
+
+typedef struct _big_buffer_general_state {
+    // uintptr_t allows cleaner addition/subtraction between pointers
+    static_assert(sizeof(uintptr_t) == sizeof(size_t));
+    uintptr_t buffer;
+    size_t    total_size;
+    uintptr_t high_watermark; // end of allocatable memory
+    uintptr_t low_watermark;
+    uintptr_t long_lived_limit;
+    uint16_t  temp_allocations_count;
+    uint16_t  long_lived_allocations_count;
+} big_buffer_general_state_t;
+
+typedef struct _big_buffer_allocation_instance {
+    uintptr_t   result;
+    size_t      requested_size;
+    size_t      requested_alignment;
+    uint32_t    owner_tag : 16; // big_buffer_owner_t ... limited to 16-bits
+	uint32_t    was_long_lived_allocation : 1;
+	uint32_t    : 15; // reserved for future use
+} big_buffer_allocation_instance_t;
+
+#define MAXIMUM_SUPPORTED_ALLOCATION_COUNT 32
+
+typedef struct _big_buffer_state {
+	big_buffer_general_state_t general;
+	big_buffer_allocation_instance_t allocation[MAXIMUM_SUPPORTED_ALLOCATION_COUNT];
+} big_buffer_state_t;
+
+/// @brief Initializes the BigBuffer module.
+/// @details Must be called before any other BigBuffer API.
+/// @note Called during system init, so in some respects this is an implementation detail.
+void BigBuffer_Initialize(void);
+
+/// @brief Verifies that all /temporary/ allocations have been freed,
+///        and that state matches expectations.
+/// @note it is expected that all temporary allocations have been freed
+///       prior to calling this API.  This is STRONGLY recommended before
+///       initializing a new mode to help avoid bugs that are essentially
+///       impossible to debug (dangling pointers --> memory corruption).
+void BigBuffer_VerifyNoTemporaryAllocations(void);
+
+/// @brief Allocates temporary buffer of the specified size and alignment.
+/// @note The memory returned by this API /MUST/ be released prior to calling
+///       BigBuffer_PartialReset().
+void* BigBuffer_AllocateTemporary(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner);
+
+/// @brief Allocates a long-lived buffer of the specified size and alignment, if possible.
+/// @details The memory returned by this API is /NOT/ required to be released prior to
+///          calling BigBuffer_PartialReset().
+/// @note Total long-lived buffer space is currently limited to 8k.
+void* BigBuffer_AllocateLongLived(size_t countOfBytes, size_t requiredAlignment, big_buffer_owner_t owner);
+
+/// @brief Frees a buffer previously allocated by `BigBuffer_AllocateTemporary()` or `BigBuffer_AllocationLongLived()`.
+/// @note The owner must match ... this helps avoid a class of bugs that are otherwise
+///       more difficult to catch / debug / track down.
+void BigBuffer_Free(const void * ptr, big_buffer_owner_t owner);
+
+
+/// @brief How many bytes of temporary memory are available with a given alignment?
+size_t BigBuffer_GetAvailableTemporaryMemory(size_t requiredAlignment);
+
+/// @brief How many bytes of long-lived memory are available with a given alignment?
+size_t BigBuffer_GetAvailableLongLivedMemory(size_t requiredAlignment);
+
+////////////////////////////////////////////////////////////////////////////////
+// Debug APIs ... not really intended for general use, but may be useful during
+//                development / debugging.
+////////////////////////////////////////////////////////////////////////////////
+
+
+/// @brief provide statistics on current BigBuffer usage
+/// @details Provides overview of BigBuffer state (high / low water marks, etc.)
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+void BigBuffer_DebugGetStatistics( big_buffer_general_state_t * general_state_out );
+
+/// @brief provide detailed information on current BigBuffer usage
+/// @details The goal of this API is to help troubleshoot memory usage issues.
+///
+///          Example question:
+///          Why is this mode failing to initialize?
+///          Example answer:
+///          The mode requires 130k buffer, which reaches into the long-lived
+///          allocation space.  However, the entire 8k of the long-lived buffer
+///          is allocated by XXXX.
+///
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+void BigBuffer_DebugGetDetailedStatistics( big_buffer_state_t * state_out );
+
+void BigBuffer_DebugDumpSummary(const big_buffer_general_state_t * state);
+void BigBuffer_DebugDumpState(const big_buffer_state_t * state);
+
+/// @brief Prints the current state of the BigBuffer module
+/// @details This is intended for debugging purposes.  It will print the
+///          current internal `big_buffer_general_state_t`.  If the `verbose`
+///          parameter is true, it will also print all currently allocated
+///          memory allocations (one allocation per line).
+/// @note This API is /NOT/ performance-critical, as it is intended for
+///       interactive display of information.
+void BigBuffer_DebugDumpCurrentState(bool verbose);
+
+// End of debug APIs
+////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////
+// LEGACY APIs ... these are deprecated and will soon be removed
+//
+// [x] Stage 0: define the new APIs (above)
+// [x] Stage 1: migrate all existing code to use the new APIs
+// [x] Stage 2: mark the functions with deprecated attribute
+// [ ] Stage 3: integrate into main branch
+// [ ] Stage 4: wait appropriate time for other braches to be updated
+// [ ] Stage 5: remove the deprecated functions entirely in main branch
 
 /// @brief Attempts to allocate a nand page buffer.
 /// @return Pointer to the buffer if available, NULL if not available
 /// @note Return value should always be checked against null.
 /// @note Max size: SPI_NAND_PAGE_SIZE + SPI_NAND_OOB_SIZE
-uint8_t *mem_alloc(size_t size, uint32_t owner);
-
+uint8_t* mem_alloc(size_t size, big_buffer_owner_t owner) __attribute__((deprecated("use BigBuffer_AllocateTemporary() instead")));
 /// @brief Frees the allocated nand page buffer
 /// @param ptr pointer to the nand page buffer
-void mem_free(uint8_t *ptr);
+void     mem_free(const uint8_t * ptr)                    __attribute__((deprecated("use BigBuffer_Free() instead")));
+
+// End of legacy memory allocation APIs
+////////////////////////////////////////////////////////////////////////////////
+
+
 
 #endif // __MEM_H

--- a/pirate/memmap_buspirate5.ld
+++ b/pirate/memmap_buspirate5.ld
@@ -196,7 +196,7 @@ SECTIONS
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     .bss  : {
-        . = ALIGN(4);
+        . = ALIGN(32K);
         __bss_start__ = .;
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
         *(COMMON)

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -122,17 +122,17 @@ bool storage_detect(void){
     return true;
 }
 
-uint8_t storage_format(void){
-    static_assert(FF_MAX_SS <= BIG_BUFFER_SIZE, "BIG_BUFFER_SIZE must be at least FF_MAX_SS for this allocation to succeed.");
-
+uint8_t storage_format(void) {
     FRESULT fr;     /* FatFs return code */
-    uint8_t *work_buffer = mem_alloc(FF_MAX_SS, BP_BIG_BUFFER_DISKFORMAT);
+    uint8_t *work_buffer = BigBuffer_AllocateTemporary(FF_MAX_SS, 4, BP_BIG_BUFFER_OWNER_DISKFORMAT);
     if (!work_buffer) {
         return FR_NOT_ENOUGH_CORE;
     }
+
     fr = f_mkfs("", 0, work_buffer, FF_MAX_SS);
-    mem_free(work_buffer);
-    if(fr == FR_OK){
+    BigBuffer_Free(work_buffer, BP_BIG_BUFFER_OWNER_DISKFORMAT);
+
+    if (fr == FR_OK) {
         fr = f_setlabel("Bus_Pirate5");
     }
     return fr;

--- a/system_config.c
+++ b/system_config.c
@@ -106,8 +106,6 @@ void system_init(void)
 	system_config.clkport=0;
 	system_config.clkpin=0;
 
-	system_config.big_buffer_owner=BP_BIG_BUFFER_NONE;
-
 	system_config.rts=0;
 
 	system_config.binmode_select=0;


### PR DESCRIPTION
## Genesis

The code base was facing pressure on the available RAM due to the use of non-const variables that were declared statically.  These variables were used in multiple mutually exclusive "modes", and were not needed when the mode was not active.

## Goals

The new `BigBuffer_...()` APIs support dynamic allocation of those large non-const variables.

* Seamless migration from legacy memory allocation APIs (`mem_alloc()` and `mem_free()`).
  * Prior memory allocation APIs (`mem_alloc()` and `mem_free()`) are temporarily converted to shims into the new APIs
  * Prior memory allocation APIs are marked deprecated, to simplify finding all users.
  * After integration into main branch, deprecated APIs will be removed.
* Support most demanding current large RAM consumer (scope)
  * The APIs must support temporary (per-mode) allocation of 128k @ 32k alignment.
  * An additional 8k was made available for _either_ temporary or long-lived allocations (or mixture of both).
* Callers may specify an alignment requirement for each allocation.
* Allocation of zero bytes is supported (and will return NULL).
* Freeing NULL is supported (and will not modify the allocation state).
* APIs can be reasoned about and are deterministic.
  * APIs get detailed information about allocations.
* Unit tests exercise the APIs, including edge cases.
* A simple way to enable extremely verbose debugging of the memory allocation system (at build time).

## Non-Goals

The `BigBuffer_...()` APIs are not intended to be a general replacement for heap.  Memory should generally be statically allocated during a mode's initialization, and then freed when the mode is no longer active.

## Overview

A static buffer is reserved that is 128k+8k in size, with a 32k alignment guarantee.

The memory layout will generall be as follows:

| Address | Name                   | Description                                                                                                      |
|---------|------------------------|-------------                                                                                                     |
| high    | `__BIG_BUFFER_END__`   | Points just past (higher than) the end of the static buffer                                                      |
| ...     | ...                    | Long-lived allocations (if any)                                                                                  |
| adjusts | `high_watermark`       | Points just past (higher than) the last unallocated memory, or equal to `low_watermark` if all memory allocated. |
| ...     | ...                    | Unallocated memory                                                                                               |
| adjusts | `low_watermark`        | Points to the first (lowest address) unallocated byte of memory                                                  |
| ...     | ...                    | Temporary allocations (if any)                                                                                   |
| low     | `__BIG_BUFFER_START__` | Guaranteed to be 32k aligned                                                                                     |

Long-lived allocations thus start from higher addresses and grow downwards, while temporary allocations start from lower addresses and grow upwards.

Long-lived allocations are limited to 8k, while temporary allocations are allowed to grow past the 128k boundary and use the full 136k (if not already used by long-lived allocations).