### PR TITLE
Optional usb serial

### DIFF
--- a/src/pirate.c
+++ b/src/pirate.c
@@ -616,8 +616,23 @@ void main(void) {
 
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,"\n");
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,
-        "Init: =========== rebooted ===========\n"
+        "Init: =========== %s ===========\n",
+        BP_HARDWARE_VERSION
         );
+    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,
+        "Init: Firmware %s @ %s (%s)\n",
+        BP_FIRMWARE_VERSION,
+        BP_FIRMWARE_HASH,
+        BP_FIRMWARE_TIMESTAMP
+        );
+    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,
+        "Init: %s with %s RAM, %s FLASH, S/N %08X%08X\n",
+           BP_HARDWARE_MCU,
+           BP_HARDWARE_RAM,
+           BP_HARDWARE_FLASH,
+           (uint32_t)(mcu_get_unique_id() >> 32),
+           (uint32_t)(mcu_get_unique_id() & 0xFFFFFFFFu)
+           );
     main_system_initialization();
 
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -201,6 +201,9 @@ static void main_system_initialization(void) {
         "Init: system init()\n"
         );
     system_init();
+#ifdef BP_MANUFACTURING_TEST_MODE
+    system_config.disable_unique_usb_serial_number = 1;
+#endif
 
     // setup the UI command buffers
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
@@ -543,8 +546,9 @@ static void core0_infinite_loop(void) {
 void main(void) {
     SEGGER_RTT_Init();
 
-    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
-        "Init: main_system_initialization()\n"
+    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,"\n");
+    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,
+        "Init: =========== rebooted ===========\n"
         );
     main_system_initialization();
 
@@ -640,8 +644,10 @@ static void core1_infinite_loop(void) {
                 }
             }
 
-            if (system_config.terminal_ansi_color && system_config.terminal_ansi_statusbar &&
-                system_config.terminal_ansi_statusbar_update && !system_config.terminal_ansi_statusbar_pause) {
+            if (system_config.terminal_ansi_color &&
+                system_config.terminal_ansi_statusbar &&
+                system_config.terminal_ansi_statusbar_update &&
+                !system_config.terminal_ansi_statusbar_pause) {
                 ui_statusbar_update(update_flags);
             }
 

--- a/src/pirate.h
+++ b/src/pirate.h
@@ -14,7 +14,7 @@
 #define BP_FIRMWARE_HASH "unknown"
 #endif
 #ifndef BP_FIRMWARE_TIMESTAMP // this variable is for the compile timestamp
-#define BP_FIRMWARE_TIMESTAMP _TIMEZ_
+    #define BP_FIRMWARE_TIMESTAMP ( __DATE__ " " __TIME__ )
 #endif
 
 #define BP_SPI_START_SPEED 1000 * 1000

--- a/src/pirate/storage.c
+++ b/src/pirate/storage.c
@@ -233,7 +233,16 @@ uint32_t storage_load_mode(const char* filename, const mode_config_t* config, ui
     f_close(&fil);
     return 1;
 }
-
+bool storage_file_exists(const char* filepath) {
+    bool result = false;
+    FIL fil = {0};
+    FRESULT fr = f_open(&fil, filepath, FA_READ | FA_OPEN_EXISTING);
+    if (fr == FR_OK) {
+        result = true;
+        f_close(&fil);
+    }
+    return result;
+}
 bool storage_ls(const char* location, const char* ext, const uint8_t flags) {
     FRESULT fr;
     DIR dir;
@@ -291,20 +300,22 @@ const char system_config_file[] = "bpconfig.bp";
 
 const mode_config_t system_config_json[] = {
     // clang-format off
-    {"$.terminal_language",       &system_config.terminal_language,       MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.terminal_ansi_color",     &system_config.terminal_ansi_color,     MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.terminal_ansi_statusbar", &system_config.terminal_ansi_statusbar, MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.display_format",          &system_config.display_format,          MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.lcd_screensaver_active",  &system_config.lcd_screensaver_active,  MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.lcd_timeout",             &system_config.lcd_timeout,             MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.led_effect",              &system_config.led_effect_as_uint32,    MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.led_color",               &system_config.led_color,               MODE_CONFIG_FORMAT_HEXSTRING, },
-    {"$.led_brightness_divisor",  &system_config.led_brightness_divisor,  MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.terminal_usb_enable",     &system_config.terminal_usb_enable,     MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.terminal_uart_enable",    &system_config.terminal_uart_enable,    MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.terminal_uart_number",    &system_config.terminal_uart_number,    MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.debug_uart_enable",       &system_config.debug_uart_enable,       MODE_CONFIG_FORMAT_DECIMAL,   },
-    {"$.debug_uart_number",       &system_config.debug_uart_number,       MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_language",           &system_config.terminal_language,                MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_ansi_color",         &system_config.terminal_ansi_color,              MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_ansi_statusbar",     &system_config.terminal_ansi_statusbar,          MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.display_format",              &system_config.display_format,                   MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.lcd_screensaver_active",      &system_config.lcd_screensaver_active,           MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.lcd_timeout",                 &system_config.lcd_timeout,                      MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.led_effect",                  &system_config.led_effect_as_uint32,             MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.led_color",                   &system_config.led_color,                        MODE_CONFIG_FORMAT_HEXSTRING, },
+    {"$.led_brightness_divisor",      &system_config.led_brightness_divisor,           MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_usb_enable",         &system_config.terminal_usb_enable,              MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_uart_enable",        &system_config.terminal_uart_enable,             MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.terminal_uart_number",        &system_config.terminal_uart_number,             MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.debug_uart_enable",           &system_config.debug_uart_enable,                MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.debug_uart_number",           &system_config.debug_uart_number,                MODE_CONFIG_FORMAT_DECIMAL,   },
+    {"$.disable_usb_serial_number",   &system_config.disable_unique_usb_serial_number, MODE_CONFIG_FORMAT_DECIMAL,   },
+    //....-....1....-....2....-....3
     // clang-format on
 };
 

--- a/src/pirate/storage.h
+++ b/src/pirate/storage.h
@@ -23,6 +23,7 @@ uint32_t storage_load_config(void);
 uint32_t storage_save_config(void);
 uint32_t storage_save_mode(const char* filename, const mode_config_t* config_t, uint8_t count);
 uint32_t storage_load_mode(const char* filename, const mode_config_t* config_t, uint8_t count);
+bool storage_file_exists(const char* filepath);
 bool storage_ls(const char* location, const char* ext, const uint8_t flags);
 
 extern const char storage_fat_type_labels[5][8];

--- a/src/system_config.c
+++ b/src/system_config.c
@@ -16,6 +16,11 @@
 struct _system_config system_config;
 
 void system_init(void) {
+    memset(&system_config, 0, sizeof(_system_config));
+    // Note: setting values to zero / false is redundant, but... it's OK to be explicit.
+
+    system_config.disable_unique_usb_serial_number = false;
+
     system_config.terminal_language = 0;
     system_config.config_loaded_from_file = false;
     system_config.terminal_usb_enable = true; // enable USB CDC terminal

--- a/src/system_config.c
+++ b/src/system_config.c
@@ -19,6 +19,9 @@ void system_init(void) {
     memset(&system_config, 0, sizeof(_system_config));
     // Note: setting values to zero / false is redundant, but... it's OK to be explicit.
 
+    // Which settings are persisted?
+    // (bpconfig.bp ... see storage.c):
+
     system_config.disable_unique_usb_serial_number = false;
 
     system_config.terminal_language = 0;

--- a/src/system_config.h
+++ b/src/system_config.h
@@ -9,7 +9,11 @@ typedef struct _pwm_config {
 } _pwm_config;
 
 typedef struct _system_config {
+    // NOTE: Most settings are uint32_t due to desire to standardize the JSON parsing.
+    // TODO: Put _persisted_ settings into a separate struct.
     bool config_loaded_from_file;
+    uint32_t disable_unique_usb_serial_number;
+
     uint8_t hardware_revision;
 
     uint32_t terminal_language;

--- a/src/translation/base.c
+++ b/src/translation/base.c
@@ -89,13 +89,33 @@ static const translation_table_t* translation_tables[COUNT_OF_LANGUAGE_IDX] = {
 
 #define UTF8_POOP_EMOJI_STRING "\xF0\x9F\x92\xA9" // poop emoji (💩) as a UTF-8 encoded, null-terminated string
 
-void translation_set(language_idx_t language) {
-    if (language >= COUNT_OF_LANGUAGE_IDX) {
+void translation_set(language_idx_t language_idx) {
+    if (language_idx >= COUNT_OF_LANGUAGE_IDX) {
         // log an error?  do nothing?
     } else {
-        current_language = language;
+        current_language = language_idx;
     }
     return;
+}
+
+const char* get_current_language_name(void) {
+    return get_language_name(current_language);
+}
+language_idx_t get_current_language_idx(void) {
+    return current_language;
+}
+const char* get_language_name(language_idx_t language_idx) {
+    if (language_idx == language_idx_en_us) {
+        return GET_T(T_CONFIG_LANGUAGE_ENGLISH);
+    } else if (language_idx == language_idx_pl_pl) {
+        return GET_T(T_CONFIG_LANGUAGE_POLISH);
+    } else if (language_idx == language_idx_bs_latn_ba) {
+        return GET_T(T_CONFIG_LANGUAGE_BOSNIAN);
+    } else if (language_idx == language_idx_it_it) {
+        return GET_T(T_CONFIG_LANGUAGE_ITALIAN);
+    } else {
+        return UTF8_POOP_EMOJI_STRING "UNKNOWN" UTF8_POOP_EMOJI_STRING;
+    }
 }
 
 const char* GET_T(enum T_translations index) {

--- a/src/translation/base.c
+++ b/src/translation/base.c
@@ -92,9 +92,10 @@ static const translation_table_t* translation_tables[COUNT_OF_LANGUAGE_IDX] = {
 void translation_set(language_idx_t language) {
     if (language >= COUNT_OF_LANGUAGE_IDX) {
         // log an error?  do nothing?
-        return;
+    } else {
+        current_language = language;
     }
-    current_language = language;
+    return;
 }
 
 const char* GET_T(enum T_translations index) {

--- a/src/translation/base.h
+++ b/src/translation/base.h
@@ -482,5 +482,8 @@ enum T_translations{
 const char * GET_T(enum T_translations index);
 void translation_init(void);
 void translation_set(language_idx_t language);
+const char* get_current_language_name(void);
+language_idx_t get_current_language_idx(void);
+const char* get_language_name(language_idx_t language_idx);
 
 #endif

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -27,6 +27,7 @@
 #include "pirate.h"
 #include "tusb.h"
 #include "pirate/mcu.h"
+#include "system_config.h"
 
 /*
  * BusPirate has obtained two VID/PID combinations from https://pid.codes/.
@@ -295,8 +296,9 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     if (index == 0) { // supported language == English
         memcpy(&_desc_str[1], string_desc_arr[0], 2);
         chr_count = 1;
-#ifndef BP_MANUFACTURING_TEST_MODE
-    } else if (index == 3) { // special-case for USB Serial number
+    } else if (index == 3 && !system_config.disable_unique_usb_serial_number) {
+        // if unique serial number is disabled, will use default value from string table `5buspirate`
+
         //  1x  uint16_t for length/type
         // 16x  uint16_t to encode 64-bit value as hex (16x nibbles)
         static_assert(MAXIMUM_DESCRIPTOR_STRING_ELEMENT_COUNT >= 17);
@@ -306,7 +308,6 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             _desc_str[16 - t] = nibble < 10 ? '0' + nibble : 'A' + nibble - 10;
         }
         chr_count = 16;
-#endif
     } else if (index >= STRING_DESC_ARR_ELEMENT_COUNT) { // if not in table, return NULL
         return NULL;
     } else {


### PR DESCRIPTION
Fixes #149.

Generally, see `src/pirate.c` around line 76, function `should_disable_unique_usb_serial_number()`.

Five options are listed here, of which four are implemented:

1. Compile-time option ... compatible with existing compile flag (
2. `bpconfig.bp` configuration option ... see `src/pirate/storage.c` for JSON field, and `system_config.disable_unique_usb_serial_number`.
3. Existence of file named `FACTORY.USB` on root of the flash storage.
4. If the file system is not formatted (or DNE for pre-REV10)

Note that factory testing can then use the same firmware as shipped.  When first loading onto the tester, there will be no file system, and thus no unique serial number will be exposed.   The test procedures, when formatting the media, will need to also create the file `FACTORY.USB` to prevent the next boot from using the unique serial number.  When factory testing is complete, simply delete the `FACTORY.USB` file.

As a developer, you can either use the configuration file setting, or create the `FACTORY.USB` file at the root of the storage.
