### PR TITLE
Payoff some technical debt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,13 +52,13 @@ This project uses `cmake` as the build system, so building the project only take
     
 2. project build
     ```bash
-    cmake --build ./build_rp2040 --target all
-    cmake --build ./build_rp2350 --target all
+    cmake --build ./build_rp2040 --parallel --target all
+    cmake --build ./build_rp2350 --parallel --target all
     # you may add a specific target, such as:
-    cmake --build ./build_rp2040 --target bus_pirate5_rev8
-    cmake --build ./build_rp2040 --target bus_pirate5_rev10
-    cmake --build ./build_rp2350 --target bus_pirate5_xl
-    cmake --build ./build_rp2350 --target bus_pirate6
+    cmake --build ./build_rp2040 --parallel --target bus_pirate5_rev8
+    cmake --build ./build_rp2040 --parallel --target bus_pirate5_rev10
+    cmake --build ./build_rp2350 --parallel --target bus_pirate5_xl
+    cmake --build ./build_rp2350 --parallel --target bus_pirate6
     ```
     You can also manually clean using `--target clean`, or
     force a clean prior to building by using `--clean-first`.

--- a/src/binmode/binio.c
+++ b/src/binmode/binio.c
@@ -519,7 +519,7 @@ uint32_t binmode_pwm_enable(uint8_t* binmode_args) {
     pwm_set_enabled(slice_num, true);
 
     // register the freq active, apply the pin label
-    system_bio_claim(true, (uint8_t)binmode_args[0], BP_PIN_PWM, ui_const_pin_states[3]);
+    system_bio_update_purpose_and_label(true, (uint8_t)binmode_args[0], BP_PIN_PWM, ui_const_pin_states[3]);
     system_set_active(true, (uint8_t)binmode_args[0], &system_config.pwm_active);
     return 0;
 }
@@ -542,7 +542,7 @@ uint32_t binmode_pwm_disable(uint8_t* binmode_args) {
     bio_input((uint8_t)binmode_args[0]);
 
     // unregister, remove pin label
-    system_bio_claim(false, (uint8_t)binmode_args[0], 0, 0);
+    system_bio_update_purpose_and_label(false, (uint8_t)binmode_args[0], 0, 0);
     system_set_active(false, (uint8_t)binmode_args[0], &system_config.pwm_active);
 
     if (binmode_debug) {
@@ -596,7 +596,7 @@ uint32_t binmode_pwm_raw(uint8_t* binmode_args) {
     pwm_set_enabled(slice_num, true);
 
     // register the freq active, apply the pin label
-    system_bio_claim(true, (uint8_t)binmode_args[0], BP_PIN_PWM, ui_const_pin_states[3]);
+    system_bio_update_purpose_and_label(true, (uint8_t)binmode_args[0], BP_PIN_PWM, ui_const_pin_states[3]);
     system_set_active(true, (uint8_t)binmode_args[0], &system_config.pwm_active);
     return 0;
 }

--- a/src/binmode/binio_helpers.c
+++ b/src/binmode/binio_helpers.c
@@ -23,12 +23,12 @@ void script_reset(void) {
 
     // POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
     static const char pin_labels[][5] = { "BIO0", "BIO1", "BIO2", "BIO3", "BIO4", "BIO5", "BIO6", "BIO7" };
-    system_bio_claim(true, BIO0, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, BIO1, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, BIO2, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, BIO3, BP_PIN_MODE, pin_labels[3]);
-    system_bio_claim(true, BIO4, BP_PIN_MODE, pin_labels[4]);
-    system_bio_claim(true, BIO5, BP_PIN_MODE, pin_labels[5]);
-    system_bio_claim(true, BIO6, BP_PIN_MODE, pin_labels[6]);
-    system_bio_claim(true, BIO7, BP_PIN_MODE, pin_labels[7]);
+    system_bio_update_purpose_and_label(true, BIO0, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, BIO1, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, BIO2, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO3, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO4, BP_PIN_MODE, pin_labels[4]);
+    system_bio_update_purpose_and_label(true, BIO5, BP_PIN_MODE, pin_labels[5]);
+    system_bio_update_purpose_and_label(true, BIO6, BP_PIN_MODE, pin_labels[6]);
+    system_bio_update_purpose_and_label(true, BIO7, BP_PIN_MODE, pin_labels[7]);
 }

--- a/src/binmode/legacy4third.c
+++ b/src/binmode/legacy4third.c
@@ -409,10 +409,10 @@ void legacy_protocol(void) {
 
                 spi_init(SPI1_BASE, 100000); // ~0.1MHz
                 hwspi_init(data_bits, cpol, cpha);
-                system_bio_claim(true, 6, 1, mpin_labels[0]);
-                system_bio_claim(true, 7, 1, mpin_labels[1]);
-                system_bio_claim(true, 4, 1, mpin_labels[2]);
-                system_bio_claim(true, 5, 1, mpin_labels[3]);
+                system_bio_update_purpose_and_label(true, 6, 1, mpin_labels[0]);
+                system_bio_update_purpose_and_label(true, 7, 1, mpin_labels[1]);
+                system_bio_update_purpose_and_label(true, 4, 1, mpin_labels[2]);
+                system_bio_update_purpose_and_label(true, 5, 1, mpin_labels[3]);
                 */
             } break;
 

--- a/src/commands/global/a_auxio.c
+++ b/src/commands/global/a_auxio.c
@@ -68,7 +68,7 @@ void auxio(struct command_result* res, bool output, bool level) {
                ui_term_color_num_float(),
                level,
                ui_term_color_reset());
-        system_bio_claim(true, pin, BP_PIN_IO, labels[level]);
+        system_bio_update_purpose_and_label(true, pin, BP_PIN_IO, labels[level]);
         system_set_active(true, pin, &system_config.aux_active);
     } else { // input
         bio_input(pin);
@@ -80,7 +80,7 @@ void auxio(struct command_result* res, bool output, bool level) {
                ui_term_color_num_float(),
                bio_get(pin),
                ui_term_color_reset());
-        system_bio_claim(false, pin, BP_PIN_IO, 0);
+        system_bio_update_purpose_and_label(false, pin, BP_PIN_IO, 0);
         system_set_active(false, pin, &system_config.aux_active);
     }
     return;

--- a/src/commands/global/freq.c
+++ b/src/commands/global/freq.c
@@ -150,7 +150,7 @@ uint32_t freq_configure_enable(void) {
     }
 
     // register the freq active, apply the pin label
-    system_bio_claim(true, (uint8_t)pin, BP_PIN_FREQ, ui_const_pin_states[4]);
+    system_bio_update_purpose_and_label(true, (uint8_t)pin, BP_PIN_FREQ, ui_const_pin_states[4]);
     system_set_active(true, (uint8_t)pin, &system_config.freq_active);
 
     printf("\r\n%s%s:%s %s on IO%s%d%s\r\n",
@@ -208,7 +208,7 @@ uint32_t freq_configure_disable(void) {
     bio_input((uint8_t)pin);
 
     // unregister, remove pin label
-    system_bio_claim(false, (uint8_t)pin, 0, 0);
+    system_bio_update_purpose_and_label(false, (uint8_t)pin, 0, 0);
     system_set_active(false, (uint8_t)pin, &system_config.freq_active);
 
     printf("\r\n%s%s:%s %s on IO%s%d%s",

--- a/src/commands/global/pwm.c
+++ b/src/commands/global/pwm.c
@@ -102,7 +102,7 @@ void pwm_configure_enable(struct command_result* res) {
     pwm_set_enabled(slice_num, true);
 
     // register the freq active, apply the pin label
-    system_bio_claim(true, (uint8_t)pin, BP_PIN_PWM, ui_const_pin_states[3]);
+    system_bio_update_purpose_and_label(true, (uint8_t)pin, BP_PIN_PWM, ui_const_pin_states[3]);
     system_set_active(true, (uint8_t)pin, &system_config.pwm_active);
 
     printf("\r\n%s%s:%s %s on IO%s%d%s\r\n",
@@ -179,7 +179,7 @@ void pwm_configure_disable(struct command_result* res) {
     bio_input((uint8_t)pin);
 
     // unregister, remove pin label
-    system_bio_claim(false, (uint8_t)pin, 0, 0);
+    system_bio_update_purpose_and_label(false, (uint8_t)pin, 0, 0);
     system_set_active(false, (uint8_t)pin, &system_config.pwm_active);
 
     printf("\r\n%s%s:%s %s on IO%s%d%s",

--- a/src/commands/global/w_psu.c
+++ b/src/commands/global/w_psu.c
@@ -35,7 +35,7 @@ void psucmd_irq_callback(void) {
     system_config.psu_error = true;
     system_config.error = true;
     system_config.info_bar_changed = true;
-    system_pin_claim(true, BP_VOUT, BP_PIN_VREF, ui_const_pin_states[5]);
+    system_pin_update_purpose_and_label(true, BP_VOUT, BP_PIN_VREF, ui_const_pin_states[5]);
 }
 
 // zero return code = success
@@ -43,7 +43,7 @@ uint32_t psucmd_enable(float volts, float current, bool current_limit_override) 
     system_config.psu = 0;
     system_config.pin_labels[0] = 0;
     system_config.pin_changed = 0xff;
-    system_pin_claim(false, BP_VOUT, 0, 0);
+    system_pin_update_purpose_and_label(false, BP_VOUT, 0, 0);
 
     uint32_t psu_result = psu_enable(volts, current, current_limit_override);
 
@@ -64,7 +64,7 @@ uint32_t psucmd_enable(float volts, float current, bool current_limit_override) 
     system_config.psu_error = false;
     system_config.psu_current_error = false;
     system_config.info_bar_changed = true;
-    system_pin_claim(true, BP_VOUT, BP_PIN_VOUT, ui_const_pin_states[1]);
+    system_pin_update_purpose_and_label(true, BP_VOUT, BP_PIN_VOUT, ui_const_pin_states[1]);
     monitor_clear_current(); // reset current so the LCD gets all characters
 
     // since we dont have any more pins, the over current detect system is read through the
@@ -211,7 +211,7 @@ void psucmd_disable(void) {
     system_config.psu = 0;
     system_config.info_bar_changed = true;
     monitor_clear_current(); // reset current so the LCD gets all characters next time
-    system_pin_claim(true, BP_VOUT, BP_PIN_VREF, ui_const_pin_states[0]); // change back to vref type pin
+    system_pin_update_purpose_and_label(true, BP_VOUT, BP_PIN_VREF, ui_const_pin_states[0]); // change back to vref type pin
 }
 
 void psucmd_disable_handler(struct command_result* res) {

--- a/src/commands/hdplxuart/bridge.c
+++ b/src/commands/hdplxuart/bridge.c
@@ -47,7 +47,7 @@ void hduart_bridge_handler(struct command_result* res) {
 
     bool suppress_local_echo = cmdln_args_find_flag('s' | 0x20);
 
-    system_bio_claim(true, BIO2, BP_PIN_MODE, label);
+    system_bio_update_purpose_and_label(true, BIO2, BP_PIN_MODE, label);
     bio_output(BIO2);
     bio_put(BIO2, system_config.rts);
 
@@ -71,7 +71,7 @@ void hduart_bridge_handler(struct command_result* res) {
     }
 
     bio_input(BIO2);
-    system_bio_claim(false, BIO2, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO2, BP_PIN_MODE, 0);
 
     if (pause_toolbar) {
         system_config.terminal_ansi_statusbar_pause = toolbar_state;

--- a/src/commands/spi/sniff.c
+++ b/src/commands/spi/sniff.c
@@ -100,10 +100,10 @@ void sniff_handler(struct command_result* res) {
 
     static const char pin_labels[][5] = { "DAT0", "DAT1", "SCLK", "SCS" };
 
-    system_bio_claim(true, BIO0, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, BIO1, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, BIO2, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, BIO3, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO0, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, BIO1, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, BIO2, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO3, BP_PIN_MODE, pin_labels[3]);
     printf("Any key to exit\r\n");
     while (true) {
         if (pio_read(&value)) {
@@ -121,8 +121,8 @@ void sniff_handler(struct command_result* res) {
 
     pio_remove_program_and_unclaim_sm(&spisnif_2_program, pio_config_d1.pio, pio_config_d1.sm, pio_config_d1.offset);
 
-    system_bio_claim(false, BIO0, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO1, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO2, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO3, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO0, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO1, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO2, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO3, BP_PIN_MODE, 0);
 }

--- a/src/commands/uart/monitor.c
+++ b/src/commands/uart/monitor.c
@@ -76,8 +76,8 @@ void uart_monitor_handler(struct command_result* res) {
     // assign peripheral to io pins
     bio_set_function(BIO0, GPIO_FUNC_UART); // tx
     bio_set_function(BIO1, GPIO_FUNC_UART); // rx
-    system_bio_claim(true, BIO0, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, BIO1, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, BIO0, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, BIO1, BP_PIN_MODE, pin_labels[1]);
 
     // set buffers to correct position
     bio_buf_input(BIO2);  // cts uart1 input
@@ -89,10 +89,10 @@ void uart_monitor_handler(struct command_result* res) {
     bio_set_function(BIO3, GPIO_FUNC_UART);
     bio_set_function(BIO6, GPIO_FUNC_UART);
     bio_set_function(BIO7, GPIO_FUNC_UART);
-    system_bio_claim(true, BIO2, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, BIO3, BP_PIN_MODE, pin_labels[3]);
-    system_bio_claim(true, BIO6, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, BIO7, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO2, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO3, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO6, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO7, BP_PIN_MODE, pin_labels[3]);
 
     printf("%s%s%s\r\n", ui_term_color_notice(), GET_T(T_HELP_UART_BRIDGE_EXIT), ui_term_color_reset());
 

--- a/src/debug_uart.c
+++ b/src/debug_uart.c
@@ -50,7 +50,7 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].tx_pin, GPIO_FUNC_UART);
         // claim and label pin
-        system_bio_claim(
+        system_bio_update_purpose_and_label(
             true, debug_uart[uart_number].tx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label * 2) + 0]);
     }
 
@@ -63,7 +63,7 @@ void debug_uart_init(int uart_number, bool dbrx, bool dbtx, bool terminal_label)
         // Set the GPIO pin mux to the UART
         bio_set_function(debug_uart[uart_number].rx_pin, GPIO_FUNC_UART);
         // claim and label pin
-        system_bio_claim(
+        system_bio_update_purpose_and_label(
             true, debug_uart[uart_number].rx_pin, BP_PIN_DEBUG, debug_pin_labels[(terminal_label * 2) + 1]);
     }
 }

--- a/src/mode/dio.c
+++ b/src/mode/dio.c
@@ -50,7 +50,7 @@ uint32_t dio_setup_exc(void) {
     for (uint8_t i = 0; i < 8; i++) {
         // user data is in result->out_data
         bio_output(i);
-        system_bio_claim(true, i, BP_PIN_IO, labels[0]);
+        system_bio_update_purpose_and_label(true, i, BP_PIN_IO, labels[0]);
         bio_put(i, 0);
         system_set_active(true, i, &system_config.aux_active);
     }    
@@ -77,10 +77,10 @@ void dio_write(struct _bytecode* result, struct _bytecode* next) {
         // user data is in result->out_data
         //bio_output(i);
         if (result->out_data & (0b1 << i)) {
-            system_bio_claim(true, i, BP_PIN_IO, labels[1]);
+            system_bio_update_purpose_and_label(true, i, BP_PIN_IO, labels[1]);
             //bio_put(i, 1);
         } else {
-            system_bio_claim(true, i, BP_PIN_IO, labels[0]);
+            system_bio_update_purpose_and_label(true, i, BP_PIN_IO, labels[0]);
             //bio_put(i, 0);
         }
         //system_set_active(true, i, &system_config.aux_active);

--- a/src/mode/dummy1.c
+++ b/src/mode/dummy1.c
@@ -60,10 +60,10 @@ uint32_t dummy1_setup_exc(void) {
     // 2. Claim IO pins that are used by your hardware/protocol
     // The Bus Pirate won't let the user manipulate these pins
     //  or use PWM/FREQ/etc on these pins while claimed.
-    system_bio_claim(true, BIO4, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, BIO5, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, BIO6, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, BIO7, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO4, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, BIO5, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, BIO6, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO7, BP_PIN_MODE, pin_labels[3]);
     printf("-DUMMY1- setup_exc()\r\n");
     return 1;
 }
@@ -74,10 +74,10 @@ void dummy1_cleanup(void) {
     bio_init();
 
     // 2. Release the IO pins and reset the labels
-    system_bio_claim(false, BIO4, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO5, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO6, BP_PIN_MODE, 0);
-    system_bio_claim(false, BIO7, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO4, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO5, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO6, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, BIO7, BP_PIN_MODE, 0);
     printf("-DUMMY1- cleanup()\r\n");
 }
 

--- a/src/mode/hiz.c
+++ b/src/mode/hiz.c
@@ -34,7 +34,7 @@ uint32_t hiz_setup_exec(void) {
     system_config.pwm_active = 0;
     system_config.aux_active = 0;
     for (int i = 0; i < count_of(bio2bufiopin); i++) {
-        system_bio_claim(false, i, BP_PIN_IO, 0);
+        system_bio_update_purpose_and_label(false, i, BP_PIN_IO, 0);
     }
     return 1;
 }

--- a/src/mode/hw1wire.c
+++ b/src/mode/hw1wire.c
@@ -48,7 +48,7 @@ uint32_t hw1wire_setup(void) {
 }
 
 uint32_t hw1wire_setup_exc(void) {
-    system_bio_claim(true, M_OW_OWD, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_OW_OWD, BP_PIN_MODE, pin_labels[0]);
 #ifdef BP_OLD_HW1WIRE
     onewire_init(bio2bufiopin[M_OW_OWD], bio2bufdirpin[M_OW_OWD]);
 #else
@@ -106,7 +106,7 @@ void hw1wire_cleanup(void) {
     ow_cleanup();
 #endif
     bio_init();
-    system_bio_claim(false, M_OW_OWD, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_OW_OWD, BP_PIN_MODE, 0);
 }
 
 // MACROS

--- a/src/mode/hw2wire.c
+++ b/src/mode/hw2wire.c
@@ -103,9 +103,9 @@ uint32_t hw2wire_setup_exc(void) {
                      bio2bufdirpin[M_2WIRE_SDA],
                      bio2bufdirpin[M_2WIRE_SCL],
                      hw2wire_mode_config.baudrate);
-    system_bio_claim(true, M_2WIRE_SDA, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_2WIRE_SCL, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, M_2WIRE_RST, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, M_2WIRE_SDA, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_2WIRE_SCL, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_2WIRE_RST, BP_PIN_MODE, pin_labels[2]);
     pio_hw2wire_reset();
     bio_put(M_2WIRE_RST, 0); // preload the RST pin to be 0 when output
 }
@@ -195,9 +195,9 @@ void hw2wire_macro(uint32_t macro) {
 void hw2wire_cleanup(void) {
     pio_hw2wire_cleanup();
     bio_init();
-    system_bio_claim(false, M_2WIRE_SDA, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_2WIRE_SCL, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_2WIRE_RST, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_2WIRE_SDA, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_2WIRE_SCL, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_2WIRE_RST, BP_PIN_MODE, 0);
 }
 
 /*void hw2wire_pins(void){

--- a/src/mode/hw3wire.c
+++ b/src/mode/hw3wire.c
@@ -179,10 +179,10 @@ uint32_t hw3wire_setup_exc(void) {
                      bio2bufiopin[M_3WIRE_SCLK],
                      bio2bufiopin[M_3WIRE_MISO],                     
                      mode_config.baudrate);
-    system_bio_claim(true, M_3WIRE_MOSI, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_3WIRE_SCLK, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, M_3WIRE_MISO, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, M_3WIRE_CS, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, M_3WIRE_MOSI, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_3WIRE_SCLK, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_3WIRE_MISO, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, M_3WIRE_CS, BP_PIN_MODE, pin_labels[3]);
     //pio_hw3wire_reset();
     //bio_put(M_2WIRE_RST, 0); // preload the RST pin to be 0 when output
     hw3wire_set_cs(M_3WIRE_DESELECT);
@@ -191,10 +191,10 @@ uint32_t hw3wire_setup_exc(void) {
 void hw3wire_cleanup(void) {
     pio_hw3wire_cleanup();
     bio_init();
-    system_bio_claim(false, M_3WIRE_MOSI, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_3WIRE_SCLK, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_3WIRE_MISO, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_3WIRE_CS, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_3WIRE_MOSI, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_3WIRE_SCLK, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_3WIRE_MISO, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_3WIRE_CS, BP_PIN_MODE, 0);
 }
 
 bool hw3wire_preflight_sanity_check(void){

--- a/src/mode/hwhduart.c
+++ b/src/mode/hwhduart.c
@@ -179,7 +179,7 @@ uint32_t hwhduart_setup_exc(void) {
     // setup peripheral
     // half duplex
     hwuart_pio_init(mode_config.data_bits, mode_config.parity, mode_config.stop_bits, mode_config.baudrate);
-    system_bio_claim(true, M_UART_RXTX, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_UART_RXTX, BP_PIN_MODE, pin_labels[0]);
     return 1;
 }
 
@@ -270,7 +270,7 @@ void hwhduart_cleanup(void) {
     // disable peripheral
     // half duplex
     hwuart_pio_deinit();
-    system_bio_claim(false, M_UART_RXTX, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_UART_RXTX, BP_PIN_MODE, 0);
 
     // reset all pins to safe mode (done before mode change, but we do it here to be safe)
     bio_init();

--- a/src/mode/hwi2c.c
+++ b/src/mode/hwi2c.c
@@ -132,8 +132,8 @@ uint32_t hwi2c_setup_exc(void) {
                 bio2bufdirpin[M_I2C_SCL],
                 mode_config.baudrate,
                 mode_config.clock_stretch);           
-    system_bio_claim(true, M_I2C_SDA, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_I2C_SCL, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_I2C_SDA, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_I2C_SCL, BP_PIN_MODE, pin_labels[1]);
     mode_config.start_sent = false;
     return 1;
 }
@@ -219,8 +219,8 @@ void hwi2c_macro(uint32_t macro) {
 void hwi2c_cleanup(void) {
     pio_i2c_cleanup();
     bio_init();
-    system_bio_claim(false, M_I2C_SDA, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_I2C_SCL, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_I2C_SDA, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_I2C_SCL, BP_PIN_MODE, 0);
 }
 
 void hwi2c_settings(void) {

--- a/src/mode/hwled.c
+++ b/src/mode/hwled.c
@@ -134,7 +134,7 @@ uint32_t hwled_setup_exc(void) {
     pio_config.sm = 0;
     switch (mode_config.device) {
         case M_LED_WS2812:
-            system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
+            system_bio_update_purpose_and_label(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
             mode_config.baudrate = 800000;
             bio_buf_output(M_LED_SDO);
             // success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio_config.pio,
@@ -152,8 +152,8 @@ uint32_t hwled_setup_exc(void) {
                                 false);            
             break;
         case M_LED_APA102:
-            system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
-            system_bio_claim(true, M_LED_SCL, BP_PIN_MODE, pin_labels[1]);
+            system_bio_update_purpose_and_label(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
+            system_bio_update_purpose_and_label(true, M_LED_SCL, BP_PIN_MODE, pin_labels[1]);
             mode_config.baudrate = (5 * 1000 * 1000);
             bio_buf_output(M_LED_SDO);
             bio_buf_output(M_LED_SCL);
@@ -300,8 +300,8 @@ void hwled_cleanup(void) {
     }
     system_config.subprotocol_name = 0x00;
     system_config.num_bits=8;
-    system_bio_claim(false, M_LED_SDO, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_LED_SCL, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_LED_SDO, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_LED_SCL, BP_PIN_MODE, 0);
     bio_init();
 }
 

--- a/src/mode/hwled.c
+++ b/src/mode/hwled.c
@@ -134,9 +134,7 @@ uint32_t hwled_setup_exc(void) {
     pio_config.sm = 0;
     switch (mode_config.device) {
         case M_LED_WS2812:
-            if(!system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0])){
-                printf("\r\nError: Unable to claim SDO pin");
-            }
+            system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
             mode_config.baudrate = 800000;
             bio_buf_output(M_LED_SDO);
             // success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio_config.pio,
@@ -154,11 +152,8 @@ uint32_t hwled_setup_exc(void) {
                                 false);            
             break;
         case M_LED_APA102:
-            if(!(system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]) &&
-                system_bio_claim(true, M_LED_SCL, BP_PIN_MODE, pin_labels[1]))){
-                printf("\r\nError: Unable to claim SDO or SCL pin");
-                return 0;
-            }
+            system_bio_claim(true, M_LED_SDO, BP_PIN_MODE, pin_labels[0]);
+            system_bio_claim(true, M_LED_SCL, BP_PIN_MODE, pin_labels[1]);
             mode_config.baudrate = (5 * 1000 * 1000);
             bio_buf_output(M_LED_SDO);
             bio_buf_output(M_LED_SCL);

--- a/src/mode/hwspi.c
+++ b/src/mode/hwspi.c
@@ -223,10 +223,10 @@ uint32_t spi_setup_exc(void) {
                mode_config.baudrate_actual / 1000);
     }
     hwspi_init(mode_config.data_bits, mode_config.clock_polarity, mode_config.clock_phase);
-    system_bio_claim(true, M_SPI_CLK, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_SPI_CDO, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, M_SPI_CDI, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, M_SPI_CS, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, M_SPI_CLK, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_SPI_CDO, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_SPI_CDI, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, M_SPI_CS, BP_PIN_MODE, pin_labels[3]);
     spi_set_cs(M_SPI_DESELECT);
     return mode_config.baudrate_actual;
 }
@@ -235,10 +235,10 @@ void spi_cleanup(void) {
     // disable peripheral
     hwspi_deinit();
     // release pin claims
-    system_bio_claim(false, M_SPI_CLK, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_SPI_CDO, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_SPI_CDI, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_SPI_CS, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_SPI_CLK, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_SPI_CDO, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_SPI_CDI, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_SPI_CS, BP_PIN_MODE, 0);
     // update system_config pins
     system_config.misoport = 0;
     system_config.mosiport = 0;

--- a/src/mode/hwuart.c
+++ b/src/mode/hwuart.c
@@ -221,16 +221,16 @@ uint32_t hwuart_setup_exc(void) {
     // assign peripheral to io pins
     bio_set_function(M_UART_TX, GPIO_FUNC_UART); // tx
     bio_set_function(M_UART_RX, GPIO_FUNC_UART); // rx
-    system_bio_claim(true, M_UART_TX, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_UART_RX, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_UART_TX, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_UART_RX, BP_PIN_MODE, pin_labels[1]);
 
     bio_set_function(M_UART_CTS, GPIO_FUNC_UART);
     bio_set_function(M_UART_RTS, GPIO_FUNC_SIO);
     bio_output(M_UART_RTS);
     if (mode_config.flow_control) {
         // only show the pins if flow control is enabled in order to avoid confusion
-        system_bio_claim(true, M_UART_RTS, BP_PIN_MODE, pin_labels[2]);
-        system_bio_claim(true, M_UART_CTS, BP_PIN_MODE, pin_labels[3]);
+        system_bio_update_purpose_and_label(true, M_UART_RTS, BP_PIN_MODE, pin_labels[2]);
+        system_bio_update_purpose_and_label(true, M_UART_CTS, BP_PIN_MODE, pin_labels[3]);
     }
     gpio_set_inover(bio2bufiopin[M_UART_CTS], mode_config.invert ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
     gpio_set_outover(bio2bufiopin[M_UART_RTS], mode_config.invert ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
@@ -332,8 +332,8 @@ void hwuart_macro(uint32_t macro) {
 void hwuart_cleanup(void) {
     // disable peripheral
     uart_deinit(M_UART_PORT);
-    system_bio_claim(false, M_UART_TX, BP_PIN_MODE, 0);
-    system_bio_claim(false, M_UART_RX, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_UART_TX, BP_PIN_MODE, 0);
+    system_bio_update_purpose_and_label(false, M_UART_RX, BP_PIN_MODE, 0);
     // reset all pins to safe mode (done before mode change, but we do it here to be safe)
     bio_init();
     // update modeConfig pins

--- a/src/mode/infrared.c
+++ b/src/mode/infrared.c
@@ -263,11 +263,11 @@ uint32_t infrared_setup_exc(void) {
     bio_buf_output(BIO4); // IR TX
 
     //claim and label pins
-    system_bio_claim(true, BIO1, BP_PIN_IO, pin_labels[0]);
-    system_bio_claim(true, BIO3, BP_PIN_IO, pin_labels[1]);
-    system_bio_claim(true, BIO4, BP_PIN_IO, pin_labels[2]);
-    system_bio_claim(true, BIO5, BP_PIN_IO, pin_labels[3]);
-    system_bio_claim(true, BIO7, BP_PIN_IO, pin_labels[4]);
+    system_bio_update_purpose_and_label(true, BIO1, BP_PIN_IO, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, BIO3, BP_PIN_IO, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, BIO4, BP_PIN_IO, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, BIO5, BP_PIN_IO, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, BIO7, BP_PIN_IO, pin_labels[4]);
 
 
     // configure and enable the state machines
@@ -294,11 +294,11 @@ void infrared_cleanup(void) {
     ir_protocol[device_cleanup].irtx_deinit(bio2bufiopin[BIO4]);
     ir_protocol[device_cleanup].irrx_deinit(bio2bufiopin[ir_rx_pins[mode_config.rx_sensor]]);
     // unclaim pins
-    system_bio_claim(false, BIO1, BP_PIN_IO, pin_labels[0]);
-    system_bio_claim(false, BIO3, BP_PIN_IO, pin_labels[1]);
-    system_bio_claim(false, BIO4, BP_PIN_IO, pin_labels[2]);
-    system_bio_claim(false, BIO5, BP_PIN_IO, pin_labels[3]);
-    system_bio_claim(false, BIO7, BP_PIN_IO, pin_labels[4]);
+    system_bio_update_purpose_and_label(false, BIO1, BP_PIN_IO, pin_labels[0]);
+    system_bio_update_purpose_and_label(false, BIO3, BP_PIN_IO, pin_labels[1]);
+    system_bio_update_purpose_and_label(false, BIO4, BP_PIN_IO, pin_labels[2]);
+    system_bio_update_purpose_and_label(false, BIO5, BP_PIN_IO, pin_labels[3]);
+    system_bio_update_purpose_and_label(false, BIO7, BP_PIN_IO, pin_labels[4]);
     // 1. Disable any hardware you used
     bio_init();
     system_config.subprotocol_name = 0x00;

--- a/src/nand/spi.c
+++ b/src/nand/spi.c
@@ -41,10 +41,10 @@ baudrate/1000000); spi_set_format(BP_SPI_PORT,8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB
     // 8bit and lsb/msb handled in UI.c
     //dff=SPI_CR1_DFF_8BIT;
     //lsbfirst=SPI_CR1_MSBFIRST;
-    system_bio_claim(true, M_SPI_CLK, BP_PIN_MODE, pin_labels[0]);
-    system_bio_claim(true, M_SPI_CDO, BP_PIN_MODE, pin_labels[1]);
-    system_bio_claim(true, M_SPI_CDI, BP_PIN_MODE, pin_labels[2]);
-    system_bio_claim(true, M_SPI_CS, BP_PIN_MODE, pin_labels[3]);
+    system_bio_update_purpose_and_label(true, M_SPI_CLK, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_SPI_CDO, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, M_SPI_CDI, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, M_SPI_CS, BP_PIN_MODE, pin_labels[3]);
 
 }
 */

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -321,7 +321,7 @@ void syntax_run_delay_ms(struct _syntax_io* syntax_io, uint32_t current_position
 void syntax_run_aux_output(struct _syntax_io* syntax_io, uint32_t current_position) {
     bio_output(syntax_io->out[current_position].bits);
     bio_put((uint8_t)syntax_io->out[current_position].bits, (bool)syntax_io->out[current_position].out_data);
-    system_bio_claim(
+    system_bio_update_purpose_and_label(
         true,
         syntax_io->out[current_position].bits,
         BP_PIN_IO,
@@ -332,7 +332,7 @@ void syntax_run_aux_output(struct _syntax_io* syntax_io, uint32_t current_positi
 void syntax_run_aux_input(struct _syntax_io* syntax_io, uint32_t current_position) {
     bio_input(syntax_io->out[current_position].bits);
     syntax_io->in[syntax_io->in_cnt].in_data = bio_get(syntax_io->out[current_position].bits);
-    system_bio_claim(false, syntax_io->out[current_position].bits, BP_PIN_IO, 0);
+    system_bio_update_purpose_and_label(false, syntax_io->out[current_position].bits, BP_PIN_IO, 0);
     system_set_active(false, syntax_io->out[current_position].bits, &system_config.aux_active);  
 }
 

--- a/src/system_config.c
+++ b/src/system_config.c
@@ -121,14 +121,14 @@ void system_init(void) {
         true; // enable the binmode TX queue, disable to handle USB directly with tinyusb functions
 }
 
-void system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label) {
+void system_pin_update_purpose_and_label(bool enable, uint8_t pin, enum bp_pin_func func, const char* label) {
     if (system_config.pin_func[pin] == BP_PIN_DEBUG) {
         // BUGBUG: Hard assert here instead of just debug output?
         //         Note that if this is called, the calling code is very likely to be attempting to mess with the pin state.
         //         It's possible that the RP2040/RP2350 lock out GPIO access when a peripheral (such as the UART) is configured
         //         to use the pin, but even then, the calling code would be expecting changes that just aren't going to happen.
         //         Thus, probably better to have a hard_assert() here?
-        PRINT_FATAL("system_pin_claim: attempt to update pin %d, which is used for debug UART\n", pin);
+        PRINT_FATAL("system_pin_update_purpose_and_label: attempt to update pin %d, which is used for debug UART\n", pin);
         return;
     }
     if (enable) {
@@ -144,8 +144,8 @@ void system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const cha
     return;
 }
 
-void system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label) {
-    return system_pin_claim(enable, bio_pin + 1, func, label);
+void system_bio_update_purpose_and_label(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label) {
+    return system_pin_update_purpose_and_label(enable, bio_pin + 1, func, label);
 }
 
 // BUGBUG -- rename this function to system_track_active_bio_pin() to more accurately

--- a/src/system_config.h
+++ b/src/system_config.h
@@ -118,6 +118,6 @@ void system_init(void);
 
 // TODO: Refactor to type-safe parameters
 //       system_pin_update_purpose_and_label() is only called directly to update the BP_VOUT pin label
-void system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label);
-void system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label);
+void system_pin_update_purpose_and_label(bool enable, uint8_t pin, enum bp_pin_func func, const char* label);
+void system_bio_update_purpose_and_label(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label);
 void system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register);

--- a/src/system_config.h
+++ b/src/system_config.h
@@ -73,7 +73,7 @@ typedef struct _system_config {
     uint8_t pwm_active;                    // pwm active, one bit per PWN channel/pin
     _pwm_config freq_config[BIO_MAX_PINS]; // holds PWM or FREQ settings for easier display later
     uint8_t freq_active;                   // freq measure active, one bit per channel/pin
-    uint8_t aux_active;                    // user controlled auc pins are outputs, resets when input
+    uint8_t aux_active;                    // user controlled aux pins are outputs, resets when used as inputs
 
     uint8_t psu; // psu (0=off, 1=on)
                  // uint8_t psu_dat_bits_readable;  // dac bits in human readable format
@@ -115,7 +115,9 @@ typedef struct _system_config {
 extern struct _system_config system_config;
 
 void system_init(void);
-bool system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label);
-bool system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label);
-bool system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register);
-bool system_load_config(void);
+
+// TODO: Refactor to type-safe parameters
+//       system_pin_update_purpose_and_label() is only called directly to update the BP_VOUT pin label
+void system_pin_claim(bool enable, uint8_t pin, enum bp_pin_func func, const char* label);
+void system_bio_claim(bool enable, uint8_t bio_pin, enum bp_pin_func func, const char* label);
+void system_set_active(bool active, uint8_t bio_pin, uint8_t* function_register);

--- a/src/ui/ui_const.h
+++ b/src/ui/ui_const.h
@@ -15,7 +15,7 @@ static const char ui_const_freq_slugs[][4] = { "ns", "us", "ms", "hz", "khz", "m
 // Pretty labels to display frequency and period
 static const char ui_const_freq_labels[][4] = { "ns", "us", "ms", "Hz", "kHz", "MHz", "%" };
 // short version of freq labels to show in constrained spaces (eg toolbar)
-static const char ui_const_freq_labels_short[][1] = { "n", "u", "m", "H", "K", "M", "%" };
+static const char ui_const_freq_labels_short[][2] = { "n", "u", "m", "H", "K", "M", "%" };
 // global constants
 static const char ui_const_bit_orders[][4] = { "MSB", "LSB" };
 


### PR DESCRIPTION
* Remove unused return value from three functions
* Rename two functions to reflect their purpose
* Fixed a typo in a comment
* Fixed array of strings to be correctly sized
* Fixed documentation to include parallel builds using `cmake` from command line

All changes are functionally equivalent to prior behavior.
Fixes #177