### PR TITLE
Technical debt -- and one SPI bus fix

### DIFF
--- a/hacks/rtt_debugging.md
+++ b/hacks/rtt_debugging.md
@@ -78,6 +78,8 @@ rtt start
 <details><summary>As a single script...</summary><P/>
 
 ```
+reset halt
+rtt stop
 program ./build_rp2040/src/bus_pirate5_rev10.elf
 reset halt
 rp2040.core1 arp_reset assert 0
@@ -85,7 +87,9 @@ rp2040.core0 arp_reset assert 0
 sleep 500
 rtt setup 0x20000000 0x100000 "SEGGER RTT"
 rtt start
+
 rtt server start 4321 0
+
 ```
 
 </details>
@@ -97,6 +101,8 @@ This requires a pre-release version of OpenOCD 0.12.0
 <details><summary>As a single script...</summary><P/>
 
 ```
+reset halt
+rtt stop
 program /home/henrygab/build_rp2350/src/bus_pirate6.elf
 reset halt
 rp2350.dap.core1 arp_reset assert 0
@@ -104,7 +110,9 @@ rp2350.dap.core0 arp_reset assert 0
 sleep 500
 rtt setup 0x20000000 0x100000 "SEGGER RTT"
 rtt start
+
 rtt server start 4321 0
+
 ```
 
 </details>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -377,20 +377,6 @@ set (bp5_rtt
 
 
 if(${PICO_PLATFORM} MATCHES "rp2350")
-        add_executable(bus_pirate5_xl
-                ${bp5_common}
-                ${bp5_nandflash}
-                ${bp5_rtt}
-                platform/bpi-rev10.h
-                platform/bpi-rev10.c 
-                pirate/shift.h
-                pirate/shift.c
-                display/robot5xx16.h
-                )
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VER=XL5)
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_REV=10)
-        target_compile_definitions(bus_pirate5_xl PUBLIC BP_FIRMWARE_HASH="${BP_FIRMWARE_HASH}")
-
         add_executable(bus_pirate6
                 ${bp5_common}
                 ${bp5_nandflash}
@@ -408,23 +394,20 @@ if(${PICO_PLATFORM} MATCHES "rp2350")
                 bus_pirate6
         )        
 
-else()
-        add_executable(bus_pirate5_rev8
+        add_executable(bus_pirate5_xl
                 ${bp5_common}
+                ${bp5_nandflash}
                 ${bp5_rtt}
-                platform/bpi-rev8.h
-                platform/bpi-rev8.c
-                #tf card access control
-                fatfs/tf_card.c
-                fatfs/tf_card.h
+                platform/bpi-rev10.h
+                platform/bpi-rev10.c 
                 pirate/shift.h
                 pirate/shift.c
-                display/robot5x16.h
+                display/robot5xx16.h
                 )
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VER=5) 
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_REV=8)
-        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_FIRMWARE_HASH="${BP_FIRMWARE_HASH}")
-
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_VER=XL5)
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_REV=10)
+        target_compile_definitions(bus_pirate5_xl PUBLIC BP_FIRMWARE_HASH="${BP_FIRMWARE_HASH}")
+else()
         add_executable(bus_pirate5_rev10
                 ${bp5_common}
                 ${bp5_nandflash}
@@ -443,6 +426,22 @@ else()
                 bus_pirate5_rev8  
                 bus_pirate5_rev10
         )
+
+        add_executable(bus_pirate5_rev8
+                ${bp5_common}
+                ${bp5_rtt}
+                platform/bpi-rev8.h
+                platform/bpi-rev8.c
+                #tf card access control
+                fatfs/tf_card.c
+                fatfs/tf_card.h
+                pirate/shift.h
+                pirate/shift.c
+                display/robot5x16.h
+                )
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_VER=5) 
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_REV=8)
+        target_compile_definitions(bus_pirate5_rev8 PUBLIC BP_FIRMWARE_HASH="${BP_FIRMWARE_HASH}")
 endif()
 
 

--- a/src/debug_rtt.c
+++ b/src/debug_rtt.c
@@ -79,6 +79,6 @@ bp_debug_level_t _DEBUG_LEVELS[32] = {
     [E_DEBUG_CAT_ONBOARD_PIXELS ] = BP_DEBUG_LEVEL_VERBOSE,
     [E_DEBUG_CAT_ONBOARD_STORAGE] = BP_DEBUG_LEVEL_VERBOSE,
     // add others here, in order of enumeration value
-    [E_DEBUG_CAT_TEMP           ] = BP_DEBUG_LEVEL_NEVER, // Print EVERYTHING in TEMP category by default
+    [E_DEBUG_CAT_TEMP           ] = BP_DEBUG_LEVEL_DEBUG,
 }; // up to 32 categories, each with a debug level
 

--- a/src/debug_rtt.h
+++ b/src/debug_rtt.h
@@ -219,13 +219,20 @@ bool bp_is_system_initialized(void);
             hard_assert(false);                                           \
         }                                                                 \
     } while (0)
+#define BP_ASSERT(_COND) \
+    do {                                                                  \
+        if (!(_COND)) {                                                   \
+            PRINT_FATAL("ASSERTION FAILED: %s:%d\n", __FILE__, __LINE__); \
+            hard_assert(false);                                           \
+        }                                                                 \
+    } while (0)
 
 #else
 
 // These assertions only assert after the system is fully initialized.
 #define BP_ASSERT_CORE0() assert((get_core_num() == 0) || !bp_is_system_initialized())
 #define BP_ASSERT_CORE1() assert((get_core_num() == 1) || !bp_is_system_initialized())
-
+#define BP_ASSERT(_COND)  assert(_COND)
 #endif
 
 

--- a/src/nand/spi_nand.c
+++ b/src/nand/spi_nand.c
@@ -180,8 +180,13 @@ typedef union {
 
 // private function prototypes
 static void csel_setup(void);
-static void csel_deselect(void);
-static void csel_select(void);
+//static void csel_deselect(void);
+// static void csel_select(void);
+#define csel_select()   csel_select_internal(__FILE__, __LINE__)
+#define csel_deselect() csel_deselect_internal(__FILE__, __LINE__)
+static void csel_select_internal(const char* file, int line);
+static void csel_deselect_internal(const char* file, int line);
+
 
 static int spi_nand_reset(void);
 static int read_id(nand_identity_t* identity_out);
@@ -216,7 +221,6 @@ int spi_nand_init(struct dhara_nand* dhara_parameters_out) {
     memset(dhara_parameters_out, 0, sizeof(struct dhara_nand));
 
     // initialize chip select
-    csel_deselect();
     csel_setup();
 
     // reset
@@ -497,15 +501,15 @@ static void csel_setup(void) {
     // gpio_set_dir(FLASH_STORAGE_CS, GPIO_OUT);
 }
 
-static void csel_deselect(void) {
+static void csel_deselect_internal(const char* file, int line) {
     // LL_GPIO_SetOutputPin(CSEL_PORT, CSEL_PIN);
     gpio_put(FLASH_STORAGE_CS, 1);
-    spi_busy_wait(false);
+    spi_busy_wait_internal(false, file, line);
 }
 
-static void csel_select(void) {
+static void csel_select_internal(const char* file, int line) {
     // LL_GPIO_ResetOutputPin(CSEL_PORT, CSEL_PIN);
-    spi_busy_wait(true);
+    spi_busy_wait_internal(true, file, line);
     gpio_put(FLASH_STORAGE_CS, 0);
 }
 

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -431,6 +431,11 @@ static void main_system_initialization(void) {
         "Init: binmode_setup()\n"
         );
     binmode_setup();
+
+    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
+        "Init: main_system_initialization() complete()\n"
+        );
+
 }
 
 static void core0_infinite_loop(void) {
@@ -639,6 +644,7 @@ void main(void) {
         "Init: entering core0_infinite_loop()\n"
         );
 
+    bp_mark_system_initialized();
     core0_infinite_loop(); // this never should exit, but....
     assert(false); // infinite loop above should never exit
 }
@@ -813,6 +819,7 @@ void core1_entry(void) {
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
         "Init: starting core1_infinite_loop()\n"
         );
+    bp_mark_system_initialized();
     core1_infinite_loop();
     assert(false); // infinite loop above should never exit
 }

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -723,6 +723,8 @@ static void core1_infinite_loop(void) {
         if (system_config.binmode_usb_tx_queue_enable) {
             bin_tx_fifo_service();
         }
+        // also receive input from RTT, if available
+        rx_from_rtt_terminal();
 
         if (system_config.psu == 1 &&
             system_config.psu_irq_en == true &&

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -847,13 +847,16 @@ void lcd_irq_enable(int16_t repeat_interval) {
 }
 
 // gives protected access to spi (core safe)
-void spi_busy_wait(bool enable) {
+void spi_busy_wait_internal(bool enable, const char *file, int line) {
+
     if (!enable) {
-        // the check is to protect against the first csel_deselect call not matched by a csel_select
-        if (lock_is_owner_id_valid(spi_mutex.owner)) {
-            mutex_exit(&spi_mutex);
-        }
+
+        BP_ASSERT(lock_get_caller_owner_id() == spi_mutex.owner);
+        mutex_exit(&spi_mutex);
+
     } else {
+
         mutex_enter_blocking(&spi_mutex);
+        BP_ASSERT(lock_get_caller_owner_id() == spi_mutex.owner);
     }
 }

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -496,7 +496,7 @@ static void core0_infinite_loop(void) {
                         result.success = true;
                     }
                 } else {
-                    PRINT_VERBOSE("Prompting to allow VT100 mode.\n");
+                    // PRINT_VERBOSE("Prompting to allow VT100 mode.\n"); // prints repeatedly ... much too verbose
                     ui_prompt_vt100_mode(&result, &value);
                 }
 

--- a/src/pirate.h
+++ b/src/pirate.h
@@ -91,7 +91,9 @@
 
 void lcd_irq_enable(int16_t repeat_interval);
 void lcd_irq_disable(void);
-void spi_busy_wait(bool enable);
+
+#define spi_busy_wait(ENABLE) spi_busy_wait_internal(ENABLE, __FILE__, __LINE__)
+void spi_busy_wait_internal(bool enable, const char *file, int line);
 
 //#define BP_PIO_SHOW_ASSIGNMENT
 

--- a/src/ui/ui_flags.h
+++ b/src/ui/ui_flags.h
@@ -1,10 +1,26 @@
 
-#define UI_UPDATE_IMAGE (1u << 0)
-#define UI_UPDATE_INFOBAR (1u << 1)
-#define UI_UPDATE_NAMES (1u << 2)
-#define UI_UPDATE_LABELS (1u << 3)
-#define UI_UPDATE_VOLTAGES (1u << 4)
-#define UI_UPDATE_CURRENT (1u << 5)
-#define UI_UPDATE_FORCE (1u << 6) // force label update
-#define UI_UPDATE_ALL                                                                                                  \
-    (UI_UPDATE_IMAGE | UI_UPDATE_INFOBAR | UI_UPDATE_NAMES | UI_UPDATE_LABELS | UI_UPDATE_VOLTAGES | UI_UPDATE_CURRENT)
+typedef enum _ui_update_flag_t {
+    UI_UPDATE_NONE     = 0u,
+    UI_UPDATE_IMAGE    = (1u << 0),
+    UI_UPDATE_INFOBAR  = (1u << 1),
+    UI_UPDATE_NAMES    = (1u << 2),
+    UI_UPDATE_LABELS   = (1u << 3),
+    UI_UPDATE_VOLTAGES = (1u << 4),
+    UI_UPDATE_CURRENT  = (1u << 5),
+    UI_UPDATE_FORCE    = (1u << 6), // force label update
+    // space for one more UI update flag before this changes from uint8_t to uint16_t....
+
+    UI_UPDATE_ALL      = (
+        UI_UPDATE_IMAGE    |
+        UI_UPDATE_INFOBAR  |
+        UI_UPDATE_NAMES    |
+        UI_UPDATE_LABELS   |
+        UI_UPDATE_VOLTAGES |
+        UI_UPDATE_CURRENT  |
+        0u
+        ),
+} ui_update_flag_t;
+
+// if size grew, need to check all uses of this enum to ensure larger size is OK
+// Likely yes, but ... safer to check.
+_Static_assert(sizeof(ui_update_flag_t) == sizeof(uint8_t), "ui_update_flag_t larger than byte; review of code required");

--- a/src/usb_rx.h
+++ b/src/usb_rx.h
@@ -1,7 +1,7 @@
 void rx_fifo_init(void);
 void rx_uart_init_irq(void);
 void rx_usb_init(void);
-void rx_fifo_service(void);
+void rx_from_rtt_terminal(void); // get terminal input from RTT until queue full or RTT input is empty
 
 void rx_fifo_add(char* c);
 bool rx_fifo_try_get(char* c);

--- a/src/usb_tx.c
+++ b/src/usb_tx.c
@@ -47,8 +47,7 @@ void tx_sb_start(uint32_t valid_characters_in_status_bar) {
 }
 
 void tx_fifo_service(void) {
-    uint core = get_core_num();
-    assert(core == 1); // tx fifo is drained from core1 only
+    BP_ASSERT_CORE1(); // tx fifo is drained from core1 only
 
 // state machine:
 #define IDLE 0


### PR DESCRIPTION
SPI arbitration was broken.  Turns out that releasing a mutex that hasn't been acquired is NOT the right thing to do, and then hiding the problem in a helper function just makes it that much harder to track down the real problem.

This branch also allows the buspirate's terminal to be controlled from RTT.
However, the terminal output is not yet sent over RTT ... so you'll still need to connect a terminal for now.

Related to #110 ... in that it may reduce corruption of the NAND file system by fixing the SPI arbitration.