### PR TITLE
Enable CodeQL scanning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBP_PICO_PLATFORM=${{matrix.board}} -DCMAKE_C_COMPILER=C:\ProgramData\chocolatey\bin\arm-none-eabi-gcc.exe -DCMAKE_CXX_COMPILER=C:\ProgramData\chocolatey\bin\arm-none-eabi-g++.exe -G "Unix Makefiles"
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --target ${{env.BUILD_TARGET}}
+      run: cmake --build ${{github.workspace}}/build --parallel --target ${{env.BUILD_TARGET}}
     
     - name: Save Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,87 @@
+# NOTE: This CodeQL builds both RP2040 and RP2350 builds.
+#       Analysis is limited to C/CPP language.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '42 15 * * 3'
+
+env:
+  BUILD_TYPE: Release
+  BUILD_TARGET: all
+
+jobs:
+  analyze:
+    name: C/CPP
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # ##########################################################################################
+    # Preparation of prerequisites and setup of CMake.
+    # Should not be considered part of the CodeQL set, so
+    # perform them outside the CodeQL Init/Analyze steps.
+    - name: Linux setup
+      run: |
+        sudo apt update && sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+        echo "PICO_SDK_FETCH_FROM_GIT=TRUE" >> "$GITHUB_ENV"
+
+    # Each board type much be in its own separate subdirectory, due to RPi SDK CMakefile's ...
+    # ... unexpectedly ... setting global settings, which preventing two directories from using
+    # different versions of SDK in a single CMake build.
+    - name: CMake Config - RP2040
+      run: cmake -B ${{github.workspace}}/build_rp2040 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBP_PICO_PLATFORM=rp2040
+    - name: CMake Config - RP2350
+      run: cmake -B ${{github.workspace}}/build_rp2350 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBP_PICO_PLATFORM=rp2350
+    # ##########################################################################################
+
+    # ##########################################################################################
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: c-cpp
+        build-mode: manual
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+    # ##########################################################################################
+
+    
+    # ##########################################################################################
+    # The following manual build steps are directly taken from build.yaml
+    - name: Build - RP2040
+      run: cmake --build ${{github.workspace}}/build_rp2040 --parallel --target ${{env.BUILD_TARGET}}
+    - name: Build - RP2350
+      run: cmake --build ${{github.workspace}}/build_rp2350 --parallel --target ${{env.BUILD_TARGET}}
+    # ##########################################################################################
+
+    # ##########################################################################################
+    # Finally, analyze the steps taken since the initialization step
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:c-cpp"
+    # ##########################################################################################


### PR DESCRIPTION
At present this is limited to C/CPP.
Because it is unclear if CodeQL can merge multiple jobs for a single language,
everything is performed within a single job.

Also, enable `--parallel` for all CMake builds.