### PR TITLE
upgrade picotool to 2.1.0 to enable build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 RUN git clone https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \
     && git -C /opt/pico-sdk submodule update --init --recursive \
     && cd /opt/pico-sdk \
-    && git checkout 2.0.0 \
+    && git checkout 2.1.0 \
     && mkdir -p build \
     && cd build \
     && cmake ../ \


### PR DESCRIPTION
Fixes #199 

Before:
```
...
TinyUSB available at /opt/pico-sdk/lib/tinyusb/src/portable/raspberrypi/rp2040; enabling build support for USB.
BTstack available at /opt/pico-sdk/lib/btstack
cyw43-driver available at /opt/pico-sdk/lib/cyw43-driver
lwIP available at /opt/pico-sdk/lib/lwip
mbedtls available at /opt/pico-sdk/lib/mbedtls
CMake Error at /opt/pico-sdk/tools/CMakeLists.txt:125 (message):
  Incompatible picotool installation found: Requires version 2.1.0, you have
  version 2.0.0

  Update your installation, or set PICOTOOL_FORCE_FETCH_FROM_GIT to download
  and build the correct version
Call Stack (most recent call first):
  /opt/pico-sdk/tools/CMakeLists.txt:485 (pico_init_picotool)
  /opt/pico-sdk/src/cmake/on_device.cmake:57 (picotool_postprocess_binary)
  src/CMakeLists.txt:547 (pico_add_extra_outputs)


-- Configuring incomplete, errors occurred!
See also "/project/build/CMakeFiles/CMakeOutput.log".
See also "/project/build/CMakeFiles/CMakeError.log".
```

After:
```
...
[  0%] Building ASM object src/pico-sdk/src/rp2040/boot_stage2/CMakeFiles/bs2_default.dir/compile_time_choice.S.o
[  0%] Linking ASM executable bs2_default.elf
[  0%] Built target bs2_default
[  0%] Generating bs2_default.bin
[  0%] Generating bs2_default_padded_checksummed.S
[  1%] Building ASM object src/pico-sdk/src/rp2040/boot_stage2/CMakeFiles/bs2_default_library.dir/bs2_default_padded_checksummed.S.o
[  1%] Built target bs2_default_library
[  1%] Built target timestamp
[  1%] Creating directories for 'pioasmBuild'
[  1%] No download step for 'pioasmBuild'
[  2%] No update step for 'pioasmBuild'
[  2%] No patch step for 'pioasmBuild'
[  3%] Performing configure step for 'pioasmBuild'
Not searching for unused variables given on the command line.
loading initial cache file /project/build/src/pico-sdk/src/rp2_common/pico_cyw43_driver/pioasm/tmp/pioasmBuild-cache-Release.cmake
-- The CXX compiler identification is GNU 12.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /project/build/pioasm
[  3%] Performing build step for 'pioasmBuild'
[100%] Built target pioasm
[  3%] Performing install step for 'pioasmBuild'
[100%] Built target pioasm
Install the project...
-- Install configuration: "Release"
...
```