### PR TITLE
Various QoL updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,16 +224,16 @@ if(${PICO_PLATFORM} MATCHES "rp2350")
                 platform/bpi-rev10.h platform/bpi-rev10.c 
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VER=XL5)
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_REV=10)
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VERSION=XL5)
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_BOARD_REVISION=10)
 
         add_executable(bus_pirate6_rev1
                 ${bp5_common}
                 ${bp5_nandflash}
                 platform/bpi6-rev1.h platform/bpi6-rev1.c 
                 )
-        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_VER=6) 
-        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_REV=10)  
+        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_VERSION=6) 
+        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_BOARD_REVISION=10)  
         
         set(revisions 
         bus_pirate5_xl  
@@ -248,8 +248,8 @@ else()
                 fatfs/tf_card.c fatfs/tf_card.h
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VER=5) 
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_REV=8)
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VERSION=5) 
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_BOARD_REVISION=8)
 
         add_executable(bus_pirate5_rev10
                 ${bp5_common}
@@ -257,8 +257,8 @@ else()
                 platform/bpi-rev10.h platform/bpi-rev10.c 
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_VER=5)                
-        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_REV=10)
+        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_VERSION=5)                
+        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_BOARD_REVISION=10)
 
         set(revisions
         bus_pirate5_rev8  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if(${PICO_PLATFORM} MATCHES "rp2350")
                 platform/bpi-rev10.h platform/bpi-rev10.c 
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VERSION=XL5)
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VERSION=BP5XL)
         target_compile_definitions(bus_pirate5_xl PUBLIC BP_BOARD_REVISION=10)
 
         add_executable(bus_pirate6_rev1
@@ -232,7 +232,7 @@ if(${PICO_PLATFORM} MATCHES "rp2350")
                 ${bp5_nandflash}
                 platform/bpi6-rev1.h platform/bpi6-rev1.c 
                 )
-        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_VERSION=6) 
+        target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_VERSION=BP6) 
         target_compile_definitions(bus_pirate6_rev1 PUBLIC BP_BOARD_REVISION=10)  
         
         set(revisions 
@@ -248,7 +248,7 @@ else()
                 fatfs/tf_card.c fatfs/tf_card.h
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VERSION=5) 
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VERSION=BP5) 
         target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_BOARD_REVISION=8)
 
         add_executable(bus_pirate5_rev10
@@ -257,7 +257,7 @@ else()
                 platform/bpi-rev10.h platform/bpi-rev10.c 
                 pirate/shift.h pirate/shift.c
                 )
-        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_VERSION=5)                
+        target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_VERSION=BP5)                
         target_compile_definitions(bus_pirate5_rev10 PUBLIC BP_BOARD_REVISION=10)
 
         set(revisions

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -319,7 +319,7 @@ bool selftest_button(void){
 }
 
 // test that the logic analyzer chip is mounted and with no shorts
-#if BP_VERSION == 6
+#if BP_VERSION == BP6
 bool selftest_la_bpio(void){
     uint32_t temp1, fails=0, iopin=0;
     printf("LA_BPIO TEST (SHOULD BE 1)\r\n");
@@ -378,9 +378,9 @@ void cmd_selftest(void){
     }
 
     // REV10 + check status of NAND flash
-    #if (BP_VERSION == 5 && BP_BOARD_REVISION < 10)
+    #if (BP_VERSION == BP5 && BP_BOARD_REVISION < 10)
         // NAND flash is not available on BP5 until Rev10
-    #elif (BP_VERSION == 5) || (BP_VERSION == XL5) || (BP_VERSION == 6)
+    #elif (BP_VERSION == BP5) || (BP_VERSION == BP5XL) || (BP_VERSION == BP6)
         if(selftest_format_nand()) fails++;
     #else
         #error "Unknown Bus Pirate version"
@@ -416,7 +416,7 @@ void cmd_selftest(void){
     if(selftest_bio_low()) fails++;
 
     //LA_BPIO test
-    #if BP_VERSION == 6
+    #if BP_VERSION == BP6
         if(selftest_la_bpio()) fails++;
     #endif
 

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -319,7 +319,7 @@ bool selftest_button(void){
 }
 
 // test that the logic analyzer chip is mounted and with no shorts
-#if BP_VER == 6
+#if BP_VERSION == 6
 bool selftest_la_bpio(void){
     uint32_t temp1, fails=0, iopin=0;
     printf("LA_BPIO TEST (SHOULD BE 1)\r\n");
@@ -378,7 +378,7 @@ void cmd_selftest(void){
     }
 
     //REV10 + check status of NAND flash
-    #if BP_REV >= 10
+    #if BP_BOARD_REVISION >= 10
         if(selftest_format_nand()) fails++;
     #endif        
 
@@ -412,7 +412,7 @@ void cmd_selftest(void){
     if(selftest_bio_low()) fails++;
 
     //LA_BPIO test
-    #if BP_VER == 6
+    #if BP_VERSION == 6
         if(selftest_la_bpio()) fails++;
     #endif
 

--- a/commands/global/cmd_selftest.c
+++ b/commands/global/cmd_selftest.c
@@ -377,9 +377,13 @@ void cmd_selftest(void){
         return;
     }
 
-    //REV10 + check status of NAND flash
-    #if BP_BOARD_REVISION >= 10
+    // REV10 + check status of NAND flash
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION < 10)
+        // NAND flash is not available on BP5 until Rev10
+    #elif (BP_VERSION == 5) || (BP_VERSION == XL5) || (BP_VERSION == 6)
         if(selftest_format_nand()) fails++;
+    #else
+        #error "Unknown Bus Pirate version"
     #endif        
 
     printf("SELF TEST STARTING\r\nDISABLE IRQ: ");

--- a/commands/global/freq.c
+++ b/commands/global/freq.c
@@ -53,7 +53,7 @@ bool freq_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     if((*i)>=count_of(bio2bufiopin)) return 0;
 
     //temp fix for power supply PWM sharing
-    #if BP_REV <= 8
+    #if BP_BOARD_REVISION <= 8
     if((*i)==0 || (*i)==1) return 0;
     #endif
     

--- a/commands/global/freq.c
+++ b/commands/global/freq.c
@@ -52,9 +52,9 @@ bool freq_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     //bounds check
     if((*i)>=count_of(bio2bufiopin)) return 0;
 
-    //temp fix for power supply PWM sharing
-    #if BP_BOARD_REVISION <= 8
-    if((*i)==0 || (*i)==1) return 0;
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+        //temp fix for power supply PWM sharing
+        if((*i)==0 || (*i)==1) return 0;
     #endif
     
     return ( pwm_gpio_to_channel(bio2bufiopin[(*i)])==PWM_CHAN_B && 

--- a/commands/global/freq.c
+++ b/commands/global/freq.c
@@ -52,7 +52,7 @@ bool freq_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     //bounds check
     if((*i)>=count_of(bio2bufiopin)) return 0;
 
-    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+    #if (BP_VERSION == BP5 && BP_BOARD_REVISION <= 8)
         //temp fix for power supply PWM sharing
         if((*i)==0 || (*i)==1) return 0;
     #endif

--- a/commands/global/pwm.c
+++ b/commands/global/pwm.c
@@ -32,7 +32,7 @@ bool pwm_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     if((*i)>=count_of(bio2bufiopin)) return 0;
     
     //temp fix for power supply PWM sharing
-    #if BP_REV <= 8
+    #if BP_BOARD_REVISION <= 8
     if((*i)==0 || (*i)==1) return 0;
     #endif 
     

--- a/commands/global/pwm.c
+++ b/commands/global/pwm.c
@@ -31,7 +31,7 @@ bool pwm_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     //bounds check
     if((*i)>=count_of(bio2bufiopin)) return 0;
     
-    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+    #if (BP_VERSION == BP5 && BP_BOARD_REVISION <= 8)
        //temp fix for power supply PWM sharing
         if((*i)==0 || (*i)==1) return 0;
     #endif 

--- a/commands/global/pwm.c
+++ b/commands/global/pwm.c
@@ -31,9 +31,9 @@ bool pwm_check_pin_is_available(const struct ui_prompt* menu, uint32_t* i)
     //bounds check
     if((*i)>=count_of(bio2bufiopin)) return 0;
     
-    //temp fix for power supply PWM sharing
-    #if BP_BOARD_REVISION <= 8
-    if((*i)==0 || (*i)==1) return 0;
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+       //temp fix for power supply PWM sharing
+        if((*i)==0 || (*i)==1) return 0;
     #endif 
     
     return ( system_config.pin_labels[(*i)+1]==0 && 

--- a/fatfs/diskio.c
+++ b/fatfs/diskio.c
@@ -11,7 +11,7 @@
 #include "pirate.h"
 #include "diskio.h" /* Declarations of disk functions */
 
-#if BP_REV <= 9
+#if BP_BOARD_REVISION <= 9
     #include "fatfs/tf_card.h"
 #else
     #include "../nand/nand_ftl_diskio.h"

--- a/fatfs/diskio.c
+++ b/fatfs/diskio.c
@@ -11,7 +11,7 @@
 #include "pirate.h"
 #include "diskio.h" /* Declarations of disk functions */
 
-#if BP_BOARD_REVISION <= 9
+#if (BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
     #include "fatfs/tf_card.h"
 #else
     #include "../nand/nand_ftl_diskio.h"

--- a/fatfs/diskio.c
+++ b/fatfs/diskio.c
@@ -11,7 +11,7 @@
 #include "pirate.h"
 #include "diskio.h" /* Declarations of disk functions */
 
-#if (BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
+#if (BP_VERSION == BP5 && BP_BOARD_REVISION <= 9)
     #include "fatfs/tf_card.h"
 #else
     #include "../nand/nand_ftl_diskio.h"

--- a/pirate.c
+++ b/pirate.c
@@ -12,7 +12,7 @@
 #include "opt_args.h"
 #include "ui/ui_lcd.h"
 #include "pirate/rgb.h"
-#if (BP_VER == 5 || BP_VER == XL5)
+#if (BP_VERSION == 5 || BP_VERSION == XL5)
     #include "pirate/shift.h"
 #endif
 #include "pirate/bio.h"
@@ -73,8 +73,8 @@ void gpio_setup(uint8_t pin, bool direction, bool level){
 int main(){
     char c;
     
-    #if (BP_VER == 5 || BP_VER==XL5)
-        uint8_t bp_rev=mcu_detect_revision();
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        uint8_t BP_BOARD_REVISION=mcu_detect_revision();
     #endif
 
     reserve_for_future_mode_specific_allocations[1] = 99;
@@ -91,12 +91,12 @@ int main(){
     gpio_set_function(BP_SPI_CDO, GPIO_FUNC_SPI);
 
     // init shift register pins
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_init();
     #endif
     
-    #ifdef BP_REV
-        system_config.hardware_revision=BP_REV;
+    #ifdef BP_BOARD_REVISION
+        system_config.hardware_revision=BP_BOARD_REVISION;
     #else
         #error "No platform revision defined. Check pirate.h."
     #endif
@@ -118,7 +118,7 @@ int main(){
     storage_init();
 
     //initial pin states
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         // configure the defaults for shift register attached hardware
         shift_clear_set_wait(CURRENT_EN_OVERRIDE, (AMUX_S3|AMUX_S1|DISPLAY_RESET|CURRENT_EN));
     #else
@@ -141,7 +141,7 @@ int main(){
     #endif
     pullups_init(); //uses shift register internally  
 
-    #if(BP_VER == 5 || BP_VER==XL5)
+    #if(BP_VERSION == 5 || BP_VERSION==XL5)
         shift_output_enable(true); //enable shift register outputs, also enabled level translator so don't do RGB LEDs before here!
     #endif
     //busy_wait_ms(10);
@@ -164,7 +164,7 @@ int main(){
     // Now continue after init of all the pins and shift registers
     // Mount the TF flash card file system (and put into SPI mode)
     // This must be done before any other SPI communications
-    #if (BP_VER == 5 && BP_REV <= 9)
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
         spi_set_baudrate(BP_SPI_PORT, BP_SPI_START_SPEED);
         storage_mount();
         if(storage_load_config()){
@@ -207,7 +207,7 @@ int main(){
 	psucmd_disable();    // disable psu and reset pin label, clear any errors
 
     // mount NAND flash here
-    #if !(BP_VER == 5 && BP_REV <= 9)
+    #if !(BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
         storage_mount();
         if(storage_load_config()){
             system_config.config_loaded_from_file=true;
@@ -219,12 +219,12 @@ int main(){
     // we need to have read any config files on the TF flash card before now
     icm_core0_send_message_synchronous(BP_ICM_INIT_CORE1);
 
-    #if (BP_VER == 5)
+    #if (BP_VERSION == 5)
         //test for PCB revision
         //must be done after shift register setup
         // if firmware mismatch, turn all LEDs red
-        if(bp_rev!=BP_REV){ //
-            //printf("Error: PCB revision does not match firmware. Expected %d, found %d.\r\n", BP_REV, mcu_detect_revision());
+        if(BP_BOARD_REVISION!=BP_BOARD_REVISION){ //
+            //printf("Error: PCB revision does not match firmware. Expected %d, found %d.\r\n", BP_BOARD_REVISION, mcu_detect_revision());
             rgb_irq_enable(false);
             while(true){ 
                 rgb_set_all(0xff, 0, 0);
@@ -462,7 +462,7 @@ void core1_entry(void){
             }
 
             //remains for legacy REV8 support of TF flash
-            #if BP_REV<10
+            #if BP_BOARD_REVISION<10
                 if(storage_detect())
                 {
 

--- a/pirate.c
+++ b/pirate.c
@@ -12,7 +12,7 @@
 #include "opt_args.h"
 #include "ui/ui_lcd.h"
 #include "pirate/rgb.h"
-#if (BP_VERSION == 5 || BP_VERSION == XL5)
+#if (BP_VERSION == BP5 || BP_VERSION == BP5XL)
     // BP5 and BPXL5 have to use an external expander due to limited pins
     #include "pirate/shift.h"
 #endif
@@ -74,7 +74,7 @@ void gpio_setup(uint8_t pin, bool direction, bool level){
 int main(){
     char c;
     
-    #if (BP_VERSION == 5)
+    #if (BP_VERSION == BP5)
         uint8_t detected_board_revision=mcu_detect_revision();
     #endif
 
@@ -92,7 +92,7 @@ int main(){
     gpio_set_function(BP_SPI_CDO, GPIO_FUNC_SPI);
 
     // init shift register pins
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_init();
     #endif
     
@@ -119,7 +119,7 @@ int main(){
     storage_init();
 
     //initial pin states
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         // configure the defaults for shift register attached hardware
         shift_clear_set_wait(CURRENT_EN_OVERRIDE, (AMUX_S3|AMUX_S1|DISPLAY_RESET|CURRENT_EN));
     #else
@@ -142,7 +142,7 @@ int main(){
     #endif
     pullups_init(); //uses shift register internally  
 
-    #if (BP_VERSION == 5 || BP_VERSION == XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION == BP5XL)
         shift_output_enable(true); //enable shift register outputs, also enabled level translator so don't do RGB LEDs before here!
     #else
         // BUGBUG ... if above enabled level translator for BP5 / BP5XL, then where is that done for BP6?
@@ -167,7 +167,7 @@ int main(){
     // Now continue after init of all the pins and shift registers
     // Mount the TF flash card file system (and put into SPI mode)
     // This must be done before any other SPI communications
-    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
+    #if (BP_VERSION == BP5 && BP_BOARD_REVISION <= 9)
         spi_set_baudrate(BP_SPI_PORT, BP_SPI_START_SPEED);
         storage_mount();
         if(storage_load_config()){
@@ -210,7 +210,7 @@ int main(){
 	psucmd_disable();    // disable psu and reset pin label, clear any errors
 
     // mount NAND flash here
-    #if ((BP_VERSION == 5 && BP_BOARD_REVISION > 9) || BP_VERSION == XL5 || BP_VERSION == 6)
+    #if ((BP_VERSION == BP5 && BP_BOARD_REVISION > 9) || BP_VERSION == BP5XL || BP_VERSION == BP6)
         storage_mount();
         if(storage_load_config()){
             system_config.config_loaded_from_file=true;
@@ -222,7 +222,7 @@ int main(){
     // we need to have read any config files on the TF flash card before now
     icm_core0_send_message_synchronous(BP_ICM_INIT_CORE1);
 
-    #if (BP_VERSION == 5)
+    #if (BP_VERSION == BP5)
         //test for PCB revision
         //must be done after shift register setup
         // if firmware mismatch, turn all LEDs red

--- a/pirate.c
+++ b/pirate.c
@@ -13,6 +13,7 @@
 #include "ui/ui_lcd.h"
 #include "pirate/rgb.h"
 #if (BP_VERSION == 5 || BP_VERSION == XL5)
+    // BP5 and BPXL5 have to use an external expander due to limited pins
     #include "pirate/shift.h"
 #endif
 #include "pirate/bio.h"

--- a/pirate.c
+++ b/pirate.c
@@ -74,8 +74,8 @@ void gpio_setup(uint8_t pin, bool direction, bool level){
 int main(){
     char c;
     
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
-        uint8_t BP_BOARD_REVISION=mcu_detect_revision();
+    #if (BP_VERSION == 5)
+        uint8_t detected_board_revision=mcu_detect_revision();
     #endif
 
     reserve_for_future_mode_specific_allocations[1] = 99;
@@ -142,8 +142,10 @@ int main(){
     #endif
     pullups_init(); //uses shift register internally  
 
-    #if(BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION == XL5)
         shift_output_enable(true); //enable shift register outputs, also enabled level translator so don't do RGB LEDs before here!
+    #else
+        // BUGBUG ... if above enabled level translator for BP5 / BP5XL, then where is that done for BP6?
     #endif
     //busy_wait_ms(10);
     //reset the LCD
@@ -208,7 +210,7 @@ int main(){
 	psucmd_disable();    // disable psu and reset pin label, clear any errors
 
     // mount NAND flash here
-    #if !(BP_VERSION == 5 && BP_BOARD_REVISION <= 9)
+    #if ((BP_VERSION == 5 && BP_BOARD_REVISION > 9) || BP_VERSION == XL5 || BP_VERSION == 6)
         storage_mount();
         if(storage_load_config()){
             system_config.config_loaded_from_file=true;
@@ -224,8 +226,8 @@ int main(){
         //test for PCB revision
         //must be done after shift register setup
         // if firmware mismatch, turn all LEDs red
-        if(BP_BOARD_REVISION!=BP_BOARD_REVISION){ //
-            //printf("Error: PCB revision does not match firmware. Expected %d, found %d.\r\n", BP_BOARD_REVISION, mcu_detect_revision());
+        if(detected_board_revision!=BP_BOARD_REVISION){ //
+            //printf("Error: PCB revision does not match firmware. Expected %d, found %d.\r\n", BP_BOARD_REVISION, detected_board_revision);
             rgb_irq_enable(false);
             while(true){ 
                 rgb_set_all(0xff, 0, 0);

--- a/pirate.h
+++ b/pirate.h
@@ -55,7 +55,7 @@
 #ifndef BP_BOARD_REVISION
     #error "No /platform/ file included in pirate.h"
 #else
-    #if BP_VERSION == 5
+    #if BP_VERSION == BP5
         #if BP_BOARD_REVISION == 8
             #include "platform/bpi-rev8.h"
         #elif BP_BOARD_REVISION == 9
@@ -65,9 +65,9 @@
         #else
             #error "Unknown platform version in pirate.h"
         #endif
-    #elif BP_VERSION == XL5
+    #elif BP_VERSION == BP5XL
         #include "platform/bpi-rev10.h"
-    #elif BP_VERSION == 6
+    #elif BP_VERSION == BP6
         #include "platform/bpi6-rev1.h"
     #else
         #error "Unknown platform version in pirate.h"

--- a/pirate.h
+++ b/pirate.h
@@ -52,22 +52,22 @@
 #define BIG_BUFFER_SIZE (128 * 1024)
 
 // include platform
-#ifndef BP_REV
+#ifndef BP_BOARD_REVISION
     #error "No /platform/ file included in pirate.h"
 #else
-    #if BP_VER == 5
-        #if BP_REV == 8
+    #if BP_VERSION == 5
+        #if BP_BOARD_REVISION == 8
             #include "platform/bpi-rev8.h"
-        #elif BP_REV == 9
+        #elif BP_BOARD_REVISION == 9
             #include "platform/bpi-rev9.h"
-        #elif BP_REV == 10
+        #elif BP_BOARD_REVISION == 10
             #include "platform/bpi-rev10.h"
         #else
             #error "Unknown platform version in pirate.h"
         #endif
-    #elif BP_VER == XL5
+    #elif BP_VERSION == XL5
         #include "platform/bpi-rev10.h"
-    #elif BP_VER == 6
+    #elif BP_VERSION == 6
         #include "platform/bpi6-rev1.h"
     #else
         #error "Unknown platform version in pirate.h"

--- a/pirate/amux.c
+++ b/pirate/amux.c
@@ -49,9 +49,9 @@ void amux_init(void){
 bool amux_select_input(uint16_t channel){
     if (scope_running) return false;// scope is using the analog subsystem
     //clear the amux control bits, set the amux channel bits
-    #if(BP_VERSION==5 || BP_VERSION==XL5)
+    #if (BP_VERSION==5 || BP_VERSION==XL5)
         shift_clear_set((0b1111<<1), (channel<<1)&0b11110, true);  
-    #else
+    #elif (BP_VERSION==6)
         //uint64_t value=(uint64_t)(channel<<AMUX_S0);
         //uint64_t mask=(uint64_t)(0b1111<<AMUX_S0);
         //gpio_put_masked(mask, value);
@@ -59,6 +59,8 @@ bool amux_select_input(uint16_t channel){
         gpio_put(AMUX_S1, (channel>>1)&1);
         gpio_put(AMUX_S2, (channel>>2)&1);
         gpio_put(AMUX_S3, (channel>>3)&1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
     return true;
 }

--- a/pirate/amux.c
+++ b/pirate/amux.c
@@ -49,9 +49,9 @@ void amux_init(void){
 bool amux_select_input(uint16_t channel){
     if (scope_running) return false;// scope is using the analog subsystem
     //clear the amux control bits, set the amux channel bits
-    #if (BP_VERSION==5 || BP_VERSION==XL5)
+    #if (BP_VERSION==BP5 || BP_VERSION==BP5XL)
         shift_clear_set((0b1111<<1), (channel<<1)&0b11110, true);  
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         //uint64_t value=(uint64_t)(channel<<AMUX_S0);
         //uint64_t mask=(uint64_t)(0b1111<<AMUX_S0);
         //gpio_put_masked(mask, value);

--- a/pirate/amux.c
+++ b/pirate/amux.c
@@ -49,7 +49,7 @@ void amux_init(void){
 bool amux_select_input(uint16_t channel){
     if (scope_running) return false;// scope is using the analog subsystem
     //clear the amux control bits, set the amux channel bits
-    #if(BP_VER==5 || BP_VER==XL5)
+    #if(BP_VERSION==5 || BP_VERSION==XL5)
         shift_clear_set((0b1111<<1), (channel<<1)&0b11110, true);  
     #else
         //uint64_t value=(uint64_t)(channel<<AMUX_S0);

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -17,9 +17,9 @@ static volatile enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){
-    #if (BP_VERSION==5)
+    #if (BP_VERSION==BP5)
         return gpio_get(EXT1);
-    #elif ((BP_VERSION==6) || (BP_VERSION==XL5))
+    #elif ((BP_VERSION==BP6) || (BP_VERSION==BP5XL))
         return !gpio_get(EXT1);
     #else
         #error "Unknown BP_VERSION"
@@ -71,9 +71,9 @@ void button_irq_disable(uint8_t button_id){
 void button_init(void){
     gpio_set_function(EXT1, GPIO_FUNC_SIO);
     gpio_set_dir(EXT1, GPIO_IN);
-    #if(BP_VERSION==5)
+    #if(BP_VERSION==BP5)
         gpio_pull_down(EXT1);
-    #elif ((BP_VERSION==6) || (BP_VERSION==XL5))
+    #elif ((BP_VERSION==BP6) || (BP_VERSION==BP5XL))
         gpio_pull_up(EXT1);
     #else
         #error "Unknown BP_VERSION"

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -17,7 +17,7 @@ static volatile enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){
-    #if(BP_VER==5)
+    #if(BP_VERSION==5)
         return gpio_get(EXT1);
     #else
         return !gpio_get(EXT1);
@@ -69,7 +69,7 @@ void button_irq_disable(uint8_t button_id){
 void button_init(void){
     gpio_set_function(EXT1, GPIO_FUNC_SIO);
     gpio_set_dir(EXT1, GPIO_IN);
-    #if(BP_VER==5)
+    #if(BP_VERSION==5)
         gpio_pull_down(EXT1);
     #else
         gpio_pull_up(EXT1);

--- a/pirate/button.c
+++ b/pirate/button.c
@@ -17,10 +17,12 @@ static volatile enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id){
-    #if(BP_VERSION==5)
+    #if (BP_VERSION==5)
         return gpio_get(EXT1);
-    #else
+    #elif ((BP_VERSION==6) || (BP_VERSION==XL5))
         return !gpio_get(EXT1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
 } 
 // check button press type
@@ -71,7 +73,9 @@ void button_init(void){
     gpio_set_dir(EXT1, GPIO_IN);
     #if(BP_VERSION==5)
         gpio_pull_down(EXT1);
-    #else
+    #elif ((BP_VERSION==6) || (BP_VERSION==XL5))
         gpio_pull_up(EXT1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
 }

--- a/pirate/lcd.c
+++ b/pirate/lcd.c
@@ -13,7 +13,7 @@ void lcd_init(void){
     gpio_put(DISPLAY_DP, 1);
     gpio_set_dir(DISPLAY_DP, GPIO_OUT);
 
-    #if (BP_VER >= 6)
+    #if (BP_VERSION >= 6)
         gpio_set_function(DISPLAY_BACKLIGHT, GPIO_FUNC_SIO);
         gpio_put(DISPLAY_BACKLIGHT, 0);
         gpio_set_dir(DISPLAY_BACKLIGHT, GPIO_OUT);
@@ -27,13 +27,13 @@ void lcd_init(void){
 void lcd_backlight_enable(bool enable){
     
     if(enable){
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait( 0, (DISPLAY_BACKLIGHT)); 
         #else
             gpio_put(DISPLAY_BACKLIGHT,1);
         #endif
     }else{
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait( (DISPLAY_BACKLIGHT), 0); 
         #else
             gpio_put(DISPLAY_BACKLIGHT,0);
@@ -43,13 +43,13 @@ void lcd_backlight_enable(bool enable){
 
 // perform a hardware reset of the LCD according to datasheet specs
 void lcd_reset(void){
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(DISPLAY_RESET,0);
     #else
         gpio_put(DISPLAY_RESET,0);
     #endif
     busy_wait_us(20);
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(0, DISPLAY_RESET);
     #else
         gpio_put(DISPLAY_RESET,1);

--- a/pirate/lcd.c
+++ b/pirate/lcd.c
@@ -13,7 +13,7 @@ void lcd_init(void){
     gpio_put(DISPLAY_DP, 1);
     gpio_set_dir(DISPLAY_DP, GPIO_OUT);
 
-    #if (BP_VERSION >= 6)
+    #if (BP_VERSION == 6)
         gpio_set_function(DISPLAY_BACKLIGHT, GPIO_FUNC_SIO);
         gpio_put(DISPLAY_BACKLIGHT, 0);
         gpio_set_dir(DISPLAY_BACKLIGHT, GPIO_OUT);
@@ -29,14 +29,18 @@ void lcd_backlight_enable(bool enable){
     if(enable){
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait( 0, (DISPLAY_BACKLIGHT)); 
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(DISPLAY_BACKLIGHT,1);
+        #else
+            #error "Unknown BP_VERSION"
         #endif
     }else{
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait( (DISPLAY_BACKLIGHT), 0); 
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(DISPLAY_BACKLIGHT,0);
+        #else
+            #error "Unknown BP_VERSION"
         #endif  
     }
 }
@@ -45,14 +49,18 @@ void lcd_backlight_enable(bool enable){
 void lcd_reset(void){
     #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(DISPLAY_RESET,0);
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(DISPLAY_RESET,0);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
     busy_wait_us(20);
     #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(0, DISPLAY_RESET);
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(DISPLAY_RESET,1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
     busy_wait_ms(100);
 }

--- a/pirate/lcd.c
+++ b/pirate/lcd.c
@@ -13,7 +13,7 @@ void lcd_init(void){
     gpio_put(DISPLAY_DP, 1);
     gpio_set_dir(DISPLAY_DP, GPIO_OUT);
 
-    #if (BP_VERSION == 6)
+    #if (BP_VERSION == BP6)
         gpio_set_function(DISPLAY_BACKLIGHT, GPIO_FUNC_SIO);
         gpio_put(DISPLAY_BACKLIGHT, 0);
         gpio_set_dir(DISPLAY_BACKLIGHT, GPIO_OUT);
@@ -27,17 +27,17 @@ void lcd_init(void){
 void lcd_backlight_enable(bool enable){
     
     if(enable){
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait( 0, (DISPLAY_BACKLIGHT)); 
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(DISPLAY_BACKLIGHT,1);
         #else
             #error "Unknown BP_VERSION"
         #endif
     }else{
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait( (DISPLAY_BACKLIGHT), 0); 
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(DISPLAY_BACKLIGHT,0);
         #else
             #error "Unknown BP_VERSION"
@@ -47,17 +47,17 @@ void lcd_backlight_enable(bool enable){
 
 // perform a hardware reset of the LCD according to datasheet specs
 void lcd_reset(void){
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_clear_set_wait(DISPLAY_RESET,0);
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         gpio_put(DISPLAY_RESET,0);
     #else
         #error "Unknown BP_VERSION"
     #endif
     busy_wait_us(20);
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_clear_set_wait(0, DISPLAY_RESET);
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         gpio_put(DISPLAY_RESET,1);
     #else
         #error "Unknown BP_VERSION"

--- a/pirate/psu.c
+++ b/pirate/psu.c
@@ -23,17 +23,17 @@ struct psu_status_t psu_status;
 
 static void psu_fuse_reset(void){
     //reset current trigger
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_clear_set_wait(CURRENT_RESET,0); //low to activate the pnp
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         gpio_put(CURRENT_RESET,0);
     #else
         #error "Unknown BP_VERSION"
     #endif
     busy_wait_ms(1);
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_clear_set_wait(0, CURRENT_RESET); //high to disable  
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         gpio_put(CURRENT_RESET,1);
     #else
         #error "Unknown BP_VERSION"
@@ -43,17 +43,17 @@ static void psu_fuse_reset(void){
 //TODO: rename this function, it actually controls if the current limit circuit is connected to the VREG
 void psu_vreg_enable(bool enable){
     if(enable){
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait(CURRENT_EN,0); //low is on (PNP)
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(CURRENT_EN,0);
         #else
             #error "Unknown BP_VERSION"
         #endif
     }else{
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait(0,CURRENT_EN); //high is off
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(CURRENT_EN,1);
         #else
             #error "Unknown BP_VERSION"
@@ -63,17 +63,17 @@ void psu_vreg_enable(bool enable){
 
 void psu_current_limit_override(bool enable){
     if(enable){
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait(0, CURRENT_EN_OVERRIDE);
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(CURRENT_EN_OVERRIDE,1);
         #else
             #error "Unknown BP_VERSION"
         #endif
     }else{
-        #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
             shift_clear_set_wait(CURRENT_EN_OVERRIDE,0);
-        #elif (BP_VERSION==6)
+        #elif (BP_VERSION==BP6)
             gpio_put(CURRENT_EN_OVERRIDE,0);
         #else
             #error "Unknown BP_VERSION"

--- a/pirate/psu.c
+++ b/pirate/psu.c
@@ -23,13 +23,13 @@ struct psu_status_t psu_status;
 
 static void psu_fuse_reset(void){
     //reset current trigger
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(CURRENT_RESET,0); //low to activate the pnp
     #else
         gpio_put(CURRENT_RESET,0);
     #endif
     busy_wait_ms(1);
-    #if (BP_VER == 5 || BP_VER==XL5)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(0, CURRENT_RESET); //high to disable  
     #else
         gpio_put(CURRENT_RESET,1);
@@ -39,13 +39,13 @@ static void psu_fuse_reset(void){
 //TODO: rename this function, it actually controls if the current limit circuit is connected to the VREG
 void psu_vreg_enable(bool enable){
     if(enable){
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(CURRENT_EN,0); //low is on (PNP)
         #else
             gpio_put(CURRENT_EN,0);
         #endif
     }else{
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(0,CURRENT_EN); //high is off
         #else
             gpio_put(CURRENT_EN,1);
@@ -55,13 +55,13 @@ void psu_vreg_enable(bool enable){
 
 void psu_current_limit_override(bool enable){
     if(enable){
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(0, CURRENT_EN_OVERRIDE);
         #else
             gpio_put(CURRENT_EN_OVERRIDE,1);
         #endif
     }else{
-        #if (BP_VER == 5 || BP_VER==XL5)
+        #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(CURRENT_EN_OVERRIDE,0);
         #else
             gpio_put(CURRENT_EN_OVERRIDE,0);

--- a/pirate/psu.c
+++ b/pirate/psu.c
@@ -25,14 +25,18 @@ static void psu_fuse_reset(void){
     //reset current trigger
     #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(CURRENT_RESET,0); //low to activate the pnp
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(CURRENT_RESET,0);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
     busy_wait_ms(1);
     #if (BP_VERSION == 5 || BP_VERSION==XL5)
         shift_clear_set_wait(0, CURRENT_RESET); //high to disable  
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(CURRENT_RESET,1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
 }
 
@@ -41,14 +45,18 @@ void psu_vreg_enable(bool enable){
     if(enable){
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(CURRENT_EN,0); //low is on (PNP)
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(CURRENT_EN,0);
+        #else
+            #error "Unknown BP_VERSION"
         #endif
     }else{
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(0,CURRENT_EN); //high is off
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(CURRENT_EN,1);
+        #else
+            #error "Unknown BP_VERSION"
         #endif
     }
 }
@@ -57,14 +65,18 @@ void psu_current_limit_override(bool enable){
     if(enable){
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(0, CURRENT_EN_OVERRIDE);
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(CURRENT_EN_OVERRIDE,1);
+        #else
+            #error "Unknown BP_VERSION"
         #endif
     }else{
         #if (BP_VERSION == 5 || BP_VERSION==XL5)
             shift_clear_set_wait(CURRENT_EN_OVERRIDE,0);
-        #else
+        #elif (BP_VERSION==6)
             gpio_put(CURRENT_EN_OVERRIDE,0);
+        #else
+            #error "Unknown BP_VERSION"
         #endif
     }
 }

--- a/pirate/pullup.c
+++ b/pirate/pullup.c
@@ -5,8 +5,8 @@
 
 void pullup_enable(void){
 
-    #if (BP_VER == 5 || BP_VER==XL5)
-        #if BP_REV <= 8
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if BP_BOARD_REVISION <= 8
             shift_clear_set_wait(0,PULLUP_EN);  
         #else
             shift_clear_set_wait(PULLUP_EN,0);
@@ -17,8 +17,8 @@ void pullup_enable(void){
 }
 
 void pullup_disable(void){
-    #if (BP_VER == 5 || BP_VER==XL5)
-        #if BP_REV <= 8
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        #if BP_BOARD_REVISION <= 8
             shift_clear_set_wait(PULLUP_EN,0); 
         #else
             shift_clear_set_wait(0,PULLUP_EN);
@@ -29,7 +29,7 @@ void pullup_disable(void){
 }
 
 void pullup_init(void){
-    #if (BP_VER >=6)
+    #if (BP_VERSION >=6)
         gpio_set_function(PULLUP_EN, GPIO_FUNC_SIO);
         gpio_set_dir(PULLUP_EN, GPIO_OUT);
     #endif

--- a/pirate/pullup.c
+++ b/pirate/pullup.c
@@ -17,11 +17,11 @@ void pullup_enable(void){
 }
 
 void pullup_disable(void){
-    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+    #if (BP_VERSION == BP5 && BP_BOARD_REVISION <= 8)
         shift_clear_set_wait(PULLUP_EN,0); 
-    #elif (BP_VERSION == 5 || BP_VERSION==XL5)
+    #elif (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         shift_clear_set_wait(0,PULLUP_EN);
-    #elif (BP_VERSION==6)
+    #elif (BP_VERSION==BP6)
         gpio_put(PULLUP_EN,1);
     #else
         #error "Unknown BP_VERSION"
@@ -29,9 +29,9 @@ void pullup_disable(void){
 }
 
 void pullup_init(void){
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+    #if (BP_VERSION == BP5 || BP_VERSION==BP5XL)
         // nothing to do for 5 / 5XL
-    #elif (BP_VERSION ==6)
+    #elif (BP_VERSION ==BP6)
         gpio_set_function(PULLUP_EN, GPIO_FUNC_SIO);
         gpio_set_dir(PULLUP_EN, GPIO_OUT);
     #else

--- a/pirate/pullup.c
+++ b/pirate/pullup.c
@@ -11,8 +11,10 @@ void pullup_enable(void){
         #else
             shift_clear_set_wait(PULLUP_EN,0);
         #endif
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(PULLUP_EN,0);        
+    #else
+        #error "Unknown BP_VERSION"
     #endif
 }
 
@@ -23,15 +25,21 @@ void pullup_disable(void){
         #else
             shift_clear_set_wait(0,PULLUP_EN);
         #endif
-    #else
+    #elif (BP_VERSION==6)
         gpio_put(PULLUP_EN,1);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
 }
 
 void pullup_init(void){
-    #if (BP_VERSION >=6)
+    #if (BP_VERSION == 5 || BP_VERSION==XL5)
+        // nothing to do for 5 / 5XL
+    #elif (BP_VERSION ==6)
         gpio_set_function(PULLUP_EN, GPIO_FUNC_SIO);
         gpio_set_dir(PULLUP_EN, GPIO_OUT);
+    #else
+        #error "Unknown BP_VERSION"
     #endif
     pullup_disable();
 }

--- a/pirate/pullup.c
+++ b/pirate/pullup.c
@@ -5,12 +5,10 @@
 
 void pullup_enable(void){
 
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+        shift_clear_set_wait(0,PULLUP_EN);  
     #if (BP_VERSION == 5 || BP_VERSION==XL5)
-        #if BP_BOARD_REVISION <= 8
-            shift_clear_set_wait(0,PULLUP_EN);  
-        #else
-            shift_clear_set_wait(PULLUP_EN,0);
-        #endif
+        shift_clear_set_wait(PULLUP_EN,0);
     #elif (BP_VERSION==6)
         gpio_put(PULLUP_EN,0);        
     #else
@@ -19,12 +17,10 @@ void pullup_enable(void){
 }
 
 void pullup_disable(void){
-    #if (BP_VERSION == 5 || BP_VERSION==XL5)
-        #if BP_BOARD_REVISION <= 8
-            shift_clear_set_wait(PULLUP_EN,0); 
-        #else
-            shift_clear_set_wait(0,PULLUP_EN);
-        #endif
+    #if (BP_VERSION == 5 && BP_BOARD_REVISION <= 8)
+        shift_clear_set_wait(PULLUP_EN,0); 
+    #elif (BP_VERSION == 5 || BP_VERSION==XL5)
+        shift_clear_set_wait(0,PULLUP_EN);
     #elif (BP_VERSION==6)
         gpio_put(PULLUP_EN,1);
     #else

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -51,7 +51,7 @@ static uint offset;
     static const coordin8_t pixel_coordin8[] = {
         //                        // SIDE      POSITION    FACING
         // clang-format off
-        #if BP_REV >= 10
+        #if BP_BOARD_REVISION >= 10
         { .x = 127, .y = 255,  }, // bottom    center      out
         #endif
         { .x = 165, .y = 255,  }, // bottom    right       side
@@ -70,7 +70,7 @@ static uint offset;
         { .x =   0, .y = 171,  }, // left      bottom      side    (by USB port)
         { .x =   0, .y = 202,  }, // left      bottom      out
         { .x =  52, .y = 255,  }, // bottom    left        out
-        #if BP_REV >= 10
+        #if BP_BOARD_REVISION >= 10
         { .x =  90, .y = 255,  }, // bottom    left        side
         #endif
         // clang-format on
@@ -84,7 +84,7 @@ static uint offset;
     static const uint8_t pixel_angle256[] = {
         //                  // SIDE      POSITION    FACING
         // clang-format off
-        #if BP_REV >= 10
+        #if BP_BOARD_REVISION >= 10
         192,                // bottom    center      out
         #endif
         204,                // bottom    right       side
@@ -103,7 +103,7 @@ static uint offset;
         141,                // left      bottom      side    (by USB port)
         150,                // left      bottom      out
         170,                // bottom    left        out
-        #if BP_REV >= 10
+        #if BP_BOARD_REVISION >= 10
         180,                // bottom    left        side
         #endif
         // clang-format on
@@ -117,7 +117,7 @@ static uint offset;
     //static const uint32_t PIXEL_MASK_SIDE  = 0b1....0;
 
     // clang-format off
-    #if BP_REV <= 9
+    #if BP_BOARD_REVISION <= 9
         // Pixels that shine    orthogonal to OLED: idx     1,2,    5,6,  8,  10,11,      14,15,
         #define PIXEL_MASK_UPPER ( 0b1100110101100110 )
         // Pixels that shine    orthogonal to OLED: idx   0,    3,4,    7,  9,      12,13,
@@ -222,7 +222,7 @@ static CPIXEL_COLOR reduce_brightness(CPIXEL_COLOR c, uint8_t numerator, uint8_t
     //    All the pixels facing upwards as one group, and all the pixels
     //    facing the sides as a second group.
 
-    #if BP_REV <= 9
+    #if BP_BOARD_REVISION <= 9
         static const uint32_t groups_top_left[] = {
             // clang-format off
             ((1u <<  1) | (1u <<  2)             ),
@@ -258,7 +258,7 @@ static CPIXEL_COLOR reduce_brightness(CPIXEL_COLOR c, uint8_t numerator, uint8_t
             ((1u << 11) | (1u << 12)),
             // clang-format on
         };
-    #elif BP_REV >= 10
+    #elif BP_BOARD_REVISION >= 10
         static const uint32_t groups_top_left[] = {
             // TODO: use grid mappings instead
             //       e.g., for iteration target from 255..0
@@ -743,7 +743,7 @@ void rgb_irq_enable(bool enable){
 
 void rgb_init(void){
 
-    #if (BP_VER == 6)
+    #if (BP_VERSION == 6)
         bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio, &sm, &offset, RGB_CDO, 16, true);
     #else
         bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio, &sm, &offset, RGB_CDO, 1, true);

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -131,7 +131,7 @@ static uint z_rgb_sm_offset;
     //static const uint32_t PIXEL_MASK_SIDE  = 0b1....0;
 
     // clang-format off
-    #if BP_BOARD_REVISION <= 9
+    #if !defined(RGB_HAS_ALL_PIXELS)
         // Pixels that shine    orthogonal to OLED: idx     1,2,    5,6,  8,  10,11,      14,15,
         #define PIXEL_MASK_UPPER ( 0b1100110101100110 )
         // Pixels that shine    orthogonal to OLED: idx   0,    3,4,    7,  9,      12,13,
@@ -236,7 +236,7 @@ static CPIXEL_COLOR reduce_brightness(CPIXEL_COLOR c, uint8_t numerator, uint8_t
     //    All the pixels facing upwards as one group, and all the pixels
     //    facing the sides as a second group.
 
-    #if BP_BOARD_REVISION <= 9
+    #if !defined(RGB_HAS_ALL_PIXELS)
         static const uint32_t groups_top_left[] = {
             // clang-format off
             ((1u <<  1) | (1u <<  2)             ),
@@ -272,7 +272,7 @@ static CPIXEL_COLOR reduce_brightness(CPIXEL_COLOR c, uint8_t numerator, uint8_t
             ((1u << 11) | (1u << 12)),
             // clang-format on
         };
-    #elif BP_BOARD_REVISION >= 10
+    #else // defined(RGB_HAS_ALL_PIXELS)
         static const uint32_t groups_top_left[] = {
             // TODO: use grid mappings instead
             //       e.g., for iteration target from 255..0

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -21,6 +21,19 @@
 //
 #define COUNT_OF_PIXELS RGB_LEN // 18 for Rev10, 16 for Rev8
 
+#if (BP_VERSION == 6)
+    #define RGB_HAS_ALL_PIXELS
+#elif (BP_VERSION == XL5)
+    #define RGB_HAS_ALL_PIXELS
+#elif (BP_VERSION == 5 && BP_BOARD_REVISION >= 10)
+    #define RGB_HAS_ALL_PIXELS
+#elif (BP_VERSION == 5)
+    // do NOT define the symbol ... as a few pixels are missing vs. later boards
+#else
+    #error "Unknown BP_VERSION" // check logic to see if pixels have changed for new board
+#endif
+
+
 static PIO z_rgb_pio;
 static int z_rgb_sm;
 static uint z_rgb_sm_offset;
@@ -51,7 +64,8 @@ static uint z_rgb_sm_offset;
     static const coordin8_t pixel_coordin8[] = {
         //                        // SIDE      POSITION    FACING
         // clang-format off
-        #if BP_BOARD_REVISION >= 10
+        #if defined(RGB_HAS_ALL_PIXELS)
+        { .x =  90, .y = 255,  }, // bottom    left        side
         { .x = 127, .y = 255,  }, // bottom    center      out
         #endif
         { .x = 165, .y = 255,  }, // bottom    right       side
@@ -70,7 +84,7 @@ static uint z_rgb_sm_offset;
         { .x =   0, .y = 171,  }, // left      bottom      side    (by USB port)
         { .x =   0, .y = 202,  }, // left      bottom      out
         { .x =  52, .y = 255,  }, // bottom    left        out
-        #if BP_BOARD_REVISION >= 10
+        #if defined(RGB_HAS_ALL_PIXELS)
         { .x =  90, .y = 255,  }, // bottom    left        side
         #endif
         // clang-format on
@@ -84,7 +98,7 @@ static uint z_rgb_sm_offset;
     static const uint8_t pixel_angle256[] = {
         //                  // SIDE      POSITION    FACING
         // clang-format off
-        #if BP_BOARD_REVISION >= 10
+        #if defined(RGB_HAS_ALL_PIXELS)
         192,                // bottom    center      out
         #endif
         204,                // bottom    right       side
@@ -103,7 +117,7 @@ static uint z_rgb_sm_offset;
         141,                // left      bottom      side    (by USB port)
         150,                // left      bottom      out
         170,                // bottom    left        out
-        #if BP_BOARD_REVISION >= 10
+        #if defined(RGB_HAS_ALL_PIXELS)
         180,                // bottom    left        side
         #endif
         // clang-format on
@@ -744,6 +758,10 @@ void rgb_irq_enable(bool enable){
 void rgb_init(void){
 
     #if (BP_VERSION == 6)
+        // BUGBUG -- What are the magic numbers `16` and `1` down below?
+        //           Better to either give a local variable a descriptive name, 
+        //           or to use symbolic constants, as this appears to be a
+        //           board-specific item (e.g. did the GPIO changed for BP6?)
         bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &z_rgb_pio, &z_rgb_sm, &z_rgb_sm_offset, RGB_CDO, 16, true);
     #else
         bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &z_rgb_pio, &z_rgb_sm, &z_rgb_sm_offset, RGB_CDO,  1, true);

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -21,13 +21,13 @@
 //
 #define COUNT_OF_PIXELS RGB_LEN // 18 for Rev10, 16 for Rev8
 
-#if (BP_VERSION == 6)
+#if (BP_VERSION == BP6)
     #define RGB_HAS_ALL_PIXELS
-#elif (BP_VERSION == XL5)
+#elif (BP_VERSION == BP5XL)
     #define RGB_HAS_ALL_PIXELS
-#elif (BP_VERSION == 5 && BP_BOARD_REVISION >= 10)
+#elif (BP_VERSION == BP5 && BP_BOARD_REVISION >= 10)
     #define RGB_HAS_ALL_PIXELS
-#elif (BP_VERSION == 5)
+#elif (BP_VERSION == BP5)
     // do NOT define the symbol ... as a few pixels are missing vs. later boards
 #else
     #error "Unknown BP_VERSION" // check logic to see if pixels have changed for new board
@@ -757,7 +757,7 @@ void rgb_irq_enable(bool enable){
 
 void rgb_init(void){
 
-    #if (BP_VERSION == 6)
+    #if (BP_VERSION == BP6)
         // BUGBUG -- What are the magic numbers `16` and `1` down below?
         //           Better to either give a local variable a descriptive name, 
         //           or to use symbolic constants, as this appears to be a

--- a/pirate/rgb.c
+++ b/pirate/rgb.c
@@ -21,9 +21,9 @@
 //
 #define COUNT_OF_PIXELS RGB_LEN // 18 for Rev10, 16 for Rev8
 
-static PIO pio;
-static int sm;
-static uint offset;
+static PIO z_rgb_pio;
+static int z_rgb_sm;
+static uint z_rgb_sm_offset;
 
 #pragma region    // 8-bit scaled pixel coordinates and angle256
     /// @brief Scaled coordinates in range [0..255]
@@ -332,7 +332,7 @@ static inline void update_pixels(void) {
         // TODO: define symbolic constant for which PIO / state machine (no magic numbers!)
         //       e.g., #define WS2812_PIO  pio1
         //       e.g., #define WS2812_SM   3
-        pio_sm_put_blocking(pio, sm, toSend);
+        pio_sm_put_blocking(z_rgb_pio, z_rgb_sm, toSend);
     }
 }
 
@@ -744,13 +744,13 @@ void rgb_irq_enable(bool enable){
 void rgb_init(void){
 
     #if (BP_VERSION == 6)
-        bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio, &sm, &offset, RGB_CDO, 16, true);
+        bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &z_rgb_pio, &z_rgb_sm, &z_rgb_sm_offset, RGB_CDO, 16, true);
     #else
-        bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio, &sm, &offset, RGB_CDO, 1, true);
+        bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &z_rgb_pio, &z_rgb_sm, &z_rgb_sm_offset, RGB_CDO,  1, true);
     #endif
     hard_assert(success);
     
-    ws2812_program_init(pio, sm, offset, RGB_CDO, 800000, false);
+    ws2812_program_init(z_rgb_pio, z_rgb_sm, z_rgb_sm_offset, RGB_CDO, 800000, false);
 
     for (int i = 0; i < COUNT_OF_PIXELS; i++){
         pixels[i] = PIXEL_COLOR_BLACK;

--- a/pirate/storage.c
+++ b/pirate/storage.c
@@ -92,13 +92,13 @@ void storage_unmount(void){
     f_unmount("");
     system_config.storage_available=false;
     system_config.storage_mount_error=0;
-#if BP_REV == 8 || BP_REV == 9
+#if BP_BOARD_REVISION == 8 || BP_BOARD_REVISION == 9
     printf("Storage removed\r\n");
 #endif
 }
 
 bool storage_detect(void){        
-    #if BP_REV==8 || BP_REV==9
+    #if BP_BOARD_REVISION==8 || BP_BOARD_REVISION==9
     //TF flash card detect is measured through the analog mux for lack of IO pins....
     //if we have low, storage not previously available, and we didn't error out, try to mount
     if(hw_adc_raw[HW_ADC_MUX_CARD_DETECT]<100 && 


### PR DESCRIPTION
_Note: It is recommended to review the changes on a per-commit basis._

* Change `BP_VER` --> `BP_VERSION` and `BP_REV` --> `BP_BOARD_REVISION`
* Change `BP_VERSION` to use non-numeric values

`BP_VER` and `BP_REV` are easily confused as they look similar, especially true for those with dyslexia.  Using more descriptive defines improves readability.

`BP_VERSION` is changed to be one of `BP5`, `BP5XL`, `BP6` for consistency.  Use of strings is intentional to clarify that checks that `BP_VERSION < 5` (or similar numeric comparisons) are subtle problems that may be difficult to diagnose/root cause.

`BP_BOARD_REVISION` remains a numeric value, but should only be used in combination with a check of `BP_VERSION`.

I also renamed a few internal aspects of the pixels code.
