### PR TITLE
PR to fix some problems with the storage 

### DIFF
--- a/fatfs/ff.c
+++ b/fatfs/ff.c
@@ -5193,7 +5193,8 @@ FRESULT f_rename (
 				res = dir_remove(&djo);		/* Remove old entry */
 				if (res == FR_OK) {
 					res = sync_fs(fs);
-				}
+                    refresh_usbmsdrive();
+                }
 			}
 /* End of the critical section */
 		}
@@ -5510,8 +5511,8 @@ FRESULT f_setlabel (
 			}
 		}
 	}
-
-	LEAVE_FF(fs, res);
+    refresh_usbmsdrive();
+    LEAVE_FF(fs, res);
 }
 
 #endif /* !FF_FS_READONLY */

--- a/msc_disk.c
+++ b/msc_disk.c
@@ -36,14 +36,24 @@
 
 #if CFG_TUD_MSC
 
-enum medium_state { md_state_not_present, md_state_reset, md_state_medium_changed, md_state_ready };
+enum medium_state {
+    md_state_not_present_stage1,
+    md_state_not_present,
+    md_state_reset,
+    md_state_medium_changed,
+    md_state_ready_stage1,
+    md_state_ready
+};
 
 static volatile uint32_t medium_state = md_state_ready;
+static volatile uint32_t next_medium_state = md_state_ready;
 
 static volatile bool eject_request = false;
 static volatile bool insert_request = false;
+static volatile bool cmd_ack = false;
 
 static volatile bool writable = true;
+static volatile bool host_ejected = false;
 
 enum
 {
@@ -130,6 +140,11 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
   memcpy(product_rev, rev, strlen(rev));
 }
 
+
+static bool command_acknowledged()
+{
+    return cmd_ack;
+}
 // This function will be called by core0
 static bool is_ejected()
 {
@@ -140,37 +155,49 @@ static bool is_inserted()
 {
     return medium_state == md_state_ready;
 }
-
 // Invoked when received Test Unit Ready command.
 // return true allowing host to read/write this LUN e.g TF flash card inserted
 bool tud_msc_test_unit_ready_cb(uint8_t lun)
 {
     (void)lun;
-    if (insert_request && medium_state == md_state_not_present) {
-        medium_state = md_state_reset;
+    bool return_value = true;
+    medium_state = next_medium_state;
+    if (host_ejected) {
+        next_medium_state = medium_state = md_state_not_present;
+        host_ejected = false;
+    } else if (insert_request && medium_state == md_state_not_present) {
+        medium_state = md_state_medium_changed;
+        cmd_ack = true;
     } else if (eject_request && medium_state == md_state_ready) {
-        medium_state = md_state_not_present;
+        medium_state = md_state_not_present_stage1;
+        cmd_ack = true;
     }
     switch (medium_state) {
+        case md_state_not_present_stage1:
         case md_state_not_present:
             tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
-            return false;
+            next_medium_state = md_state_not_present;
+            return_value = false;
             break;
-        case md_state_reset:
-            tud_msc_set_sense(lun, SCSI_SENSE_UNIT_ATTENTION, 0x29, 0x00);
-            medium_state = md_state_medium_changed;
-            return false;
-            break;
+        // This state isn't implemented by my SD card reader
+        // case md_state_reset:
+        //     tud_msc_set_sense(lun, SCSI_SENSE_UNIT_ATTENTION, 0x29, 0x00);
+        //     medium_state = md_state_medium_changed;
+        //     return_value = false;
+        //     break;
         case md_state_medium_changed:
             tud_msc_set_sense(lun, SCSI_SENSE_UNIT_ATTENTION, 0x28, 0x00);
-            medium_state = md_state_ready;
-            return false;
+            next_medium_state = md_state_ready_stage1;
+            return_value = false;
             break;
+        case md_state_ready_stage1:
         case md_state_ready:
             tud_msc_set_sense(lun, 0x00, 0x00, 0x00);
-            return true;
+            next_medium_state = md_state_ready;
+            return_value = true;
             break;
     }
+    return return_value;
 }
 
 // Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
@@ -205,27 +232,13 @@ bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, boo
 
   if ( load_eject )
   {
-    if (start)
-    {
-        insert_request = true;
-        while(!is_inserted())
-        {
-            sleep_ms(10);
-        }
-        insert_request = false;
-        // load disk storage
-    }else
-    {
-      // unload disk storage
-      eject_request = true;
-      while(!is_ejected())
-      {
-          sleep_ms(1);
+      if (start) {
+          host_ejected = false;
+          // load disk storage
+      }else {
+          host_ejected = true;
       }
-      eject_request = false;
-    }
   }
-
   return true;
 }
 
@@ -289,6 +302,17 @@ int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* 
   return bufsize;
 }
 
+bool tud_msc_prevent_allow_medium_removal_cb(uint8_t lun, uint8_t prohibit_removal, uint8_t control)
+{
+    (void)lun;
+    if (prohibit_removal != 0) {
+      tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x24, 0x0);
+      return false;
+    } else {
+        tud_msc_set_sense(lun, 0, 0, 0);
+        return true;
+    }
+}
 // Callback invoked when received an SCSI command not in built-in list below
 // - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
 // - READ10 and WRITE10 has their own callbacks
@@ -304,17 +328,13 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
 
   switch (scsi_cmd[0])
   {
-    case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-      // Host is about to read/write etc ... better not to disconnect disk
-      resplen = 0;
-    break;
 
     default:
-      // Set Sense = Invalid Command Operation
-      tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+    // Set Sense = Invalid Command Operation
+    tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
 
-      // negative means error -> tinyusb could stall and/or response with failed status
-      resplen = -1;
+    // negative means error -> tinyusb could stall and/or response with failed status
+    resplen = -1;
     break;
   }
 
@@ -340,21 +360,44 @@ bool tud_msc_is_writable_cb(uint8_t lun)
   return writable;
 }
 
-//eject and insert the usbms drive to force the host to sync its contents
-void refresh_usbmsdrive(void)
+bool insert_or_eject_usbmsdrive(bool insert) 
 {
-  // eject the usb drive
-  tud_msc_start_stop_cb(0, 0, 0, 1);
-  // make sure the storage is synced
-  disk_ioctl(0, CTRL_SYNC, 0);
-  // insert the drive back
-  tud_msc_start_stop_cb(0, 0, 1, 1);
+    cmd_ack = false;
+    if (insert) {
+        insert_request = true;
+        while (!command_acknowledged()) {
+            sleep_ms(1);
+        }
+        insert_request = false;
+        // load disk storage
+    } else {
+        if (is_ejected())
+            return true;
+        // unload disk storage
+        eject_request = true;
+        while (!command_acknowledged()) {
+            sleep_ms(1);
+        }
+        eject_request = false;
+    }
+    return true;
 }
-//eject and insert the usbms drive to force the host to sync its contents
+
 void eject_usbmsdrive(void)
 {
-  // eject the usb drive
-  tud_msc_start_stop_cb(0, 0, 0, 1);
+    insert_or_eject_usbmsdrive(false);
+}
+void insert_usbmsdrive(void)
+{
+    insert_or_eject_usbmsdrive(true);
+}
+
+// eject and insert the usbms drive to force the host to sync its contents
+void refresh_usbmsdrive(void) {
+    // eject the usb drive
+    eject_usbmsdrive();
+    // insert the drive back
+    insert_usbmsdrive();
 }
 
 // The drive is removed but not inserted back
@@ -364,7 +407,7 @@ void prepare_usbmsdrive_readonly(void)
   if (!writable)
     return;
   // eject the usb drive
-  tud_msc_start_stop_cb(0, 0, 0, 1);
+  eject_usbmsdrive();
   // make sure the storage is synced
   disk_ioctl(0, CTRL_SYNC, 0);
   writable = false;
@@ -374,12 +417,12 @@ void make_usbmsdrive_writable(void)
   if(writable)
     return;
   // eject the usb drive
-  tud_msc_start_stop_cb(0, 0, 0, 1);
+  eject_usbmsdrive();
   //make sure the storage is synced
   disk_ioctl(0, CTRL_SYNC, 0);
   writable = true;
   //insert the drive back
-  tud_msc_start_stop_cb(0, 0, 1, 1);
+  insert_usbmsdrive();
 }
 
 #endif

--- a/msc_disk.c
+++ b/msc_disk.c
@@ -237,6 +237,8 @@ bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, boo
           // load disk storage
       }else {
           host_ejected = true;
+          if (writable)
+              disk_ioctl(0, CTRL_SYNC, 0);
       }
   }
   return true;

--- a/msc_disk.h
+++ b/msc_disk.h
@@ -23,14 +23,14 @@
  *
  */
 
-// eject and insert the usbms drive to force the host to sync its contents
+// remove and insert the usbms drive to force the host to sync its contents
 void refresh_usbmsdrive(void);
 
-//make the usb drive appear read only on the host
-void make_usbmsdrive_readonly(void);
+//remove the usb drive and prepare to make it read only on the host
+void prepare_usbmsdrive_readonly(void);
 
 // make the usb drive appear read write on the host
 void make_usbmsdrive_writable(void);
 
-//eject before jump to bootloader
+//remove before jump to bootloader
 void eject_usbmsdrive(void);

--- a/msc_disk.h
+++ b/msc_disk.h
@@ -29,6 +29,9 @@ void refresh_usbmsdrive(void);
 //remove the usb drive and prepare to make it read only on the host
 void prepare_usbmsdrive_readonly(void);
 
+//insert the usbms drive to expose it to the host
+void insert_usbmsdrive(void);
+
 // make the usb drive appear read write on the host
 void make_usbmsdrive_writable(void);
 

--- a/nand/nand_ftl_diskio.c
+++ b/nand/nand_ftl_diskio.c
@@ -6,6 +6,7 @@
  */
 #include <stdint.h>
 #include "pico/stdlib.h"
+#include "pico/mutex.h"
 #include "pirate.h"
 
 #include "../fatfs/ff.h"     // BYTE type
@@ -24,12 +25,13 @@ static bool initialized = false;
 static struct dhara_map map;
 static uint8_t page_buffer[SPI_NAND_PAGE_SIZE];
 static struct dhara_nand dhara_nand_parameters = {};
+static mutex_t diskio_mutex;
 
 // public function definitions
 DSTATUS diskio_initialize(BYTE drv)
 {
     if (drv) return STA_NOINIT;			/* Supports only drive 0 */
-
+    mutex_init(&diskio_mutex);
     // init flash management stack
     int ret = spi_nand_init(&dhara_nand_parameters);
     if (SPI_NAND_RET_OK != ret) {
@@ -66,7 +68,7 @@ DRESULT diskio_read(BYTE drv, BYTE *buff, LBA_t sector, UINT count)
     dhara_error_t err;
 
 	if (drv) return STA_NOINIT;		/* Supports only drive 0 */
-
+    mutex_enter_blocking(&diskio_mutex);
     // read *count* consecutive sectors
     for (int i = 0; i < count; i++) {
         int ret = dhara_map_read(&map, sector, buff, &err);
@@ -77,7 +79,7 @@ DRESULT diskio_read(BYTE drv, BYTE *buff, LBA_t sector, UINT count)
         buff += SPI_NAND_PAGE_SIZE; // sector size == page size
         sector++;
     }
-
+    mutex_exit(&diskio_mutex);
     return RES_OK;
 }
 
@@ -86,7 +88,7 @@ DRESULT diskio_write(BYTE drv, const BYTE *buff, LBA_t sector, UINT count)
     dhara_error_t err;
 
 	if (drv) return STA_NOINIT;		/* Supports only drive 0 */
-
+    mutex_enter_blocking(&diskio_mutex);
     // write *count* consecutive sectors
     for (int i = 0; i < count; i++) {
         int ret = dhara_map_write(&map, sector, buff, &err);
@@ -97,7 +99,7 @@ DRESULT diskio_write(BYTE drv, const BYTE *buff, LBA_t sector, UINT count)
         buff += SPI_NAND_PAGE_SIZE; // sector size == page size
         sector++;
     }
-
+    mutex_exit(&diskio_mutex);
     return RES_OK;
 }
 
@@ -106,7 +108,7 @@ DRESULT diskio_ioctl(BYTE drv, BYTE cmd, void *buff)
     dhara_error_t err;
 
    	if (drv) return STA_NOINIT;		/* Supports only drive 0 */
-
+    mutex_enter_blocking(&diskio_mutex);
     switch (cmd) {
         case CTRL_SYNC:;
             ;
@@ -150,6 +152,6 @@ DRESULT diskio_ioctl(BYTE drv, BYTE cmd, void *buff)
         default:
             return RES_PARERR;
     }
-
+    mutex_exit(&diskio_mutex);
     return RES_OK;
 }

--- a/pirate.c
+++ b/pirate.c
@@ -263,7 +263,7 @@ int main(){
                 //sync with the host 
                 storage_unmount();
                 storage_mount();
-                refresh_usbmsdrive();
+                insert_usbmsdrive();
             }
         }
         else{

--- a/pirate.c
+++ b/pirate.c
@@ -261,7 +261,6 @@ int main(){
                 has_been_connected = true;
                 prepare_usbmsdrive_readonly();
                 //sync with the host 
-                storage_unmount();
                 storage_mount();
                 insert_usbmsdrive();
             }

--- a/pirate.c
+++ b/pirate.c
@@ -259,10 +259,11 @@ int main(){
         if (tud_cdc_n_connected(0)){
             if(!has_been_connected){
                 has_been_connected = true;
-                make_usbmsdrive_readonly();
+                prepare_usbmsdrive_readonly();
                 //sync with the host 
                 storage_unmount();
                 storage_mount();
+                refresh_usbmsdrive();
             }
         }
         else{


### PR DESCRIPTION
Bunch of fixes to fix the hand over of the file system changes between BP and the host (At least Windows). 
Support for Windows device eject command. 
After all file system object writes, the BP mass storage is ejected and re-inserted to force Windows to notice the changed storage. 
By analyzing the USB MSC traffic between a well known Trenscend SD card reader I found out and implemented the correct sequence of SENSE CODEs to emit during ejection and insertion of a changed storage system. 
 