### PR TITLE
fix regression: missing status bar

### DIFF
--- a/src/pirate.c
+++ b/src/pirate.c
@@ -711,7 +711,9 @@ static void core1_initialization(void) {
 }
 static void core1_infinite_loop(void) {
 
+    uint32_t core0_requested_update_flags = 0;
     while (1) {
+
         // service (thread safe) tinyusb tasks
         if (system_config.terminal_usb_enable) {
             tud_task(); // tinyusb device task
@@ -736,7 +738,8 @@ static void core1_infinite_loop(void) {
 
         if (lcd_update_request) {
             monitor(system_config.psu); // TODO: fix monitor to return bool up_volts and up_current
-            uint32_t update_flags = 0;
+            uint32_t update_flags = core0_requested_update_flags;
+            core0_requested_update_flags = 0;
             if (lcd_update_force) {
                 lcd_update_force = false;
                 update_flags |= UI_UPDATE_FORCE | UI_UPDATE_ALL;
@@ -786,6 +789,10 @@ static void core1_infinite_loop(void) {
         while (multicore_fifo_rvalid()) {
             bp_icm_raw_message_t raw_message = icm_core1_get_raw_message();
             switch (get_embedded_message(raw_message)) {
+                case BP_ICM_UPDATE_STATUS_BAR:
+                    lcd_update_request = true;
+                    core0_requested_update_flags |= UI_UPDATE_ALL;
+                    break;
                 case BP_ICM_DISABLE_LCD_UPDATES:
                     lcd_irq_disable();
                     lcd_update_request = false;

--- a/src/pirate/intercore_helpers.h
+++ b/src/pirate/intercore_helpers.h
@@ -15,6 +15,7 @@
 //
 typedef uint8_t bp_icm_message_t;
 #define BP_ICM_INIT_CORE1 ((bp_icm_message_t)0xA5)          // Used to synchronize Core0 and Core1 intialization.
+#define BP_ICM_UPDATE_STATUS_BAR  ((bp_icm_message_t)0xC0)  // Core0 requests update of the status bar
 #define BP_ICM_DISABLE_LCD_UPDATES ((bp_icm_message_t)0xF0) // disables LCD updates / IRQ
 #define BP_ICM_ENABLE_LCD_UPDATES ((bp_icm_message_t)0xF1)  // enables LCD updates / IRQ
 #define BP_ICM_FORCE_LCD_UPDATE ((bp_icm_message_t)0xF2)    // enable LCD updates / IRQ and force an update

--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -212,7 +212,8 @@ uint32_t ui_statusbar_value(char* buf, size_t buffLen) {
 }
 void ui_statusbar_update_blocking() {
     BP_ASSERT_CORE0(); // if called from core1, this will deadlock
-    icm_core0_send_message_synchronous(BP_ICM_FORCE_LCD_UPDATE);
+    system_config.terminal_ansi_statusbar_update = true;
+    icm_core0_send_message_synchronous(BP_ICM_UPDATE_STATUS_BAR);
 }
 void ui_statusbar_update_from_core1(uint32_t update_flags) {
     BP_ASSERT_CORE1();


### PR DESCRIPTION
Prior fix attempt was incompleted, broke in commit c5aba879c18ea838176578a0d9b2fb086ed92f03.

While prior fix worked in that it prevented corruption of the status bar buffer, it failed to set a necessary variable and thus the status bar was **_never_** updated.

