### PR TITLE
quiet a long-standing compiler warning

### DIFF
--- a/commands/spi/sniff.c
+++ b/commands/spi/sniff.c
@@ -26,6 +26,7 @@ static struct _pio_config pio_config;
 static struct _pio_config pio_config_d1;
 
 static const char * const usage[]= {
+    "This command has no help text. (yet)"
 /*    "flash [init|probe|erase|write|read|verify|test]\r\n\t[-f <file>] [-e(rase)] [-v(verify)] [-h(elp)]",
     "Initialize and probe: flash probe",
     "Erase and program, with verify: flash write -f example.bin -e -v",


### PR DESCRIPTION
The following is the compiler warning:
```
./commands/spi/sniff.c: In function 'sniff_handler':
./commands/spi/sniff.c:78:8: warning: 'ui_help_show' reading 4 bytes from a region of size 0 [-Wstringop-overread]
   78 |     if(ui_help_show(res->help_flag,usage,count_of(usage), &options[0],count_of(options) )) return;
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./commands/spi/sniff.c:78:8: note: referencing argument 2 of type 'const char * const[0]'

In file included from ./commands/spi/sniff.c:17:
./ui/ui_help.h:10:6: note: in a call to function 'ui_help_show'
   10 | bool ui_help_show(bool help_flag, const char * const usage[], uint32_t count_of_usage, const struct ui_help_options *options, uint32_t count_of_options);
      |      ^~~~~~~~~~~~
```

I've scratched my head trying to understand where the invalid read is coming from, but in the end, just ensuring there's some help string here is a safe enough fix.