### PR TITLE
DRAFT - DO NOT MERGE - Add third USB CDC (COM) port for debug output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
 
     steps:
     - uses: actions/checkout@v4

--- a/debug.c
+++ b/debug.c
@@ -38,7 +38,15 @@ bool debug_rx(char *c)
 }
 
 void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label) // BUGBUG -- no error return path!
-{   
+{
+    // BUGBUG -- rewrite for improved safety
+    // First, claim the pins (because this could theoretically fail)
+    // If only one pin was claimed, then release the claimed pin.
+    //     Alternatives:
+    //     * hard-lock the BP5 (not terrible, since only called at start of core1_entry()...)
+    //     * make this function return a value so can return error code
+    // Else both pins were claimed, so do the actual initialization, etc.
+
     // Initialise debug UART
     uart_init(debug_uart[uart_number].uart, 115200);
     uart_set_fifo_enabled(debug_uart[uart_number].uart, true); //might set to false    
@@ -52,7 +60,7 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         bio_buf_output(debug_uart[uart_number].tx_pin); //output TX
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].tx_pin, GPIO_FUNC_UART);
-        //claim and label pin
+        //claim and label pin // BUGBUG -- Should claim and label pin BEFORE modifying the pin direction, etc.
         system_bio_claim(true, debug_uart[uart_number].tx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 0]); // BUGBUG -- unchecked error return value
     }
 
@@ -65,12 +73,20 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         bio_buf_input(debug_uart[uart_number].rx_pin); //input RX
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].rx_pin, GPIO_FUNC_UART);
-        //claim and label pin
+        //claim and label pin // BUGBUG -- Should claim and label pin BEFORE modifying the pin direction, etc.
         system_bio_claim(true, debug_uart[uart_number].rx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 1]); // BUGBUG -- unchecked error return value
     }
 }
 
-void rx_uart_disable(void)
+// BUGBUG -- remove unused function, rx_uart_disable()
+void rx_uart_disable(void) // BUGBUG -- does not actually perform any cleanup!
 {
+    // BUGBUG -- should call uart_set_fifo_enabled(uart, false)
+    // BUGBUG -- should call uart_deinit(uart)
+    // BUGBUG -- should set pins to HiZ state ???
+    // BUGBUG -- should set pin functions to ... ??? GPIO_FUNC_SIO ???
+    // BUGBUG -- should call system_bio_claim(false, rx_pin, BP_PIN_IO, NULL);
+    // BUGBUG -- should call system_bio_claim(false, tx_pin, BP_PIN_IO, NULL);
     //cleanup uart hardware and pin
+    
 }

--- a/debug.c
+++ b/debug.c
@@ -37,7 +37,7 @@ bool debug_rx(char *c)
     return false;
 }
 
-void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
+void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label) // BUGBUG -- no error return path!
 {   
     // Initialise debug UART
     uart_init(debug_uart[uart_number].uart, 115200);
@@ -53,7 +53,7 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].tx_pin, GPIO_FUNC_UART);
         //claim and label pin
-        system_bio_claim(true, debug_uart[uart_number].tx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 0]);
+        system_bio_claim(true, debug_uart[uart_number].tx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 0]); // BUGBUG -- unchecked error return value
     }
 
     if(dbrx)
@@ -66,7 +66,7 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].rx_pin, GPIO_FUNC_UART);
         //claim and label pin
-        system_bio_claim(true, debug_uart[uart_number].rx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 1]);
+        system_bio_claim(true, debug_uart[uart_number].rx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label *2) + 1]); // BUGBUG -- unchecked error return value
     }
 }
 

--- a/pirate.h
+++ b/pirate.h
@@ -83,12 +83,15 @@ void lcd_irq_enable(int16_t repeat_interval);
 void lcd_irq_disable(void);
 void spi_busy_wait(bool enable);
 
-#if BP_VER ==6
-#define PIO_RGB_LED_PIO pio2
-#define PIO_RGB_LED_SM 0
+#if BP_VER == 6
+    // BP6 pixel data uses pin 36.
+    // Each PIO can only interact with 32 consecutive pins.
+    // The RGB Pixel pin is on pin 36
+    #define PIO_RGB_LED_PIO pio1 // BUGBUG -- compilation fails if set to PIO2???  May just be my environment?
+    #define PIO_RGB_LED_SM 0
 #else
-#define PIO_RGB_LED_PIO pio0
-#define PIO_RGB_LED_SM 0
+    #define PIO_RGB_LED_PIO pio0
+    #define PIO_RGB_LED_SM 0
 #endif
 
 #define PIO_LOGIC_ANALYZER_PIO pio0
@@ -102,8 +105,8 @@ void spi_busy_wait(bool enable);
 
 // UART settings
 #define M_UART_PORT uart0
-#define M_UART_TX BIO4
-#define M_UART_RX BIO5
+#define M_UART_TX   BIO4
+#define M_UART_RX   BIO5
 #define M_UART_RTS
 #define M_UART_CTS
 #define M_UART_RXTX BIO0
@@ -113,12 +116,12 @@ void spi_busy_wait(bool enable);
 #define M_I2C_SCL BIO1
 
 // SPI settings
-#define M_SPI_PORT spi1
-#define M_SPI_CLK BIO6
-#define M_SPI_CDO BIO7
-#define M_SPI_CDI BIO4
-#define M_SPI_CS BIO5
-#define M_SPI_SELECT 0
+#define M_SPI_PORT     spi1
+#define M_SPI_CLK      BIO6
+#define M_SPI_CDO      BIO7
+#define M_SPI_CDI      BIO4
+#define M_SPI_CS       BIO5
+#define M_SPI_SELECT   0
 #define M_SPI_DESELECT 1
 
 // 2wire settings

--- a/platform/bpi-rev10.h
+++ b/platform/bpi-rev10.h
@@ -9,6 +9,7 @@
 //font and pin colors
 // HEX 24bit RGB format
 //used in terminal
+//BUGBUG -- prefix should be BP_COLOR_RGB24_ to distinguish from ANSI_RGB_24_, ANSI_256_, LCD_RGB565_, etc.
 #define BP_COLOR_RED 0xdb3030 
 #define BP_COLOR_ORANGE 0xdb7530
 #define BP_COLOR_YELLOW 0xdbca30 
@@ -24,6 +25,19 @@
 
 //these have to be ASCII strings for the terminal
 //TODO: abuse pre-compiler to use 0x000000 format as above...
+
+//BUGBUG ... the ANSI_RGB_24 attribute sequence should be of the form: ";2;r;g;b", where:
+//           ';2' indicates the FORMAT of the color as 24-bit color with three control segments
+//           ';r' is the red   control segment, with `r` being a decimal value in range [0..255]
+//           ';g' is the green control segment, with `g` being a decimal value in range [0..255]
+//           ';b' is the blue  control segment, with `b` being a decimal value in range [0..255]
+//           Requires updating other macros to reflect the inclusion of ";2"
+//BUGBUG ... the ANSI_256 attribute sequence should be of the form: ";5;n", where:
+//           ';5' indicates the FORMAT of the color as 256-color with one control segment
+//           ';n' is the color index, with `n` being a decimal value in range [0..255]
+//           Requires updating other macros to reflect the inclusion of ";5"
+
+//BUGBUG -- prefix should be ANSI_RGB_24_ or ANSI_256_ to distinguish from BP_COLOR_RGB24_, LCD_RGB565_, etc.
 #define BP_COLOR_PROMPT_TEXT "150;203;89"
 #define BP_COLOR_256_PROMPT_TEXT "113"
 #define BP_COLOR_INFO_TEXT "191;165;48"
@@ -38,6 +52,7 @@
 #define BP_COLOR_256_NUM_FLOAT_TEXT "26"
 
 // LCD color pallet 5-6-5 RGB
+//BUGBUG -- prefix should be LCD_RGB565_ to standardize with BP_COLOR_RGB24_, ANSI_RGB_24_, ANSI_256_, etc.
 #define BP_LCD_COLOR_RED    0b1111100000000000
 #define BP_LCD_COLOR_ORANGE 0b1111100000000000
 #define BP_LCD_COLOR_YELLOW 0b1111100000000000
@@ -117,46 +132,58 @@ extern const uint8_t bio2bufdirpin[8];
 
 // SPI Defines
 // We are going to use SPI 0 for on-board peripherals
+// BUGBUG -- rename these to BP_PIN_SPI_*
 #define BP_SPI_PORT spi0
 #define BP_SPI_CDI 16
 #define BP_SPI_CLK  18
 #define BP_SPI_CDO 19
 
 // NAND flash is on the BP_SPI_PORT, define Chip Select
+// BUGBUG -- rename to BP_PIN_FLASH_STORAGE_CS
 #define FLASH_STORAGE_CS 26 
 
 // LCD is on the BP_SPI_PORT, define CS and DP pins
+// BUGBUG -- rename these to BP_PIN_DISPLAY_*
 #define DISPLAY_CS 25
 #define DISPLAY_DP 24
 
 // Two 74HC595 shift registers are on BP_SPI_PORT, define latch and enable pins
+// BUGBUG -- rename these to BP_PIN_SHIFT_*
 #define SHIFT_EN 21
 #define SHIFT_LATCH 20
 
 // Controller data out to SK6812 RGB LEDs
+// BUGBUG -- rename to BP_PIN_PIXEL_DATA
 #define RGB_CDO 17
 // The number of SK6812 LEDs in the string
+// BUGBUG -- rename to BP_PIXEL_COUNT
 #define RGB_LEN 18 
 
 //PWM based PSU control pins
+// BUGBUG -- rename these to BP_PIN_PSU_PWM_*
 #define PSU_PWM_CURRENT_ADJ 22 //3A
 #define PSU_PWM_VREG_ADJ 23 //3B
 
 //First pin (base) of logic analyzer input
+// BUGBUG -- rename to BP_PIN_LA_BPIO0
 #define LA_BPIO0 8
 
 // A single ADC pin is used to measure the source selected by a 74hct4067
+// BUGBUG -- rename these to BP_PIN_AMUX_*
 #define AMUX_OUT 28
 #define AMUX_OUT_ADC (AMUX_OUT - 26)
 
 // Current sense ADC
+// BUGBUG -- rename these to BP_PIN_CURRENT_SENSE_*
 #define CURRENT_SENSE 29
 #define CURRENT_SENSE_ADC (CURRENT_SENSE - 26)
 
-// Two pins for front buttons
+// One pin for front button
+// BUGBUG -- rename to BP_PIN_FRONT_BUTTON
 #define EXT1 27
 
 // The two 75hc595 shift registers control various hardware on the board
+// BUGBUG -- rename these to have a comon prefix, such as BP_SHIFT_*
 #define AMUX_EN             (1u<<0)
 #define AMUX_S0             (1u<<1)
 #define AMUX_S1             (1u<<2)
@@ -179,50 +206,58 @@ extern const uint8_t bio2bufdirpin[8];
 // ADC connections as they appear on the analog mux pins
 // will be disambiguated in the hw_pin_voltages_ordered'
 enum adc_mux{
-    HW_ADC_MUX_BPIO7, //0
-    HW_ADC_MUX_BPIO6, //1
-    HW_ADC_MUX_BPIO5, //2
-    HW_ADC_MUX_BPIO4, //3
-    HW_ADC_MUX_BPIO3, //4
-    HW_ADC_MUX_BPIO2, //5
-    HW_ADC_MUX_BPIO1, //6
-    HW_ADC_MUX_BPIO0, //7
-    HW_ADC_MUX_VUSB, //8
-    HW_ADC_MUX_CURRENT_DETECT,    //9
-    HW_ADC_MUX_VREG_OUT, //10
-    HW_ADC_MUX_VREF_VOUT, //11
-    HW_ADC_MUX_COUNT
+    HW_ADC_MUX_BPIO7,          //  0
+    HW_ADC_MUX_BPIO6,          //  1
+    HW_ADC_MUX_BPIO5,          //  2
+    HW_ADC_MUX_BPIO4,          //  3
+    HW_ADC_MUX_BPIO3,          //  4
+    HW_ADC_MUX_BPIO2,          //  5
+    HW_ADC_MUX_BPIO1,          //  6
+    HW_ADC_MUX_BPIO0,          //  7
+    HW_ADC_MUX_VUSB,           //  8
+    HW_ADC_MUX_CURRENT_DETECT, //  9
+    HW_ADC_MUX_VREG_OUT,       // 10
+    HW_ADC_MUX_VREF_VOUT,      // 11
+    HW_ADC_MUX_COUNT           // Total: 12 values
 };
-
 #define HW_ADC_MUX_GND 15
+static_assert(HW_ADC_MUX_COUNT < HW_ADC_MUX_GND, "HW_ADC_MUX_COUNT must be 12");
 
-#define bufio2amux(x) (7 - x)
+// BUGBUG -- make this an inline function that returns the enum type for (at least) better self-documentation
+#define bufio2amux(x) (7 - x) // converts buffer IO [0..8] number to enum value for HW_ADC_MUX_BPIOx
 
-//CURRENT SENSE is attached to a separate ADC, not through the mux
-//lets make a define for it (and space in the hw_adc_x arrays) at the end of HW_ADC_MUX_count
-#define HW_ADC_CURRENT_SENSE HW_ADC_MUX_COUNT
-#define HW_ADC_COUNT  (HW_ADC_MUX_COUNT+1)
+//CURRENT SENSE is attached to a separate ADC (not through the mux)
+//lets make a define for it (and space in the HW_ADC_hw_adc_x arrays) at the end of HW_ADC_MUX_count
+#define HW_ADC_CURRENT_SENSE  HW_ADC_MUX_COUNT
+#define HW_ADC_COUNT         (HW_ADC_MUX_COUNT+1) // size of the below buffers
 
 //the adc variable holds all the ADC readings
-extern uint16_t hw_adc_raw[];
-extern uint32_t hw_adc_voltage[];
-extern uint32_t *hw_pin_voltage_ordered[];
+extern uint16_t hw_adc_raw[];               // BUGBUG ... can we define size of the array here?  (HW_ADC_COUNT)
+extern uint32_t hw_adc_voltage[];           // BUGBUG ... can we define size of the array here?  (HW_ADC_COUNT)
+
+// this array references the pin voltages in the order that
+// they appear in terminal and LCD for easy loop writeout
+extern uint32_t *hw_pin_voltage_ordered[]; // BUGBUG: what's the safe way to index this array?  Wish could use C++ and strongly-typed indices to prevent errors.
 
 //convert raw ADC to volts, for pin with a /2 resistor divider (MUX inputs)
+// BUGBUG -- make this an inline function for (at least) better self-documentation, type safety, debugging, etc.
+// BUGBUG -- Valid indices for `X` is [0..HW_ADC_MUX_COUNT-1].  Document and assert this.
 #define hw_adc_to_volts_x2(X) ((6600*hw_adc_raw[X])/4096);
 //convert raw ADC to volts, for pin with no resistor divider (Current sense inputs)
+// BUGBUG -- make this an inline function for (at least) better self-documentation, type safety, debugging, etc.
+// BUGBUG -- ONLY valid value for `X` is HW_ADC_CURRENT_SENSE.  Document and assert this.
 #define hw_adc_to_volts_x1(X) ((3300*hw_adc_raw[X])/4096);
 
 //how many 595 shift registers are connected
-#define SHIFT_REG_COUNT 2
+#define SHIFT_REG_COUNT 2 // BUGBUG -- remove unused defines?
 
-#define BP_DEBUG_UART_0 uart0
+#define BP_DEBUG_UART_0    uart0
 #define BP_DEBUG_UART_0_TX BIO4
 #define BP_DEBUG_UART_0_RX BIO5
-#define BP_DEBUG_UART_1 uart1
+#define BP_DEBUG_UART_1    uart1
 #define BP_DEBUG_UART_1_TX BIO0 
 #define BP_DEBUG_UART_1_RX BIO1     
 
-#define BP_FLASH_DISK_BLOCK_SIZE 2048 //512
+#define BP_FLASH_DISK_BLOCK_SIZE 2048
 
 #endif

--- a/platform/bpi5-rev10.h
+++ b/platform/bpi5-rev10.h
@@ -220,6 +220,6 @@ extern uint32_t *hw_pin_voltage_ordered[];
 #define BP_DEBUG_UART_1_TX BIO0 
 #define BP_DEBUG_UART_1_RX BIO1     
 
-#define BP_FLASH_DISK_BLOCK_SIZE 2048 //512
+#define BP_FLASH_DISK_BLOCK_SIZE 2048
 
 #endif

--- a/platform/bpi5xl-rev0.h
+++ b/platform/bpi5xl-rev0.h
@@ -223,6 +223,6 @@ extern uint32_t *hw_pin_voltage_ordered[];
 #define BP_DEBUG_UART_1_TX BIO0 
 #define BP_DEBUG_UART_1_RX BIO1     
 
-#define BP_FLASH_DISK_BLOCK_SIZE 2048 //512
+#define BP_FLASH_DISK_BLOCK_SIZE 2048
 
 #endif

--- a/platform/bpi6-rev1.h
+++ b/platform/bpi6-rev1.h
@@ -223,6 +223,6 @@ extern uint32_t *hw_pin_voltage_ordered[];
 #define BP_DEBUG_UART_1_TX BIO0 
 #define BP_DEBUG_UART_1_RX BIO1     
 
-#define BP_FLASH_DISK_BLOCK_SIZE 2048 //512
+#define BP_FLASH_DISK_BLOCK_SIZE 2048
 
 #endif

--- a/system_config.c
+++ b/system_config.c
@@ -134,7 +134,7 @@ bool system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const cha
     }
     else
     {
-        system_config.pin_labels[pin]=0;
+        system_config.pin_labels[pin]=NULL;
         system_config.pin_func[pin]=BP_PIN_IO;	
     }
 

--- a/system_config.h
+++ b/system_config.h
@@ -16,13 +16,13 @@ typedef struct _system_config
 
 	uint32_t terminal_language;
 
-	uint32_t terminal_usb_enable; 		//enable USB CDC terminal
+	uint32_t terminal_usb_enable;       //enable USB CDC terminal
+	uint32_t terminal_uart_enable;      //enable UART terminal on IO pins
+	uint32_t terminal_uart_number;      //which HW UART to use -- BUGBUG -- only values of 0 and 1 are supported; use Enum for clarity on allowed values?
 
-	uint32_t terminal_uart_enable; 		//enable UART terminal on IO pins
-	uint32_t terminal_uart_number; 	//which UART to use
-
-	uint32_t debug_uart_enable;			//initializes a UART for general developer use
-	uint32_t debug_uart_number;		//which UART to use
+	uint32_t debug_usb_enable;          //enable USB CDC for general developer use (debug output)
+	uint32_t debug_uart_enable;         //initializes a UART for general developer use
+	uint32_t debug_uart_number;         //which HW UART to use -- BUGBUG -- only values of 0 and 1 are supported; use Enum for clarity on allowed values?
 
     uint32_t lcd_screensaver_active;
     uint32_t lcd_timeout;

--- a/system_monitor.c
+++ b/system_monitor.c
@@ -26,6 +26,7 @@ bool monitor_get_current_char(uint8_t digit, char *c)
 }
 
 //if changed, return pointer to value string
+// maximum characters in string is 5 (+null terminator)
 bool monitor_get_current_ptr(char **c)
 {
     *c=current_value;
@@ -50,6 +51,7 @@ bool monitor_get_voltage_char(uint8_t pin, uint8_t digit, char *c)
     return false;
 }
 
+// returned string pointer is maximum 3 characters (+null terminator)
 bool monitor_get_voltage_ptr(uint8_t pin, char **c)
 {
     *c=voltages_value[pin];

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -96,24 +96,27 @@
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC              2
-#define CFG_TUD_MSC              1
-#define CFG_TUD_HID              0
-#define CFG_TUD_MIDI             0
-#define CFG_TUD_VENDOR           0
+#define CFG_TUD_CDC              2 // BUGBUG -- Remove unused defines?
+#define CFG_TUD_MSC              1 // BUGBUG -- Remove unused defines?
+#define CFG_TUD_HID              0 // BUGBUG -- Remove unused defines?
+#define CFG_TUD_MIDI             0 // BUGBUG -- Remove unused defines?
+#define CFG_TUD_VENDOR           0 // BUGBUG -- Remove unused defines?
 
-// CDC FIFO size of TX and RX
-#define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+// Config descriptor indicates power in mA
+#define CFG_TUD_CONFIG_DESCRIPTOR_POWER_IN_mA 100 // BUGBUG -- Is this the correct value?
 
 // CDC Endpoint transfer buffer size, more is faster
-#define CFG_TUD_CDC_EP_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_EP_BUFSIZE   64
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE   CFG_TUD_CDC_EP_BUFSIZE
+#define CFG_TUD_CDC_TX_BUFSIZE   CFG_TUD_CDC_EP_BUFSIZE
 
 // MSC Buffer size of Device Mass storage
-#define CFG_TUD_MSC_EP_BUFSIZE   2048
+#define CFG_TUD_MSC_EP_BUFSIZE   64 // BUGBUG -- Consider 512 or higher for better performance?
 
 #ifdef __cplusplus
- }
+}
 #endif
 
 #endif /* _TUSB_CONFIG_H_ */

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -96,11 +96,16 @@
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC              2 // BUGBUG -- Remove unused defines?
-#define CFG_TUD_MSC              1 // BUGBUG -- Remove unused defines?
-#define CFG_TUD_HID              0 // BUGBUG -- Remove unused defines?
-#define CFG_TUD_MIDI             0 // BUGBUG -- Remove unused defines?
-#define CFG_TUD_VENDOR           0 // BUGBUG -- Remove unused defines?
+// This section defines the count of each type of interface
+#if defined(ENABLE_THIRD_CDC_PORT)
+  #define CFG_TUD_CDC              3
+#else
+  #define CFG_TUD_CDC              2
+#endif
+#define CFG_TUD_MSC              1
+#define CFG_TUD_HID              0
+#define CFG_TUD_MIDI             0
+#define CFG_TUD_VENDOR           0
 
 // Config descriptor indicates power in mA
 #define CFG_TUD_CONFIG_DESCRIPTOR_POWER_IN_mA 100 // BUGBUG -- Is this the correct value?

--- a/ui/ui_statusbar.c
+++ b/ui/ui_statusbar.c
@@ -13,111 +13,147 @@
 #include "display/scope.h"
 
 
+// maximum return value: 150
 uint32_t ui_statusbar_info(char *buf)
 {
     uint32_t len=0;
     uint32_t temp=0;
-    uint32_t cnt=0;
+    uint32_t cnt=0;  // visible characters added (not including VT100 codes)
 
-	len+=ui_term_color_text_background_buf(&buf[len], 0x000000, BP_COLOR_GREY);
+    // max_len += 36
+	len += ui_term_color_text_background_buf(&buf[len], 0x000000, BP_COLOR_GREY);
     
+    // max_len += 31
     if(system_config.psu)
     {
-        temp=sprintf(&buf[len],"Vout: %u.%uV",
-           (system_config.psu_voltage)/10000, ((system_config.psu_voltage)%10000)/100
+        // max_len += 14 (6 + 4 + 1 + 2 + 1)
+        temp=sprintf(&buf[len],"Vout: %u.%02uV",
+           (system_config.psu_voltage)/10000u, ((system_config.psu_voltage)%10000u)/100u
         );
         len+=temp;
         cnt+=temp;
+
+        // max_len += 14 (1 + 4 + 1 + 2 + 6)
         if(system_config.psu_current_limit_en)
         {
-            temp=sprintf(&buf[len],"/%u.%umA max",
-                (system_config.psu_current_limit)/10000, ((system_config.psu_current_limit)%10000)/100 
+            temp=sprintf(&buf[len],"/%u.%02umA max",
+                (system_config.psu_current_limit)/10000u, ((system_config.psu_current_limit)%10000u)/100u 
             );
             len+=temp;
             cnt+=temp;           
         }
+
+        // max_len += 3
         temp=sprintf(&buf[len]," | ");
         len+=temp;
         cnt+=temp;
     }
 
+    // max_len += 26 (14 + 4 + 1 + 2 + 5)
     if(system_config.psu_error)
     {
         //show Power Supply: ERROR
-        temp=sprintf(&buf[len],"Vout: ERROR > %u.%umA | ",
-           (system_config.psu_current_limit)/10000, ((system_config.psu_current_limit)%10000)/100 
+        temp=sprintf(&buf[len],"Vout: ERROR > %u.%02umA | ",
+           (system_config.psu_current_limit)/10000u, ((system_config.psu_current_limit)%10000u)/100u
         );
         len+=temp;
         cnt+=temp;
     }
     
+    // max_len += 15
     if(system_config.pullup_enabled)
     {
         //show Pull-up resistors ON
-        temp=sprintf(&buf[len],"Pull-ups: ON | ",
-           (system_config.psu_voltage)/10000, ((system_config.psu_voltage)%10000)/100,
-           (system_config.psu_current_limit)/10000, ((system_config.psu_current_limit)%10000)/100 
-        );
+        temp=sprintf(&buf[len],"Pull-ups: ON | ");
         len+=temp;
         cnt+=temp;
     }
+
+    // max_len += 34
     if (scope_running) { // scope is using the analog subsystem
         temp=sprintf(&buf[len],"V update slower when scope running");
         len+=temp;
         cnt+=temp;
     }
-    //fill in blank space
-    len+=sprintf(&buf[len], "\e[%dX", system_config.terminal_ansi_columns-cnt);	
+    
+    // max_len at this point is thus: 142
+    //fill in blank space using CSI sequence "ESC [ n X" for "erase `n` characters"
+
+    // BUGFIX: previously, len could have been longer than number of columns.
+    // max_len += 4
+    if (cnt > system_config.terminal_ansi_columns) {
+        // do nothing?  maybe output debug message to debug port?
+    } else {
+        len += sprintf(&buf[len], "\e[%hhuX", system_config.terminal_ansi_columns-cnt);	
+    }
+    // max_len += 4
 	len+=sprintf(&buf[len], "%s", ui_term_color_reset()); //sprintf to buffer
     return len;
 }
 
 // show voltages/pinstates
+// maximum return value: 484
 uint32_t ui_statusbar_names(char *buf)
 {
+
     uint32_t len=0;
 	// pin list
-	for(int i=0; i<HW_PINS; i++)
-	{
-		len+=ui_term_color_text_background_buf(&buf[len],hw_pin_label_ordered_color[i][0],hw_pin_label_ordered_color[i][1]);
-		len+=sprintf(&buf[len],"\e[8X"); //clear existing
-        uint8_t cnt=sprintf(&buf[len],"%d.%s\t", i+1, hw_pin_label_ordered[i]);
-		len+=cnt;
 
+    // max_len += 480
+    // Ten pins x 480 chars each pin (worst case)
+	for(uint8_t i=0; i<HW_PINS; i++)
+	{
+        // max_len += 36
+		len+=ui_term_color_text_background_buf(&buf[len],hw_pin_label_ordered_color[i][0],hw_pin_label_ordered_color[i][1]);
+        // max_len +=  4
+		len+=sprintf(&buf[len],"\e[8X"); //clear existing
+        // max_len +=  8 (3 + 1 + 4 for all pins except one)
+        uint8_t cnt=sprintf(&buf[len],"%hhu.%s\t", i+1, hw_pin_label_ordered[i]);
+		len+=cnt;
 	}
 
+    // max_len += 4
     len+=sprintf(&buf[len],"%s",ui_term_color_reset());
     return len;
 }
 
+// maximum increase of len: 10
 bool label_default(uint32_t *len, char *buf, uint32_t i)
 {
     if(system_config.pin_changed & (0x01<<(uint8_t)i))
     {
-	    *len+=sprintf(&buf[*len],"\e[8X%s\t", system_config.pin_labels[i]==0?"-":(char*)system_config.pin_labels[i]);
+        // max_len += 10 (4 + 5 + 1)
+        // pin_labels are maximum 5 characters long ... BUT NOT ENFORCED ANYWHERE ... sigh.
+        // BUGBUG -- manually copy pin label string to buffer instead of using sprintf, to limit to five characters (and alert if ever longer)
+	    *len += sprintf(&buf[*len],"\e[8X%s\t", system_config.pin_labels[i]==0?"-":(char*)system_config.pin_labels[i]);
         return true;
     }
     return false;
 }
 
+// maximum increase of len: 35
 bool label_current(uint32_t *len, char *buf, uint32_t i)
 {
     //uint32_t isense;
     char *c;
     if(monitor_get_current_ptr(&c) || (system_config.pin_changed & (0x01<<(uint8_t)i))) 
     {
-        *len+=sprintf(&buf[*len],"\e[8X%s%s%smA\t",ui_term_color_num_float(), c, ui_term_color_reset());
+        // c points to maximum 5 non-null characters
+        // max_len += 35 (4 + 19 + 5 + 4 + 3)
+        *len += sprintf(&buf[*len], "\e[8X%s%s%smA\t", ui_term_color_num_float(), c, ui_term_color_reset());
         return true;
     }           
     return false;
 }
 
+// maximum increase of len: 28
 bool value_voltage(uint32_t *len, char *buf, uint32_t i)
 {
     char *c;
     if(monitor_get_voltage_ptr(i, &c))
     {
-        *len+=sprintf(&buf[*len], "%s%s%sV\t", ui_term_color_num_float(), c, ui_term_color_reset());
+        // max_len += 28 ( 19 + 3 + 4 + 2)
+        *len += sprintf(&buf[*len], "%s%s%sV\t", ui_term_color_num_float(), c, ui_term_color_reset());
         return true;
     }
 
@@ -126,13 +162,16 @@ bool value_voltage(uint32_t *len, char *buf, uint32_t i)
 }
 
 // TODO: freq function (update on change), pwm function (write once, untill update)
+// maximum increase of len: 34
 bool value_freq(uint32_t *len, char *buf, uint32_t i)
 {
-    *len+=sprintf(&buf[*len], "\e[8X"); //clear out tab, return to tab 	
+    // max_len += 4
+    *len += sprintf(&buf[*len], "\e[8X"); //clear out tab, return to tab 	
     float freq_friendly_value;
     uint8_t freq_friendly_units;
     freq_display_hz(&system_config.freq_config[i-1].period, &freq_friendly_value, &freq_friendly_units);
-    *len+=sprintf(&buf[*len],"%s%3.1f%s%c\t", 
+    // max_len += 30 ( 19 + 5 + 4 + 1 + 1)
+    *len += sprintf(&buf[*len],"%s%3.1f%s%c\t", 
         ui_term_color_num_float(), 
         freq_friendly_value,
         ui_term_color_reset(),
@@ -142,6 +181,7 @@ bool value_freq(uint32_t *len, char *buf, uint32_t i)
     return true;
 }
 
+// maximum increase of len: 34
 bool value_pwm(uint32_t *len, char *buf, uint32_t i)
 {
 
@@ -149,18 +189,21 @@ bool value_pwm(uint32_t *len, char *buf, uint32_t i)
     {
         return false;
     }
-
+    // max_len += 34
     return value_freq(len, buf, i);
 }
 
+// maximum increase of len: translation dependent; en-US-POSIX: 3
 bool value_ground(uint32_t *len, char *buf, uint32_t i)
 {
+    // BUGBUG -- look at all callers to see if length of the translated string is of concern
     if(!(system_config.pin_changed & (0x01<<(uint8_t)(i))))
     {
         return false;
     }
-
-	*len+=sprintf(&buf[*len], "%s",t[T_GND]);
+    // max_len += 3 (but not enforced (yet); translations may overflow?)
+    // BUGBUG -- does not enforce limits on translated strings
+	*len += sprintf(&buf[*len], "%s", t[T_GND]);
     return true; 
 }
 struct _iopins 
@@ -170,35 +213,45 @@ struct _iopins
     bool (*value)(uint32_t *len, char *buf, uint32_t i); 
 };
 
+// N.B. - Although const, because this stores the address of other variables,
+//        it likely get copied into RAM.
 const struct _iopins ui_statusbar_pin_functions[]=
 {
-    [BP_PIN_IO]={&label_default,&value_voltage},
-    [BP_PIN_MODE]={&label_default,&value_voltage},
-    [BP_PIN_PWM]={&label_default,&value_pwm},
-    [BP_PIN_FREQ]={&label_default,&value_freq},   
-    [BP_PIN_VREF]={&label_default,&value_voltage},
-    [BP_PIN_VOUT]={&label_current,&value_voltage},             
-    [BP_PIN_GROUND]={&label_default,&value_ground},
-    [BP_PIN_DEBUG]={&label_default,&value_voltage}
-
+    [ BP_PIN_IO     ] = { .label = &label_default, .value = &value_voltage },
+    [ BP_PIN_MODE   ] = { .label = &label_default, .value = &value_voltage },
+    [ BP_PIN_PWM    ] = { .label = &label_default, .value = &value_pwm     },
+    [ BP_PIN_FREQ   ] = { .label = &label_default, .value = &value_freq    },
+    [ BP_PIN_VREF   ] = { .label = &label_default, .value = &value_voltage },
+    [ BP_PIN_VOUT   ] = { .label = &label_current, .value = &value_voltage },
+    [ BP_PIN_GROUND ] = { .label = &label_default, .value = &value_ground  },
+    [ BP_PIN_DEBUG  ] = { .label = &label_default, .value = &value_voltage },
 };
 
+// maximum return value: 390
 uint32_t ui_statusbar_labels(char *buf)
 {
     uint32_t len=0;
     uint8_t j=0;
 
 	// show state of IO pins
+    // max_len += 390 (10 pins, each at +39)
 	for(uint i=0; i<HW_PINS; i++)
 	{
 
+        // max_len += 4
         if(system_config.pin_changed & (0x01<<(uint8_t)i))
 		{
 			len+=sprintf(&buf[len], "\e[8X"); //clear out tab, return to tab 		
 		}
-
+        // max_len += 35
+        // function called through a function pointer in the if() statement
+        // label_default: // maximum increase of len: 10
+        // label_current: // maximum increase of len: 35
         if(!ui_statusbar_pin_functions[system_config.pin_func[i]].label(&len, buf, i))
         {
+            // if that function did not write any characters to the buffer,
+            // then write a tab character instead
+            // max_len += 1
             len+=sprintf(&buf[len], "\t"); //todo: just handle this
         }
 	}
@@ -206,6 +259,7 @@ uint32_t ui_statusbar_labels(char *buf)
     return len;
 }	
 
+// maximum return value: 380
 uint32_t ui_statusbar_value(char *buf)
 {	
     uint32_t len=0;
@@ -213,20 +267,30 @@ uint32_t ui_statusbar_value(char *buf)
     bool do_update=false;
 
 	// show state of IO pins
+    // max_len += 380 (10 pins, each at +38)
 	for(uint i=0; i<HW_PINS; i++)
 	{
-
+        // max_len += 4
         if(system_config.pin_changed & (0x01<<(uint8_t)i))
 		{
-			len+=sprintf(&buf[len], "\e[8X"); //clear out tab, return to tab 		
+			len += sprintf(&buf[len], "\e[8X"); //clear out tab, return to tab 		
 		}
 
+        // max_len += 34
+        // function called through a function pointer in the if() statement
+        // value_voltage : 28
+        // value_pwm     : 34
+        // value_freq    : 34
+        // value_ground  : typically 3 (translation dependent)
+        // else statement:  1
         if(ui_statusbar_pin_functions[system_config.pin_func[i]].value(&len, buf, i))
         {
             do_update=true;
         }
         else
         {
+            // if that function did not write any characters to the buffer,
+            // then write a tab character instead
             len+=sprintf(&buf[len], "\t"); //todo: just handle this
         }
 
@@ -236,6 +300,7 @@ uint32_t ui_statusbar_value(char *buf)
 	
 }
 
+// maximum buffer usage: 1492 characters ... which overflows the 1024 character buffer
 void ui_statusbar_update(uint32_t update_flags)
 { 
     uint32_t len=0;
@@ -245,54 +310,92 @@ void ui_statusbar_update(uint32_t update_flags)
         return;
     }
 
+    // BUGBUG: len can exceed tx_sb_buf size.  Stop using unsafe function `sprintf()`
+    //         and mark those unsafe functions deprecated.  Better if there was a way
+    //         to detect at compilation time this overflow via static_assert().
+    //         However, manual calculation (documented in code with this commit) shows
+    //         worst-case buffer use results in overflow.  Thus, not currently safe.
+    //         maybe assert assert len <= tx_sb_buf_count at the end of this function?
+
     //save cursor, hide cursor
-    len+=sprintf(&tx_sb_buf[len],"\e7\e[?25l");
+    // max_len +=   8
+    len += sprintf(&tx_sb_buf[len],"\e7\e[?25l");
 
     //print each line of the toolbar
+    // max_len += 158
     if(update_flags & UI_UPDATE_INFOBAR)
     {
         monitor_force_update(); //we want to repaint the whole screen if we're doing the pin names...
-        len+=sprintf(&tx_sb_buf[len],"\e[%d;0H",system_config.terminal_ansi_rows-3); //position at row-3 col=0
+        // %u with uint8_t max characters is 3.  max +8 to len here
+        // max_len += 8
+        len+=sprintf(&tx_sb_buf[len],"\e[%hhu;0H",system_config.terminal_ansi_rows-3); //position at row-3 col=0
+        // max_len += 150
         len+=ui_statusbar_info(&tx_sb_buf[len]);
     }
 
+    // max_len += 492
     if(update_flags & UI_UPDATE_NAMES)
     {
-        len+=sprintf(&tx_sb_buf[len],"\e[%d;0H",system_config.terminal_ansi_rows-2);
+        // BUGBUG ... behaves poorly when terminal has only fewer than two rows
+        // max_len += 8
+        len+=sprintf(&tx_sb_buf[len],"\e[%hhu;0H",system_config.terminal_ansi_rows-2);
+        // max_len += 484
         len+=ui_statusbar_names(&tx_sb_buf[len]);
     }
 
+    // max_len +=  38
     if((update_flags & UI_UPDATE_CURRENT) && !(update_flags & UI_UPDATE_LABELS)) //show current under Vout
     {
         char *c;
         if(monitor_get_current_ptr(&c)) 
         {
-            len+=sprintf(&tx_sb_buf[len],"\e[%d;0H%s%s%smA",
-                system_config.terminal_ansi_rows-1, ui_term_color_num_float(), c, ui_term_color_reset()
+            // "\e[%hhu;0H%s%s%smA"
+            //  1 1   3111 _ 5 411
+            // max_len += 38 (2 + 3 + 3 + 19 + 5 + 4 + 2)
+            len+=sprintf(&tx_sb_buf[len],"\e[%hhu;0H%s%s%smA",
+                system_config.terminal_ansi_rows-1,
+                ui_term_color_num_float(),
+                c,
+                ui_term_color_reset()
             );
         }           
 
     }
 
+    // max_len += 398
     if(update_flags & UI_UPDATE_LABELS)
     {
-        len+=sprintf(&tx_sb_buf[len],"\e[%d;0H",system_config.terminal_ansi_rows-1);
+        // BUGBUG - behaves poorly when terminal has zero or one row
+        // max_len += 8
+        len+=sprintf(&tx_sb_buf[len],"\e[%hhu;0H",system_config.terminal_ansi_rows-1);
+        // max_len += 390
         len+=ui_statusbar_labels(&tx_sb_buf[len]);
     }
 
+    // max_len += 388
     if(update_flags & UI_UPDATE_VOLTAGES)
     {
-        len+=sprintf(&tx_sb_buf[len],"\e[%d;0H",system_config.terminal_ansi_rows-0);
+        // max_len += 8
+        len+=sprintf(&tx_sb_buf[len],"\e[%hhu;0H",system_config.terminal_ansi_rows-0);
+        // max_len += 380
         len+=ui_statusbar_value(&tx_sb_buf[len]);
     }
 
     //restore cursor, show cursor
+    // max_len +=   2
     len+=sprintf(&tx_sb_buf[len],"\e8"); 
+    // max_len +=   6
     if(!system_config.terminal_hide_cursor)
     {
         len+=sprintf(&tx_sb_buf[len],"\e[?25h"); 
     }
-    
+
+    // BUGBUG -- Status bar buffer size overflow possible.
+    // Maximum value of len at time of writing:
+    // 8 + 158 + 492 + 38 + 398 + 388 + 2 + 6 = 1492
+    // This is MUCH MORE than the buffer size of 1024.
+    assert(len <= count_of(tx_sb_buf));
+
     tx_sb_start(len);
 
 }

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -158,24 +158,20 @@ enum
 uint8_t const desc_fs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, CFG_TUD_CONFIG_DESCRIPTOR_POWER_IN_mA),
 
   // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_0?
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, CFG_TUD_CDC_EP_BUFSIZE),
 
   // 2nd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_1?
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, CFG_TUD_CDC_EP_BUFSIZE),
 
   // Interface number, string index, EP Out & EP In address, EP size
-  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_MSC?
-  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
+  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC,   5, EPNUM_MSC_OUT, EPNUM_MSC_IN, CFG_TUD_MSC_EP_BUFSIZE),
 
 #if defined(ENABLE_THIRD_CDC_PORT)
   // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_2?
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, CFG_TUD_CDC_EP_BUFSIZE),
 #endif
 };
 
@@ -186,20 +182,20 @@ uint8_t const desc_fs_configuration[] =
 uint8_t const desc_hs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, CFG_TUD_CONFIG_DESCRIPTOR_POWER_IN_mA),
 
   // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, CFG_TUD_CDC_EP_BUFSIZE),
 
   // 2nd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, CFG_TUD_CDC_EP_BUFSIZE),
 
   // Interface number, string index, EP Out & EP In address, EP size
-  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC,   5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 512),
+  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC,   5, EPNUM_MSC_OUT, EPNUM_MSC_IN, CFG_TUD_MSC_EP_BUFSIZE),
 
 #if defined(ENABLE_THIRD_CDC_PORT)
   // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, CFG_TUD_CDC_EP_BUFSIZE),
 #endif};
 
 // other speed configuration

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -36,6 +36,9 @@
 #define USB_BCD   0x0200
 #define USB_VID   0x1209
 
+//#define ENABLE_THIRD_CDC_PORT 1
+
+
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
@@ -85,8 +88,10 @@ enum
 
   ITF_NUM_MSC,
 
+#if defined(ENABLE_THIRD_CDC_PORT)
   ITF_NUM_CDC_2,
   ITF_NUM_CDC_2_DATA,
+#endif
 
   ITF_NUM_TOTAL
 };
@@ -135,13 +140,19 @@ enum
   #define EPNUM_MSC_OUT     0x05
   #define EPNUM_MSC_IN      0x85
 
-  #define EPNUM_CDC_2_NOTIF   0x86
-  #define EPNUM_CDC_2_OUT     0x06
-  #define EPNUM_CDC_2_IN      0x87
+  #if defined(ENABLE_THIRD_CDC_PORT)
+    #define EPNUM_CDC_2_NOTIF   0x86
+    #define EPNUM_CDC_2_OUT     0x06
+    #define EPNUM_CDC_2_IN      0x87
+  #endif
 
 #endif
 
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN + TUD_CDC_DESC_LEN)
+#if defined(ENABLE_THIRD_CDC_PORT)
+  #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN + TUD_CDC_DESC_LEN)
+#else
+  #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN)
+#endif
 
 // full speed configuration
 uint8_t const desc_fs_configuration[] =
@@ -150,16 +161,22 @@ uint8_t const desc_fs_configuration[] =
   TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
 
   // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_0?
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
 
   // 2nd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_1?
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, 64),
 
   // Interface number, string index, EP Out & EP In address, EP size
+  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_MSC?
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
 
+#if defined(ENABLE_THIRD_CDC_PORT)
   // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  // BUGBUG -- Magic numbers ... should define as USB_ENDPOINT_SIZE_CDC_2?
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
+#endif
 };
 
 #if TUD_OPT_HIGH_SPEED
@@ -180,9 +197,10 @@ uint8_t const desc_hs_configuration[] =
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC,   5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 512),
 
+#if defined(ENABLE_THIRD_CDC_PORT)
   // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
-};
+#endif};
 
 // other speed configuration
 uint8_t desc_other_speed_config[CONFIG_TOTAL_LEN];
@@ -262,7 +280,9 @@ char const* string_desc_arr [] =
   "Bus Pirate CDC",                 // 4: Main   CDC Interface
   "Bus Pirate MSC",                 // 5: MSC Interface
   "Bus Pirate BIN",                 // 6: Binary CDC Interface
+#if defined(ENABLE_THIRD_CDC_PORT)
   "Bus Pirate DBG",                 // 7: Debug  CDC Interface
+#endif
 };
 // automatically update if an additional string is later added to the table
 #define STRING_DESC_ARR_ELEMENT_COUNT (sizeof(string_desc_arr)/sizeof(string_desc_arr[0]))

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -196,7 +196,8 @@ uint8_t const desc_hs_configuration[] =
 #if defined(ENABLE_THIRD_CDC_PORT)
   // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, CFG_TUD_CDC_EP_BUFSIZE),
-#endif};
+#endif
+};
 
 // other speed configuration
 uint8_t desc_other_speed_config[CONFIG_TOTAL_LEN];

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -32,10 +32,7 @@
  * Auto ProductID layout's Bitmap:
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
-#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID  0x7332         /*(0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )*/
-
+#define USB_PID   0x7332
 #define USB_BCD   0x0200
 #define USB_VID   0x1209
 
@@ -78,20 +75,19 @@ uint8_t const * tud_descriptor_device_cb(void)
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-#define USB_TEST 1
-
 enum
 {
-  #ifndef USB_TEST
-  ITF_NUM_CDC = 0,
-  ITF_NUM_CDC_DATA,
-  #else
   ITF_NUM_CDC_0 = 0,
   ITF_NUM_CDC_0_DATA,
+
   ITF_NUM_CDC_1,
   ITF_NUM_CDC_1_DATA,
+
   ITF_NUM_MSC,
-  #endif
+
+  ITF_NUM_CDC_2,
+  ITF_NUM_CDC_2_DATA,
+
   ITF_NUM_TOTAL
 };
 
@@ -128,14 +124,6 @@ enum
   #define EPNUM_MSC_IN      0x84
 
 #else
-  #ifndef USB_TEST
-  #define EPNUM_CDC_NOTIF   0x81
-  #define EPNUM_CDC_OUT     0x02
-  #define EPNUM_CDC_IN      0x82
-
-  #define EPNUM_MSC_OUT     0x03
-  #define EPNUM_MSC_IN      0x83
-  #else
   #define EPNUM_CDC_0_NOTIF   0x81
   #define EPNUM_CDC_0_OUT     0x02
   #define EPNUM_CDC_0_IN      0x82
@@ -146,36 +134,32 @@ enum
 
   #define EPNUM_MSC_OUT     0x05
   #define EPNUM_MSC_IN      0x85
-  #endif
-  
 
+  #define EPNUM_CDC_2_NOTIF   0x86
+  #define EPNUM_CDC_2_OUT     0x06
+  #define EPNUM_CDC_2_IN      0x87
 
 #endif
 
-#ifndef USB_TEST
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN)
-#else
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN)
-#endif
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN + TUD_CDC_DESC_LEN)
 
 // full speed configuration
 uint8_t const desc_fs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
   TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
-  #ifndef USB_TEST
-  // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
-  #else
+
   // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
 
   // 2nd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, 64),
 
-  #endif
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
+
+  // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
 };
 
 #if TUD_OPT_HIGH_SPEED
@@ -187,11 +171,17 @@ uint8_t const desc_hs_configuration[] =
   // Config number, interface count, string index, total length, attribute, power in mA
   TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
 
-  // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 512),
+  // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
+
+  // 2nd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 6, EPNUM_CDC_1_NOTIF, 8, EPNUM_CDC_1_OUT, EPNUM_CDC_1_IN, 64),
 
   // Interface number, string index, EP Out & EP In address, EP size
-  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 512),
+  TUD_MSC_DESCRIPTOR(ITF_NUM_MSC,   5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 512),
+
+  // 3rd CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 7, EPNUM_CDC_2_NOTIF, 8, EPNUM_CDC_2_OUT, EPNUM_CDC_2_IN, 64),
 };
 
 // other speed configuration
@@ -269,9 +259,10 @@ char const* string_desc_arr [] =
   "Bus Pirate",                     // 1: Manufacturer
   "Bus Pirate 5",                   // 2: Product
   "5buspirate",                     // 3: Serial -- now using chip ID (serial port can be remembered per device)
-  "Bus Pirate CDC",                 // 4: CDC Interface
+  "Bus Pirate CDC",                 // 4: Main   CDC Interface
   "Bus Pirate MSC",                 // 5: MSC Interface
-  "Bus Pirate BIN"                  // 6: Binary CDC Interface
+  "Bus Pirate BIN",                 // 6: Binary CDC Interface
+  "Bus Pirate DBG",                 // 7: Debug  CDC Interface
 };
 // automatically update if an additional string is later added to the table
 #define STRING_DESC_ARR_ELEMENT_COUNT (sizeof(string_desc_arr)/sizeof(string_desc_arr[0]))

--- a/usb_rx.c
+++ b/usb_rx.c
@@ -19,14 +19,17 @@
 // on a USB attached device is a nightmare. BP_DEBUG_ENABLED In the /platform/ folder
 // configuration file enables a UART debugging option. All user interface IO
 // will be routed to one of the two UARTs (selectable) on the Bus Pirate buffered IO pins
-// UART debug mode is way over engineered using DMA et al, and has some predelection for bugs
+// UART debug mode is way over engineered using DMA et al, and has some predilection for bugs
 // in status bar updates
+
+// BUGBUG -- Rename all functions here with `bp_usb_cdc_` prefix
+// BUGBUG -- make all internal functions and variables static
 
 void rx_uart_irq_handler(void);
 
 queue_t rx_fifo;
 queue_t bin_rx_fifo;
-#define RX_FIFO_LENGTH_IN_BITS 7 // 2^n buffer size. 2^3=8, 2^9=512
+#define RX_FIFO_LENGTH_IN_BITS 7 // 2^n buffer size. 2^3=8, 2^7=128, 2^9=512
 #define RX_FIFO_LENGTH_IN_BYTES (0x0001<<RX_FIFO_LENGTH_IN_BITS)
 char rx_buf[RX_FIFO_LENGTH_IN_BYTES]; 
 char bin_rx_buf[RX_FIFO_LENGTH_IN_BYTES]; 
@@ -52,7 +55,7 @@ void rx_uart_irq_handler(void){
     while(uart_is_readable(debug_uart[system_config.terminal_uart_number].uart)) {
         uint8_t c=uart_getc(debug_uart[system_config.terminal_uart_number].uart);
         queue2_add_blocking(&rx_fifo, &c);
-    }   
+    }
 }
 
 void rx_usb_init(void){
@@ -70,7 +73,7 @@ void tud_cdc_rx_cb(uint8_t itf) {
         // while bytes available shove them in the buffer
         for(uint8_t i=0; i<count; i++) {
             queue2_add_blocking(&rx_fifo, &buf[i]);
-        }     
+        }
     }
 
     if(system_config.binmode_usb_rx_queue_enable && itf==1 && tud_cdc_n_available(1)){
@@ -79,8 +82,8 @@ void tud_cdc_rx_cb(uint8_t itf) {
         // while bytes available shove them in the buffer
         for(uint8_t i=0; i<count; i++) {
             queue2_add_blocking(&bin_rx_fifo, &buf[i]);           
-        }     
-    }    
+        }
+    }
 }
 
 // Invoked when cdc when line state changed e.g connected/disconnected

--- a/usb_rx.h
+++ b/usb_rx.h
@@ -1,3 +1,6 @@
+#pragma once
+
+// BUGBUG - rename these functions to have `bp_usb_cdc_` prefix
 void rx_fifo_init(void);
 void rx_uart_init_irq(void);
 void rx_usb_init(void);

--- a/usb_tx.h
+++ b/usb_tx.h
@@ -1,10 +1,12 @@
+#pragma once
+
 void tx_fifo_init(void);
 void tx_fifo_service(void);
 void tx_fifo_put(char *c);
 void tx_sb_start(uint32_t len);
 void bin_tx_fifo_put(const char c);
 void bin_tx_fifo_service(void);
-bool bin_tx_not_empty(void);
+bool bin_tx_not_empty(void); // BUGBUG -- Unused function should be removed
 bool bin_tx_fifo_try_get(char *c);
 
 extern char tx_sb_buf[1024];


### PR DESCRIPTION
For discussion of the feature, review as it is developed, etc.

N.B. - This branch is **_NOT_** intended to be merged directly.  It has too many changes.  Small commits at each step, but still ... too much for one PR.   Besides, the second time it's written, things are done more cleanly.  :wink:


<hr/>
<details><summary>Log</summary><P/>

* When I first tried to expose the new COM port (commit titled, "Maybe this adds...", zero COM ports appeared in Windows.  This was likely because I misunderstood how to define the count of each interface that is needed in `tusb_config.h`.  Need to re-test to see if this was the primary cause.
* Filed two issues for tracking purposes that likely need trivial changes to the Makefile.  See issue #91 and issue #92.
* USB Descriptor indicates power usage of only `100mA`.  Not sure if that's OK, so opened new issue #94 to get input and awareness.
* May have found a deadlock when using `printf` and the like from Core1.  May have also found a solution.  See new issue #97.
* Got concerned about the use of unsafe `sprintf`.  Manually calculated worst-case buffer usage for status bar.  `ui_statusbar_update()` theoretically could write `1492` bytes into the buffer ... which is only `1024` bytes in size.  Conversion to use safe string functions is **_strongly recommended_**.  See new issue #98.
* That raised awareness of a common experience for programs supporting multiple translations. 
 Users may be presented with UI in a default language, and have trouble selecting their native / preferred language.  See new issue #96.

</details><hr/>