### PR TITLE
Reduce measurement jitter for FALA.

### DIFF
--- a/src/binmode/fala.c
+++ b/src/binmode/fala.c
@@ -42,7 +42,7 @@ void fala_set_triggers(uint8_t trigger_pin, uint8_t trigger_level) {
 // start the logic analyzer
 void fala_start(void) {
     // configure and arm the logic analyzer
-    logic_analyzer_configure(
+    fala_config.actual_sample_frequency = logic_analyzer_configure(
         fala_config.base_frequency * fala_config.oversample, DMA_BYTES_PER_CHUNK * LA_DMA_COUNT, 0x00, 0x00, false, false);
     logic_analyzer_arm(false);
 }
@@ -173,11 +173,12 @@ void fala_stop_hook(void) {
 void fala_mode_change_hook(void) {
     fala_set_freq(modes[system_config.mode].protocol_get_speed());
     fala_set_oversample(8);
+    fala_config.actual_sample_frequency = logic_analyzer_compute_actual_sample_frequency(fala_config.base_frequency * fala_config.oversample, NULL);
     if (fala_has_hook()) {
         printf("\r\n%sLogic analyzer speed:%s %dHz (%dx oversampling)\r\n",
                ui_term_color_info(),
                ui_term_color_reset(),
-               fala_config.base_frequency * fala_config.oversample,
+               fala_config.actual_sample_frequency,
                fala_config.oversample);
         printf(
             "%sUse the 'logic' command to change capture settings%s\r\n", ui_term_color_info(), ui_term_color_reset());

--- a/src/binmode/fala.h
+++ b/src/binmode/fala.h
@@ -4,6 +4,7 @@
 typedef struct {
     uint32_t base_frequency;
     uint32_t oversample;
+    uint32_t actual_sample_frequency;
     uint8_t debug_level;
 } FalaConfig;
 

--- a/src/binmode/falaio.c
+++ b/src/binmode/falaio.c
@@ -41,7 +41,7 @@ void falaio_notify(void) {
                                0,
                                0,
                                'N',
-                               fala_config.base_frequency * fala_config.oversample,
+                               fala_config.actual_sample_frequency,
                                fala_samples,
                                0);
         if (tud_cdc_n_write_available(CDC_INTF) >= sizeof(buf)) {

--- a/src/binmode/logicanalyzer.h
+++ b/src/binmode/logicanalyzer.h
@@ -6,7 +6,7 @@ int logicanalyzer_status(void);
 void logic_analyzer_dump(uint8_t* txbuf);
 bool logic_analyzer_is_done(void);
 void logic_analyser_done(void);
-bool logic_analyzer_configure(
+uint32_t logic_analyzer_configure(
     float freq, uint32_t samples, uint32_t trigger_mask, uint32_t trigger_direction, bool edge, bool interrupt);
 void logic_analyzer_arm(bool led_indicator_enable);
 bool logic_analyzer_cleanup(void);
@@ -19,3 +19,4 @@ void logic_analyzer_reset_ptr(void);
 uint8_t logic_analyzer_read_ptr(uint32_t read_pointer);
 void logic_analyzer_set_base_pin(uint8_t base_pin);
 uint32_t logic_analyzer_get_samples_from_zero(void);
+uint32_t logic_analyzer_compute_actual_sample_frequency(float desired_frequency, float* div_out);

--- a/src/binmode/logicanalyzer.pio
+++ b/src/binmode/logicanalyzer.pio
@@ -57,7 +57,7 @@ capture:
     irq 0
 
 % c-sdk {
-static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
+static inline uint32_t logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);    
@@ -78,8 +78,9 @@ static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uin
     sm_config_set_out_shift(&c, false, true, 32);
     sm_config_set_in_shift(&c, false, true, 8);
 
-	float div = clock_get_hz(clk_sys) / (freq * 2); //2 instructions per sample, run twice as fast as requested sampling rate  
-	sm_config_set_clkdiv(&c, div);
+    float div = 0;
+    uint32_t real_frequency = logic_analyzer_compute_actual_sample_frequency(freq, &div);
+    sm_config_set_clkdiv(&c, div);
 
     pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
     pio_set_irq1_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
@@ -87,10 +88,10 @@ static inline void logicanalyzer_high_trigger_program_init(PIO pio, uint sm, uin
     uint program_offset = offset + (edge ? logicanalyzer_high_trigger_offset_edge_trigger_rising : logicanalyzer_high_trigger_offset_high_trigger);
     // Load our configuration, and jump to the start of the program
     pio_sm_init(pio, sm, program_offset, &c);
-
+    return real_frequency;
 }
 
-static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
+static inline uint32_t logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, uint trigger, float freq, bool edge) {
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);    
@@ -111,8 +112,9 @@ static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint
     sm_config_set_out_shift(&c, false, true, 32);
     sm_config_set_in_shift(&c, false, true, 8);
 
-	float div = clock_get_hz(clk_sys) / (freq * 2); //2 instructions per sample, run twice as fast as requested sampling rate  
-	sm_config_set_clkdiv(&c, div);
+    float div = 0;
+    uint32_t real_frequency = logic_analyzer_compute_actual_sample_frequency(freq, &div);
+    sm_config_set_clkdiv(&c, div);
 
     pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
     pio_set_irq1_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
@@ -120,10 +122,10 @@ static inline void logicanalyzer_low_trigger_program_init(PIO pio, uint sm, uint
     uint program_offset = offset + (edge ? logicanalyzer_low_trigger_offset_edge_trigger_falling : logicanalyzer_low_trigger_offset_low_trigger);
     // Load our configuration, and jump to the start of the program
     pio_sm_init(pio, sm, program_offset, &c);
-
+    return real_frequency;
 }
 
-static inline void logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, float freq) {
+static inline uint32_t logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint offset, uint pin, float freq) {
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);    
@@ -144,7 +146,8 @@ static inline void logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint 
     sm_config_set_out_shift(&c, false, true, 32);
     sm_config_set_in_shift(&c, false, true, 8);
 
-    float div = clock_get_hz(clk_sys) / (freq * 2);
+    float div = 0;
+    uint32_t real_frequency = logic_analyzer_compute_actual_sample_frequency(freq, &div);
     sm_config_set_clkdiv(&c, div);
 
     pio_set_irq0_source_enabled(pio, (enum pio_interrupt_source) ((uint) pis_interrupt0 + sm), false);
@@ -152,7 +155,7 @@ static inline void logicanalyzer_no_trigger_program_init(PIO pio, uint sm, uint 
 
     // Load our configuration, and jump to the start of the program
     pio_sm_init(pio, sm, offset, &c);
- 
+    return real_frequency;
 }
 
 %}

--- a/src/commands/global/logic.c
+++ b/src/commands/global/logic.c
@@ -216,14 +216,19 @@ void logic_handler(struct command_result* res) {
     }
 
     if (has_info || has_oversample || has_frequency) {
+        fala_config.actual_sample_frequency =
+            logic_analyzer_compute_actual_sample_frequency(fala_config.base_frequency * fala_config.oversample, NULL);
         printf("\r\nLogic Analyzer settings\r\n");
+        float foversample = (float)fala_config.actual_sample_frequency / fala_config.base_frequency;
         printf(" Oversample rate: %d\r\n", fala_config.oversample);
         printf(" Sample frequency: %dHz\r\n", fala_config.base_frequency);
-        if (oversample != 1) {
-            printf("\r\nNote: oversample rate is not 1\r\n");
-            printf("Actual sample frequency: %dHz (%d * %dHz)\r\n",
-                   fala_config.base_frequency * fala_config.oversample,
-                   fala_config.oversample,
+        if (foversample != 1.0) {
+            printf("\r\nNote: actual oversample rate is not 1\r\n");
+        }
+        if (fala_config.actual_sample_frequency != fala_config.base_frequency) {
+            printf("Actual sample frequency: %dHz (%f * %dHz)\r\n",
+                   fala_config.actual_sample_frequency,
+                   foversample,
                    fala_config.base_frequency);
         }
     }


### PR DESCRIPTION
Note that magically, the bump mode works already with pulseview. That's because they populate a list of acceptable sample rates based on integer division of the max sample rate passed in the meta data. Other clients may not be so lucky... Unfortunately, there isn't enough meta data to communicate the intent. 