### PR TITLE
Add cross-reference table to `.elf.map`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build/**
-build_rp2040/**
-build_rp2350/**
+build_*/**
 .vscode/**
 .env
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -515,7 +515,7 @@ foreach(revision ${revisions})
         #pico_set_linker_script(${revision} ${CMAKE_CURRENT_LIST_DIR}/pirate/memmap_default.ld)
 endforeach()
 
-string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
+string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--cref,--print-memory-usage")
 
 
 # by default this project uses LGPL3 libraries, if you do not want to comply


### PR DESCRIPTION
This allows for more in-depth understanding of what code
is causing usage of what other code, helping to track memory
and code usage of final project.

Also update `.gitignore` to exclude any root directory starting with `build_` ... allowing individuals to have many builds without having to have a local edit to `.gitignore`