### PR TITLE
Fix output to not always say IO0

### DIFF
--- a/src/commands/global/bug.c
+++ b/src/commands/global/bug.c
@@ -38,10 +38,10 @@ bool bug_e9_seems_fixed(bool pullup, uint8_t bio_pin) {
     bool bug_seems_fixed = false;
     printf("Disabling Bus Pirate pull-ups\r\n");
     pullup_disable();
-    printf("Making IO0 buffer and GPIO input\r\n");
+    printf("Making IO%d buffer and GPIO input\r\n", bio_pin);
     bio_input(bio_pin);
     busy_wait_ms(10);
-    printf("Making IO0 buffer an output\r\n");
+    printf("Making IO%d buffer an output\r\n", bio_pin);
     bio_buf_output(bio_pin);
     busy_wait_ms(10);
 
@@ -50,13 +50,13 @@ bool bug_e9_seems_fixed(bool pullup, uint8_t bio_pin) {
     if (pin_state) {
         printf("Warning: GPIO is 1, cannot test for E9\r\n");
     } else {
-        printf("Making IO0 buffer and GPIO input\r\n");
+        printf("Making IO%d buffer and GPIO input\r\n", bio_pin);
         bio_input(bio_pin);
         if (pullup) {
             printf("Enabling Bus Pirate pull-ups\r\n");
             pullup_enable();
         }
-        printf("Making IO0 buffer an output\r\n");
+        printf("Making IO%d buffer an output\r\n", bio_pin);
         bio_buf_output(bio_pin);
         printf("Disabling Bus Pirate pull-ups\r\n");
         pullup_disable();
@@ -65,7 +65,7 @@ bool bug_e9_seems_fixed(bool pullup, uint8_t bio_pin) {
         pin_state = bio_get(bio_pin);
         printf("GPIO pin should be 0: %d\r\n", pin_state);
         if (pin_state) {
-            printf("Warning: GPIO is 1, E9 found\r\n");
+            printf("Warning: GPIO is 1, E9 found for IO%d\r\n", bio_pin);
         } else {
             bug_seems_fixed = true;
         }


### PR DESCRIPTION
Minor fix to output of `bug e9 -a` to properly indicate which IO is being tested and/or exhibits the errata.