### PR TITLE
temporarily disable windows builds due to unrelated failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
See PR #99, which includes this change.

<details><summary>outdated, but reviewable</summary>
<p>



Windows builds are failing.
This causes the other builds to be cancelled in the middle of the job.
The overall status is also shown as failed, even when the other two jobs succeed.
Finally, GitHub does not support a tag/config setting in the YAML that would simultaneously:

* marks a job as being allowed to fail
* show the job status as failed when it actually failed, **_AND_**
* allow the overall action to be shown as succeeded (even if an allowed-to-fail job failed)

Therefore, just remove the Windows builds for the moment, so the action status shows something of value when a code change is good.

</p>
</details> 
