### PR TITLE
1-step automated USB whitelabel

### DIFF
--- a/src/binmode/falaio.c
+++ b/src/binmode/falaio.c
@@ -66,7 +66,7 @@ void falaio_setup(void) {
 }
 
 void falaio_setup_message(void){
-#if BP_VER < 6
+#if BP_VER < 6 // BUGBUG / TODO - Should this be a hardware feature flag, rather than a version check?
     printf("%sWarning: What you see may not be what you get!%s\r\n", ui_term_color_error(), ui_term_color_reset());
     printf("%sThis hardware version captures samples from behind the IO buffer.%s\r\n",
             ui_term_color_info(),

--- a/src/binmode/sump.c
+++ b/src/binmode/sump.c
@@ -144,6 +144,7 @@ static void sump_do_meta(void) {
 
     sysclk = clock_get_hz(clk_sys) / SAMPLING_DIVIDER;
     snprintf(cpu, sizeof(cpu), "RP2040 %uMhz", sysclk / ONE_MHZ);
+    // BUGBUG / TODO - make this switch based on #if RPI_PLATFORM == RP2350 or == RP2040, and pull meta name from OTP directory on RP2350
     #if (BP_VER == 5)
         ptr = sump_add_metas(ptr, SUMP_META_NAME, "Bus Pirate 5");
     #elif (BP_VER == XL5)

--- a/src/commands/global/cmd_mcu.c
+++ b/src/commands/global/cmd_mcu.c
@@ -25,6 +25,7 @@ void cmd_mcu_jump_to_bootloader_handler(struct command_result* res) {
 
     printf("Jump to bootloader for firmware upgrades\r\n\r\n%s\r\n", BP_HARDWARE_VERSION);
     printf("Firmware download:\r\nhttps://forum.buspirate.com/t/bus-pirate-5-auto-build-main-branch/20/999999\r\n");
+    // BUGBUG / TODO - make this switch based on #if RPI_PLATFORM == RP2350 or == RP2040, and pull USB disk name from OTP directory
     #if BP_VER == 5
         printf("Hardware revision: %d\r\n", system_config.hardware_revision);
         printf("Firmware file: bus_pirate5_rev%d.uf2\r\n", system_config.hardware_revision);

--- a/src/commands/global/cmd_selftest.c
+++ b/src/commands/global/cmd_selftest.c
@@ -388,7 +388,7 @@ bool selftest_button(void) {
 }
 
 // test that the logic analyzer chip is mounted and with no shorts
-#if BP_VER >= 6
+#if BP_VER >= 6 // BUGBUG / TODO - Should this be a hardware feature flag, rather than a version check?
 bool selftest_la_bpio(void) {
     uint32_t temp1, fails = 0, iopin = 0;
     printf("LA_BPIO TEST (SHOULD BE 1)\r\n");
@@ -511,7 +511,7 @@ void cmd_selftest(void) {
     }
 
     // LA_BPIO test
-    #if BP_VER >= 6
+    #if BP_VER >= 6 // BUGBUG / TODO - Should this be a hardware feature flag, rather than a version check?
         if (selftest_la_bpio()) {
             fails++;
         }

--- a/src/lib/picorvd/picoswio.c
+++ b/src/lib/picorvd/picoswio.c
@@ -70,9 +70,13 @@ void ch32vswio_reset(int pin, int dirpin) {
 
    sm_config_set_clkdiv(&c, clock_get_hz(clk_sys)/10000000);
 
-#if BP_VER==5
-  gpio_pull_down(pin);
-  #endif
+#if RPI_PLATFORM == RP2040
+ // TODO: Document what is done on RP2350, and why this works.
+ //       Is there intentional split ownership in RP2040 of a GPIO used by PIO?
+ //       Is there a bug on RP2350 that prevents this?
+ //       Is this a workaround for a bug on RP2040?
+ gpio_pull_down(pin);
+#endif
   pio_sm_set_pindirs_with_mask(pio_config.pio, pio_config.sm, 0, (1u<<pin)); //read pins to input (0, mask)  
   pio_sm_set_pindirs_with_mask(pio_config.pio, pio_config.sm, (1u<<dirpin), (1u<<dirpin)); //buf pins to output (pins, mask)    
   pio_sm_set_pins_with_mask(pio_config.pio, pio_config.sm, 0, (1u<<dirpin)); //buf dir to 0, buffer input/HiZ on the bus

--- a/src/otp/bp_otp.h
+++ b/src/otp/bp_otp.h
@@ -70,7 +70,8 @@ uint32_t bp_otp_decode_raw(uint32_t data); // [[unsequenced]]
     // so code calling it on RP2040 is probably in error?
     // This is a nicer error message than a linker error....
     __attribute__((deprecated)) inline void bp_otp_apply_whitelabel_data(void) { }
-    __attribute__((deprecated)) inline bool bp_otp_apply_manufacturing_string(const char* manufacturing_data_string)        { return false; }
+    __attribute__((deprecated)) inline bool bp_otp_lock_whitelabel(void) { return false; }
+
     __attribute__((deprecated)) inline bool bp_otp_write_single_row_raw(uint16_t row, uint32_t new_value)                   { return false; }
     __attribute__((deprecated)) inline bool bp_otp_read_single_row_raw(uint16_t row, uint32_t* out_data)                    { return false; }
     __attribute__((deprecated)) inline bool bp_otp_write_single_row_ecc(uint16_t row, uint16_t new_value)                   { return false; }
@@ -83,7 +84,7 @@ uint32_t bp_otp_decode_raw(uint32_t data); // [[unsequenced]]
 
 #else
     void bp_otp_apply_whitelabel_data(void);
-    bool bp_otp_apply_manufacturing_string(const char* manufacturing_data_string);
+    bool bp_otp_lock_whitelabel(void);
 
     // RP2350 OTP can encode data in multiple ways:
     // * 24 bits of raw data (no error correction / detection)

--- a/src/otp/bp_otp_rw.c
+++ b/src/otp/bp_otp_rw.c
@@ -366,18 +366,20 @@ static bool write_otp_byte_3x(uint16_t row, uint8_t new_value) {
 /// Only the below are the public API functions.
 
 
+//#define BP_USE_VIRTUALIZED_OTP
 #if defined(BP_USE_VIRTUALIZED_OTP)
 
 // Enable "virtualized" OTP ... useful for testing.
 // 8k of OTP is a lot to virtualize...
-// maybe only track written sections up to a fixed maximum,
-// and pretend all other sections are filled with 0xFFFFFFu?
+// maybe only track written sections up to a fixed maximum?
+// For any other sections, fallback to reading the actual OTP?
 typedef struct _BP_OTP_VIRTUALIZED_PAGE {
     uint16_t start_row;    // If zero, this page hasn't been written to yet.
     uint16_t rfu_padding;
     BP_OTP_RAW_READ_RESULT data[0x40];   // each page stores 0x40 (64) rows of OTP data
 } BP_OTP_VIRTUALIZED_PAGE;
-static BP_OTP_VIRTUALIZED_PAGE virtualized_otp[40] = NULL;
+static BP_OTP_VIRTUALIZED_PAGE virtualized_otp[40] = { };
+static bool virtualized_otp_full = false;
 
 // probably want a helper function to map from row to virtualized page (nullptr if not exists)
 // Set allocate_if_needed only when next action is to write to the page.
@@ -396,10 +398,26 @@ static inline BP_OTP_VIRTUALIZED_PAGE* ROW_TO_VIRTUALIZED_PAGE(uint16_t row, boo
     if ((result == NULL) && allocate_if_needed) {
         for (size_t i = 0; (result == NULL) && (i < ARRAY_SIZE(virtualized_otp)); ++i) {
             if (virtualized_otp[i].start_row == 0u) {
-                result = &virtualized_otp[i];
-                result->start_row = page_start_row;
+                BP_OTP_VIRTUALIZED_PAGE* tmp = &virtualized_otp[i];
+                // read the page from OTP into the virtualized page...
+                if (read_raw_wrapper(pages_start_row, tmp->data, sizeof(tmp->data)) != BOOTROM_OK) {
+                    tmp->start_row = page_start_row;
+                    result = tmp;
+                }
             }
-        }    
+        }
+    }
+    // NOTE: it's possible to return NULL even when not full, when unable to read the page from OTP
+    if ((result == NULL) && allocate_if_needed) {
+        bool full = true;
+        for (size_t i = 0; (result == NULL) && (i < ARRAY_SIZE(virtualized_otp)); ++i) {
+            if (virtualized_otp[i].start_row == 0u) {
+                full = false;
+            }
+        }
+        if (full) {
+            virtualized_otp_full = true;
+        }
     }
     return result;
 }

--- a/src/otp/bp_otp_rw.c
+++ b/src/otp/bp_otp_rw.c
@@ -80,6 +80,19 @@ static int read_ecc_wrapper(uint16_t starting_row, void* buffer, size_t buffer_s
     cmd.flags |= OTP_CMD_ECC_BITS;
     return rom_func_otp_access((uint8_t*)buffer, buffer_size, cmd);
 }
+
+// RP2350 OTP storage is strongly recommended to use some form of
+// error correction.  Most rows will use ECC, but three other forms exist:
+// (1) 2-of-3 voting of a single byte in a single row
+// (2) 2-of-3 voting of 24-bits across three consecutive OTP rows (RBIT-3)
+// (3) 3-of-8 voting of 24-bits across eight consecutive OTP rows (RBIT-8)
+//
+// A note on RBIT-8:
+// RBIT-8 is used _ONLY_ for CRIT0 and CRIT1. It works similarly to RBIT-3,
+// except that each bit is considered set if at least three (3) of the eight
+// rows have that bit set.  Thus, it's not a simple majority vote, instead
+// tending to favor considering bits as set.
+// 
 static bool write_single_otp_ecc_row(uint16_t row, uint16_t data) {
     uint16_t existing_data;
     int r;

--- a/src/otp/bp_whitelabel.c
+++ b/src/otp/bp_whitelabel.c
@@ -464,7 +464,7 @@ void bp_otp_apply_whitelabel_data(void) {
         bp_otp_write_single_row_ecc(row, data) || DIE();
     }
 
-    // 3. write the INFO_UF2.TXT board id
+    // 3. write the INFO_UF2.TXT board id (serial number)
     if (true) {
         uint8_t board_id_as_string[BP_OTP_ROW__BOARD_ID_STRING_MAX_CHARCOUNT + 1u] = { 0 };
         pico_unique_board_id_t id;

--- a/src/otp/bp_whitelabel.c
+++ b/src/otp/bp_whitelabel.c
@@ -10,6 +10,7 @@
 #include "pico.h"
 #include <boot/bootrom_constants.h>
 #include "pico/bootrom.h"
+#include "pico/unique_id.h"
 #include "debug_rtt.h"
 
 #ifndef BP_OTP_PRODUCT_VERSION_STRING
@@ -26,7 +27,7 @@
 //
 // Because OTP fuses can only transition from 0 -> 1, this capability is critical to
 // minimizing the number of RP2350 chips with invalid data during development.
-
+#pragma region    // Support for RTT-based single-stepping
 
 // TODO: update this to wait for actual keypresses over RTT (as in the earlier experimentation firmware)
 //       to allow for review of all the things happening....
@@ -54,9 +55,9 @@ static void MyWaitForAnyKey_with_discards(void) {
 
     return;
 }
-
+#pragma endregion // Support for RTT-based single-stepping
+#pragma region    // DIE() macro
 #define DIE() die(__LINE__)
-
 // define as returning bool to allow:
 //     funcA() || DIE();
 // Otherwise, compiler complains because of using void in a boolean context.
@@ -65,8 +66,7 @@ static bool __attribute__((noreturn)) die(int line) {
     hard_assert(false);
     while (1);
 }
-
-
+#pragma endregion    // DIE() macro
 static char byte_to_printable_char(uint8_t byte) {
     if (byte < 0x20u) {
         return '.';
@@ -76,7 +76,7 @@ static char byte_to_printable_char(uint8_t byte) {
     }
     return byte;
 }
-
+#pragma region    // Whitelabel OTP structures
 typedef struct _BP_OTP_USB_BOOT_FLAGS {
     union {
         uint32_t as_uint32;
@@ -112,9 +112,14 @@ typedef struct _BP_OTP_USB_BOOT_FLAGS {
 static_assert(sizeof(BP_OTP_USB_BOOT_FLAGS) == sizeof(uint32_t), "BP_OTP_USB_BOOT_FLAGS must be 32-bits");
 
 typedef struct _BP_OTP_WHITELABEL_STRDEF {
-    uint16_t character_count : 7;
-    uint16_t is_unicode      : 1; // Unicode only supported for usb manufacturer, product, and serial
-    uint16_t row_offset      : 8; // USB_WHITE_LABEL_ADDR + row_offset == start row for the string
+    union {
+        uint16_t as_uint16;
+        struct {
+            uint16_t character_count : 7;
+            uint16_t is_unicode      : 1; // Unicode only supported for usb manufacturer, product, and serial
+            uint16_t row_offset      : 8; // USB_WHITE_LABEL_ADDR + row_offset == start row for the string
+        };
+    };
 } BP_OTP_WHITELABEL_STRDEF;
 static_assert(sizeof(BP_OTP_WHITELABEL_STRDEF) == sizeof(uint16_t), "BP_OTP_WHITELABEL_STRDEF must be 16-bits");
 
@@ -138,6 +143,31 @@ typedef struct _BP_OTP_WHITELABEL {
 } BP_OTP_WHITELABEL;
 static_assert(sizeof(BP_OTP_WHITELABEL) == 0x20u, "BP_OTP_WHITELABEL must be 32 bytes (16 rows)");
 
+typedef struct _BP_OTP_ROW_RANGE {
+    uint16_t start_row;
+    uint16_t row_count;
+} BP_OTP_ROW_RANGE;
+#pragma endregion // Whitelabel OTP structures
+#pragma region    // static/const USB whitelabel data
+static const BP_OTP_USB_BOOT_FLAGS usb_boot_flags = {
+    .usb_vid_valid          = 1,
+    .usb_pid_valid          = 1,
+    .usb_bcd_valid          = 0,
+    .usb_lang_id_valid      = 0,
+    .usb_manufacturer_valid = 1,
+    .usb_product_valid      = 1,
+    .usb_serial_valid       = 0,
+    .usb_max_power_valid    = 0,
+    .volume_label_valid     = 1,
+    .scsi_vendor_valid      = 1,
+    .scsi_product_valid     = 1,
+    .scsi_rev_valid         = 0,
+    .redirect_url_valid     = 1,
+    .redirect_name_valid    = 1,
+    .info_uf2_model_valid   = 1,
+    .info_uf2_boardid_valid = 1,
+    .white_label_addr_valid = 1,
+};
 
 static const uint16_t _static_portion[] = {
     // offset 0x10, chars 0x16: "https://buspirate.com/"
@@ -171,6 +201,8 @@ static const uint16_t _static_portion[] = {
     0x6574, // `te` // Row 0x0e7 -- offset 0x27
 };
 static_assert(ARRAY_SIZE(_static_portion) == 0x18u); // 24 rows
+#define BP_OTP_ROW__STATIC_PORTION_OFFSET (sizeof(BP_OTP_WHITELABEL)/2u)
+
 
 // NOTE: Reserved for board id string exposed in INFO_UF2.TXT file
 //       Ian is choosing to use this to make it
@@ -204,7 +236,6 @@ static_assert(ARRAY_SIZE(_static_portion) == 0x18u); // 24 rows
 // validate the structure of the OTP data
 static_assert(BP_OTP_ROW__PRODUCT_VERSION_STRING_OFFSET        == 0x28u);
 static_assert(BP_OTP_ROW__BOARD_ID_STRING_OFFSET               == 0x34u);
-static_assert(BP_OTP_ROW__PRODUCT_VERSION_STRING_MAX_ROWCOUNT  == 0x0Cu);
 static_assert(BP_OTP_ROW__BOARD_ID_STRING_MAX_CHARCOUNT        == 0x17u);
 static_assert(BP_OTP_ROW__PRODUCT_VERSION_STRING_MAX_CHARCOUNT == 0x17u);
 
@@ -231,6 +262,78 @@ static_assert(sizeof(char) == sizeof(uint8_t), "char must be 8-bits");
 // Since the string includes NULL and whitelabel uses counted strings,
 // can calculate the number of rows needed by simply dividing by 2 (rounds down).
 static_assert(ARRAY_SIZE(_product_string)/2 <= BP_OTP_ROW__PRODUCT_VERSION_STRING_MAX_ROWCOUNT);
+#pragma endregion // static/const USB whitelabel data
+
+#pragma region    // Internal (static) helper functions
+static uint16_t strdef_to_start_row(uint16_t base, BP_OTP_WHITELABEL_STRDEF strdef) {
+    return base + strdef.row_offset;
+}
+static uint16_t strdef_to_next_unused_row(uint16_t base, BP_OTP_WHITELABEL_STRDEF strdef) {
+    uint16_t result = base;
+    if (strdef.is_unicode) {
+        result += strdef.character_count; // each character is a full row
+    } else {
+        result += (strdef.character_count + 1) / 2u; // every two characters is a row ... rounding up
+    }
+    return result;
+}
+static inline __attribute__((always_inline)) uint16_t my_max_row(uint16_t a, uint16_t b) {
+    return (a > b) ? a : b;
+}
+
+bool internal_get_whitelabel_row_range(BP_OTP_ROW_RANGE *result_out) {
+    // NOTE: This is entirely read-only against the OTP fuses
+    memset(result_out, 0, sizeof(BP_OTP_ROW_RANGE));
+    
+    BP_OTP_USB_BOOT_FLAGS current_usb_boot_flags;
+    if (!bp_otp_read_redundant_rows_2_of_3(0x059, &current_usb_boot_flags.as_uint32)) {
+        PRINT_ERROR("Whitelabel Error: Raw OTP rows 0x59..0x5B (USB BOOT FLAGS) did not find majority agreement\n");
+        return false;
+    }
+    PRINT_DEBUG("Whitelabel Debug: found USB BOOT FLAGS: %06x\n", current_usb_boot_flags.as_uint32);
+
+    uint16_t base;
+    if (!bp_otp_read_single_row_ecc(0x05C, &base)) {
+        PRINT_ERROR("Whitelabel Error: OTP row 0x05C could not be read (WHITE_LABEL_ADDR)\n");
+        return false;
+    }
+    if (base < 0x0C0u || base > 0xEC0u) {
+        PRINT_ERROR("Whitelabel Error: WHITE_LABEL_ADDR 0x%03X is out of range [0x0C0 .. 0xEC0]\n", base);
+        return false;
+    }
+    PRINT_DEBUG("Whitelabel Debug: WHITE_LABEL_ADDR points to row index 0x%03x\n", base);
+
+    uint16_t start_row        = base;
+    uint16_t first_unused_row = base + sizeof(BP_OTP_WHITELABEL)/2u; // whitelabel structure (16 rows) is implied
+
+    // Read in the whitelabel structure
+    BP_OTP_WHITELABEL whitelabel = {0};
+    if (!bp_otp_read_ecc_data(base, &whitelabel, sizeof(whitelabel))) {
+        PRINT_ERROR("Whitelabel Error: Failed to read existing whitelabel data\n");
+        return false;
+    }
+
+    // Now go through each STRDEF that's marked valid, calculate the row(s) it uses, and update the first_unused_row if needed
+    if (current_usb_boot_flags.usb_manufacturer_valid == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.usb_manufacturer        )); }
+    if (current_usb_boot_flags.usb_product_valid      == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.usb_product             )); }
+    if (current_usb_boot_flags.usb_serial_valid       == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.usb_serial              )); }
+    if (current_usb_boot_flags.volume_label_valid     == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.storage_volume_label    )); }
+    if (current_usb_boot_flags.scsi_vendor_valid      == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.scsi_vid                )); }
+    if (current_usb_boot_flags.scsi_product_valid     == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.scsi_pid                )); }
+    if (current_usb_boot_flags.scsi_rev_valid         == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.scsi_rev                )); }
+    if (current_usb_boot_flags.redirect_url_valid     == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.index_htm_redirect_url  )); }
+    if (current_usb_boot_flags.redirect_name_valid    == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.index_htm_redirect_name )); }
+    if (current_usb_boot_flags.info_uf2_model_valid   == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.info_uf2_model          )); }
+    if (current_usb_boot_flags.info_uf2_boardid_valid == 1) { first_unused_row = my_max_row(first_unused_row, strdef_to_next_unused_row( base, whitelabel.info_uf2_boardid        )); }
+
+    // return the results
+    result_out->start_row = start_row;
+    result_out->row_count = first_unused_row - start_row;
+    return true;
+}
+#pragma endregion // Internal helper functions
+
+
 
 
 // Restartable whitelabel process ... controlled via RTT (no USB connection required)
@@ -240,21 +343,21 @@ void bp_otp_apply_whitelabel_data(void) {
     // g_WaitForKey = true;
 
     static const uint16_t base = 0x0c0; // written so this can be changed easily
-    static const size_t product_extension_rows = sizeof(_product_string) /2u; // sizeof() includes null; round down to even number
+    static const size_t product_extension_rows = sizeof(_product_string) / 2u; // sizeof() includes null; rounds down to even number
     uint16_t product_char_count = strlen("Bus Pirate") + strlen(_product_string);
     
     // 1. write the static portion         --> Rows 0x0d0 .. 0x0e7
     for (uint16_t i = 0; i < ARRAY_SIZE(_static_portion); ++i) {
-        uint16_t row = base + 0x10u +  i;
+        uint16_t row = base + BP_OTP_ROW__STATIC_PORTION_OFFSET +  i;
         PRINT_DEBUG("Whitelabel Debug: Write static portion index %d: row 0x%03x, data 0x%04x\n", i, row, _static_portion[i]);
         WAIT_FOR_KEY();
         bp_otp_write_single_row_ecc(row, _static_portion[i]) || DIE();
     }
     PRINT_DEBUG("Whitelabel Debug: Version extension: '%s'\n", _product_string);
 
-    // 2. also write the product version extension
+    // 2. also write the product version extension ... appends to the "Bus Pirate" string at the end of the static portion
     for (uint16_t i = 0; i < product_extension_rows; ++i) {
-        uint16_t row = base + 0x28u + i;
+        uint16_t row = base + BP_OTP_ROW__PRODUCT_VERSION_STRING_OFFSET + i;
         uint16_t data = 0;
         // First  character is stored in LSB
         // Second character is stored in MSB
@@ -267,13 +370,51 @@ void bp_otp_apply_whitelabel_data(void) {
         bp_otp_write_single_row_ecc(row, data) || DIE();
     }
 
+    // 3. write the INFO_UF2.TXT board id
+    if (true) {
+        uint8_t board_id_as_string[BP_OTP_ROW__BOARD_ID_STRING_MAX_CHARCOUNT + 1u] = { 0 };
+        pico_unique_board_id_t id;
+        pico_get_unique_board_id(&id); 
+        //convert the unique ID to ANSI string
+        snprintf(
+            board_id_as_string, sizeof(board_id_as_string),
+            "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+            id.id[0], id.id[1], id.id[2], id.id[3], id.id[4], id.id[5], id.id[6], id.id[7]
+        );
+
+        PRINT_DEBUG("Whitelabel Debug: Manufacturing ID string: %s\r\n", board_id_as_string);
+        WAIT_FOR_KEY();
+
+        // Write the actual string's data
+        size_t row_count = (strlen(board_id_as_string)+1) / 2u;
+        for (size_t i = 0; i < row_count; ++i) {
+            uint16_t row = base + BP_OTP_ROW__BOARD_ID_STRING_OFFSET + i;
+            uint16_t data = 0;
+            // First  character is stored in LSB
+            // Second character is stored in MSB
+            data  |= (uint8_t)(board_id_as_string[2u * i + 1]);
+            data <<= 8;
+            data  |= (uint8_t)(board_id_as_string[2u * i    ]);
+
+            PRINT_DEBUG("Whitelabel Debug: Writing row 0x%03x: 0x%04x (`%c%c`)\n", row, data, byte_to_printable_char(data & 0xFFu), byte_to_printable_char(data >> 8)); WAIT_FOR_KEY();
+            bp_otp_write_single_row_ecc(row, data) || DIE();
+        }
+        
+
+
+    }
+
     // NOTE: MUST UPDATE TO WRITE THE INFO_UF2.TXT BOARD ID
 
-    // 3. encode the product string length and offset
-    uint16_t tmp_p = 0x2300 | product_char_count;
+    // 4. encode the product string length and offset
+    BP_OTP_WHITELABEL_STRDEF product_revision_strdef = {
+        .character_count = product_char_count,
+        .is_unicode      = 0,
+        .row_offset      = 0x23u, // NOTE: This is not the offset defined above, as it re-uses the USB manufacturer as a prefix
+    };
+    uint16_t tmp_p = product_revision_strdef.as_uint16;
 
     // 4. Write the portions of the first 16 rows that have valid data:
-    //                                                                                                                                                                    // XXX <= 0x17 (23) chars ... product / revision specific
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 0: row 0x%03x\n", base + 0x0u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x0u, 0x1209u) || DIE();   // USB VID == 0x1209
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 1: row 0x%03x\n", base + 0x1u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x1u, 0x7332u) || DIE();   // USB PID == 0x7332
     //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 2: row 0x%03x\n", base + 0x2u); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x2u, 0x....u) || DIE();   // USB BCD Device
@@ -287,39 +428,15 @@ void bp_otp_apply_whitelabel_data(void) {
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index A: row 0x%03x\n", base + 0xAu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xAu, tmp_p  ) || DIE();   // SCSI INQUIRY PRODUCT  XXX   chars @ offset 0x23
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index C: row 0x%03x\n", base + 0xCu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xCu, 0x1016u) || DIE();   // redirect URL          22    chars @ offset 0x10
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index D: row 0x%03x\n", base + 0xDu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xDu, 0x140du) || DIE();   // redirect name         13    chars @ offset 0x14
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index E: row 0x%03x\n", base + 0xEu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xEu, tmp_p  ) || DIE();   // info_uf2.txt product  XXX   chars @ offset 0x34
-    //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index F: row 0x%03x\n", base + 0xFu); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xFu, 0x....u) || DIE();   // info_uf2.txt board ID 23    chars @ offset 0x28
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index E: row 0x%03x\n", base + 0xEu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xEu, tmp_p  ) || DIE();   // info_uf2.txt product  XXX   chars @ offset 0x23
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index F: row 0x%03x\n", base + 0xFu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xFu, 0x3417u) || DIE();   // info_uf2.txt board ID 23    chars @ offset 0x34
 
     // 5. write the `WHITE_LABEL_ADDR` to point to the base address used here
     // NOTE: this is a fixed OTP row ... only get one shot to write this, so ensuring the above values are correctly written first is important!
     PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL_BASE_ADDR 0x%03x to row 0x05C\n", base); WAIT_FOR_KEY();
     bp_otp_write_single_row_ecc(0x05c, base) || DIE();
 
-    // 6. NON-ECC write the USB boot flags ... writes go to three (3) consecutive rows
-    // NOTE: Flags can be migrated from 0 --> 1 later.  This is used to allow board id to be written later, for example.
-    BP_OTP_USB_BOOT_FLAGS usb_boot_flags = {
-        .usb_vid_valid          = 1,
-        .usb_pid_valid          = 1,
-        .usb_bcd_valid          = 0,
-        .usb_lang_id_valid      = 0,
-        .usb_manufacturer_valid = 1,
-        .usb_product_valid      = 1,
-        .usb_serial_valid       = 0,
-        .usb_max_power_valid    = 0,
-        .volume_label_valid     = 1,
-        .scsi_vendor_valid      = 1,
-        .scsi_product_valid     = 1,
-        .scsi_rev_valid         = 0,
-        .redirect_url_valid     = 1,
-        .redirect_name_valid    = 1,
-        .info_uf2_model_valid   = 1,
-        .info_uf2_boardid_valid = 0, // TODO -- update this to 1!
-        .white_label_addr_valid = 1,
-    };
-    hard_assert(usb_boot_flags.as_uint32 == 0x407733u); // manually calculated ... should match the friendly description above.
-    
-    // 7. Read the existing USB boot flags
-    // NOTE: This is a fixed set of OTP rows, stored redundantly using 2-of-3 voting
+    // 6. Read the existing USB boot flags ... stored RBIT-3 (three rows, majority voting per bit)
     BP_OTP_USB_BOOT_FLAGS old_usb_boot_flags;
     if (!bp_otp_read_redundant_rows_2_of_3(0x059, &old_usb_boot_flags.as_uint32)) {
         PRINT_ERROR("Whitelabel Error: Raw OTP rows 0x59..0x5B (old USB BOOT FLAGS) did not find majority agreement\n");
@@ -335,10 +452,11 @@ void bp_otp_apply_whitelabel_data(void) {
             old_usb_boot_flags.as_uint32, usb_boot_flags.as_uint32,
             old_usb_boot_flags.as_uint32 & ~usb_boot_flags.as_uint32
         );
-        // continue anyways? // TODO -- update this to exit as it's an error!
+        // continue anyways? YES ... it just means there's some additional valid data
     }
-    BP_OTP_USB_BOOT_FLAGS new_flags = { .as_uint32 = old_usb_boot_flags.as_uint32 | usb_boot_flags.as_uint32 };
 
+    // 7. NON-ECC write the USB boot flags ... RBIT-3 encoding
+    BP_OTP_USB_BOOT_FLAGS new_flags = { .as_uint32 = old_usb_boot_flags.as_uint32 | usb_boot_flags.as_uint32 };
     PRINT_DEBUG("Whitelabel Debug: Writing USB BOOT FLAGS: 0x%06x -> 0x%06x\n", old_usb_boot_flags.as_uint32, new_flags);  WAIT_FOR_KEY();
     if (!bp_otp_write_redundant_rows_2_of_3(0x059, new_flags.as_uint32)) {
         PRINT_ERROR("Whitelabel Error: Failed to write USB BOOT FLAGS\n");
@@ -350,15 +468,16 @@ void bp_otp_apply_whitelabel_data(void) {
 
     // That's it!
 }
+bool bp_otp_lock_whitelabel(void) {
 
-// TODO -- Remove below as no longer relevant / required
-bool bp_otp_apply_manufacturing_string(const char* board_id_string) {
+    // Which pages do we expect to have the whitelabel data?
+    // NOTE: See TODO near end of function ... if expect_* variables change, so will that area of code
+    const uint16_t expect_start_row      = 0x0C0;
+    const uint16_t expect_used_row_count = 0x040;
 
     // // Uncomment next line to single-step (using RTT for input)
     // g_WaitForKey = true;
 
-    uint16_t base;
-    // Follow the breadcrumbs to find the base address
     BP_OTP_USB_BOOT_FLAGS old_usb_boot_flags;
     if (!bp_otp_read_redundant_rows_2_of_3(0x059, &old_usb_boot_flags.as_uint32)) {
         PRINT_ERROR("Whitelabel Error: Raw OTP rows 0x59..0x5B (USB BOOT FLAGS) did not find majority agreement\n");
@@ -366,108 +485,37 @@ bool bp_otp_apply_manufacturing_string(const char* board_id_string) {
     }
     PRINT_DEBUG("Whitelabel Debug: found USB BOOT FLAGS: %06x\n", old_usb_boot_flags.as_uint32);
 
-    // validate the USB BOOT FLAGS?
-    if (!old_usb_boot_flags.white_label_addr_valid) {
-        PRINT_ERROR("Whitelabel Error: No white label data to update (%06x)\n", old_usb_boot_flags.as_uint32);
-        return false;
-    }
-    if (old_usb_boot_flags.info_uf2_boardid_valid) {
-        PRINT_DEBUG("Whitelabel Debug: boardid string already set ... exiting\n");
-        return true;
-    }
-
-    if (!bp_otp_read_single_row_ecc(0x05C, &base)) {
-        PRINT_ERROR("Whitelabel Error: OTP row 0x5C could not be read (WHITE_LABEL_ADDR)\n");
-        return false;
-    }
-    if (base != 0x0C0) {
-        // TODO: other validation as needed
-        PRINT_ERROR("Whitelabel Error: OTP row 0x5C (WHITE_LABEL_ADDR) is not set to 0x0C0, but 0x%03x\n", base);
-        return false;
-    }
-    PRINT_DEBUG("Whitelabel Debug: WHITE_LABEL_ADDR points to row index 0x%03x\n", base);
-
-    // Validate the static portion of the strings matches
-    // That static portion starts at offset 0x10 from the base whitelabel structure.
-    uint16_t _written_static_portion[ARRAY_SIZE(_static_portion)];
-    if (!bp_otp_read_ecc_data(base+0x10, _written_static_portion, sizeof(_written_static_portion))) {
-        PRINT_ERROR("Whitelabel Error: Failed to read static portion of white label data at row 0x%03x (0x%03x)\n", base, base+0x10);
-        return false;
-    }
-    if (memcmp(_written_static_portion, _static_portion, sizeof(_static_portion)) != 0) {
-        PRINT_ERROR("Whitelabel Error: Static portion of white label data at row 0x%03x (0x%03x) does not match\n", base, base+0x10);
+    if ((old_usb_boot_flags.as_uint32 & usb_boot_flags.as_uint32) != usb_boot_flags.as_uint32) {
+        PRINT_ERROR("Whitelabel Error: USB BOOT FLAGS 0x%06x does not have all required bits set (0x%06x)\n", old_usb_boot_flags.as_uint32, usb_boot_flags.as_uint32);
         return false;
     }
 
-    PRINT_DEBUG("Whitelabel Debug: Static portion of the strings look ok\n");
-
-    size_t char_count = strlen(board_id_string);
-    if (char_count > BP_OTP_ROW__BOARD_ID_STRING_MAX_CHARCOUNT) {
-        PRINT_ERROR("Whitelabel Error: board id string is too long (%d chars > %d chars)\n", char_count, BP_OTP_ROW__BOARD_ID_STRING_MAX_CHARCOUNT);
+    BP_OTP_ROW_RANGE whitelabel_range = {0};
+    if (!internal_get_whitelabel_row_range(&whitelabel_range)) {
+        PRINT_ERROR("Whitelabel Error: Failed to get whitelabel row range\n");
         return false;
     }
 
-    // create the STRDEF value for the board id.
-    // It currently goes to a fixed offset from the base address.
-    uint16_t strdef = BP_OTP_ROW__BOARD_ID_STRING_OFFSET;
-    strdef <<= 8;
-    strdef |= char_count;
-
-    // check if the STRDEF is already set ... if it is, verify it matches the current provided string's length
-    uint16_t oldstrdef;
-    if (bp_otp_read_single_row_ecc(base + 0xFu, &oldstrdef)) {
-        PRINT_ERROR("Whitelabel Error: Failed to read prior board id STRDEF\n");
+    if (whitelabel_range.start_row != expect_start_row) {
+        PRINT_ERROR("Whitelabel Error: Whitelabel data does not start at expected row: 0x%03X != 0x%03X\n", whitelabel_range.start_row, expect_start_row);
         return false;
-    } else if ((oldstrdef != 0u) && (oldstrdef != strdef)) {
-        PRINT_ERROR("Whitelabel Error: Old board id STRDEF (0x%06x) does not match new (0x%06x)\n", oldstrdef, strdef);
+    }
+    if (whitelabel_range.row_count > expect_used_row_count) {
+        PRINT_ERROR("Whitelabel Error: Whitelabel data uses more than expected row count: 0x%03X > 0x%03X\n", whitelabel_range.row_count, expect_used_row_count);
         return false;
     }
 
-    PRINT_DEBUG("Whitelabel Debug: Writing the board id string data\n"); WAIT_FOR_KEY();
+    const uint8_t LOCK0_VALUE = 0x3Fu; // NO_KEY_STATE: 0b00, KEY_R: 0b111, KEY_W: 0b111 (no key; read-only without key)
+    const uint8_t LOCK1_VALUE = 0x15u; // LOCK_S: 0b01, LOCK_NS: 0b01, LOCK_BL: 0b01 (read-only for all)
 
-    // first write the actual string's data
-    for (size_t i = 0; i < (char_count+1)/2; ++i) {
-        uint16_t row = base + BP_OTP_ROW__BOARD_ID_STRING_OFFSET + i;
-        uint16_t data = 0;
-        // First  character is stored in LSB
-        // Second character is stored in MSB
-        data  |= (uint8_t)(board_id_string[2u * i + 1]);
-        data <<= 8;
-        data  |= (uint8_t)(board_id_string[2u * i    ]);
 
-        PRINT_DEBUG("Whitelabel Debug: Writing row 0x%03x: 0x%04x (`%c%c`)\n", row, data, byte_to_printable_char(data & 0xFFu), byte_to_printable_char(data >> 8)); WAIT_FOR_KEY();
-        if (!bp_otp_write_single_row_ecc(row, data)) {
-            PRINT_ERROR("Whitelabel Error: Failed with partial board id string data written.\n");
-            return false;
-        }
-    }
+    // NOTE: CURRENTLY HARD-CODED TO LOCK OTP ROW RANGE 0x0C0 .. 0x0FF
+    // TODO: allow locking different page
+    // TODO: allow locking more than one page
+    PRINT_WARNING("Whitelabel Warning: Locking OTP rows 0x0C0 .. 0x0FF\n");
 
-    PRINT_DEBUG("Whitelabel Debug: Writing row 0x%03x: STRDEF %04x\n", base + 0xFu, strdef); WAIT_FOR_KEY();
-    if (!bp_otp_write_single_row_ecc(base + 0xFu, strdef)) {
-        PRINT_ERROR("Whitelabel Error: Failed to write board id STRDEF\n");
-    }
-
-    PRINT_DEBUG("Whitelabel Debug: Updating the USB_BOOT_FLAGS to mark the board id string as valid\n");
-
-    BP_OTP_USB_BOOT_FLAGS new_usb_boot_flags = { .as_uint32 = old_usb_boot_flags.as_uint32 };
-    new_usb_boot_flags.info_uf2_boardid_valid = 1;
-
-    PRINT_DEBUG("Whitelabel Debug: Writing rows 0x059..0x05B: 0x%06x --> 0x%06x\n", old_usb_boot_flags.as_uint32, new_usb_boot_flags.as_uint32); WAIT_FOR_KEY();
-    if (!bp_otp_write_redundant_rows_2_of_3(0x059, new_usb_boot_flags.as_uint32)) {
-        PRINT_ERROR("Whitelabel Error: Failed to update USB BOOT FLAGs\n");
-        return false;
-    }
-
-    if (base != 0x0c0) {
-        // Currently hard-coded the mapping from pages to PAGEn_LOCK0 / PAGEn_LOCK1
-        PRINT_ERROR("Whitelabel Error: Not yet supporting locking of OTP page unless base address is 0x0C0\n");
-        return false;
-    }
-
-    // Finally, update page protections for page 3 (`0x0c0 .. 0x0ff`).
-    // Row `0xF86`, PAGE3_LOCK0 = `0x3F3F3F` = `0b00'111'111`  : NO_KEY_STATE: 0b00, KEY_R: 0b111, KEY_W: 0b111 (no key; read-only without key)
-    // Row `0xF87`, PAGE3_LOCK1 = `0x151515` = `0b00'01'01'01` : LOCK_S: 0b01, LOCK_NS: 0b01, LOCK_BL: 0b01 (read-only for all)
-    PRINT_DEBUG("Whitelabel Debug: Setting PAGE3_LOCK0 (0xF86) to `0x3Fu` (no keys; read-only without key)\n"); WAIT_FOR_KEY();
+    // TODO: is there an SDK API for locking pages?
+    PRINT_DEBUG("Setting PAGE3_LOCK0 (0xF86) to `0x3Fu` (no keys; read-only without key)\n"); WAIT_FOR_KEY();
     if (!bp_otp_write_single_row_byte3x(0xF86, 0x3Fu)) {
         PRINT_ERROR("Whitelabel Error: Failed to write PAGE3_LOCK0\n");
         return false;
@@ -477,11 +525,7 @@ bool bp_otp_apply_manufacturing_string(const char* board_id_string) {
         PRINT_ERROR("Whitelabel Error: Failed to write PAGE3_LOCK1\n");
         return false;
     }
-
     PRINT_DEBUG("Whitelabel Debug: Board ID string successfully applied and locked down.\n");
     return true;
 }
 
-
-
-                 

--- a/src/otp/bp_whitelabel.c
+++ b/src/otp/bp_whitelabel.c
@@ -31,11 +31,11 @@
 
 // TODO: update this to wait for actual keypresses over RTT (as in the earlier experimentation firmware)
 //       to allow for review of all the things happening....
-#define WAIT_FOR_KEY()
-// #define WAIT_FOR_KEY() MyWaitForAnyKey_with_discards()
+// #define WAIT_FOR_KEY()
+#define WAIT_FOR_KEY() MyWaitForAnyKey_with_discards()
 
 // decide where to single-step through the whitelabel process ... controlled via RTT (no USB connection required)
-static volatile bool g_WaitForKey = false;
+static volatile bool g_WaitForKey = true;
 static void MyWaitForAnyKey_with_discards(void) {
     if (!g_WaitForKey) {
         return;
@@ -55,6 +55,7 @@ static void MyWaitForAnyKey_with_discards(void) {
 
     return;
 }
+
 #pragma endregion // Support for RTT-based single-stepping
 #pragma region    // DIE() macro
 #define DIE() die(__LINE__)
@@ -148,7 +149,99 @@ typedef struct _BP_OTP_ROW_RANGE {
     uint16_t row_count;
 } BP_OTP_ROW_RANGE;
 #pragma endregion // Whitelabel OTP structures
+
+// NEXT STEPS: Another Pico to sacrafice to the USB Whitelabel testing....
+// Current code is single-stepping successfully....
+
+#pragma region    // Expected Results
+
+// Expected results:
+// | Row   | Data     | Chars    | Type   | Description
+// |-------|----------|----------|--------|-------------------------------------------
+// | 0x059 | 0x40F733 |          | RBIT-3 | USB BOOT FLAGS
+// | 0x05A | 0x40F733 |          | RBIT-3 | ""
+// | 0x05B | 0x40F733 |          | RBIT-3 | ""
+// | 0x05C |   0x00C0 |          | ECC    | WHITE_LABEL_ADDR
+
+// | Row   | Data     | Chars    | Type   | Description (static whitelabel structure)
+// |-------|----------|----------|--------|-------------------------------------------
+// | 0x0C0 |   0x1209 |          | ECC    | USB VID
+// | 0x0C1 |   0x7332 |          | ECC    | USB PID
+// | 0x0C2 |   0x0000 |          | ECC    | USB BCD Device
+// | 0x0C3 |   0x0000 |          | ECC    | USB LangID for strings
+// | 0x0C4 |   0x230A |          | ECC    | USB MANU
+// | 0x0C5 |   0x2311 | *****    | ECC    | USB PROD
+// | 0x0C6 |   0x0000 |          | ECC    | USB Serial Number
+// | 0x0C7 |   0x0000 |          | ECC    | USB config attributes & max power
+// | 0x0C8 |   0x1B08 |          | ECC    | STOR VOLUME LABEL
+// | 0x0C9 |   0x1F08 |          | ECC    | SCSI INQUIRY VENDOR
+// | 0x0CA |   0x2311 | *****    | ECC    | SCSI INQUIRY PRODUCT
+// | 0x0CB |   0x0000 |          | ECC    | SCSI INQUIRY REVISION
+// | 0x0CC |   0x1016 |          | ECC    | redirect URL
+// | 0x0CD |   0x140D |          | ECC    | redirect name
+// | 0x0CE |   0x2311 | *****    | ECC    | info_uf2.txt product
+// | 0x0CF |   0x3417 |          | ECC    | info_uf2.txt boardid
+
+// | Row   | Data     | Chars    | Type   | Description (static portion)
+// |-------|----------|----------|--------|-------------------------------------------
+// | 0x0D0 |   0x7468 | `ht`     | ECC    | STRDEF offset 0x10 Len 0x16 = "https://buspirate.com/"
+// | 0x0D1 |   0x7074 | `tp`     | ECC    | 
+// | 0x0D2 |   0x3a73 | `s:`     | ECC    |
+// | 0x0D3 |   0x2f2f | `//`     | ECC    |
+// | 0x0D4 |   0x7562 | `bu`     | ECC    | STRDEF offset 0x14 Len 0x0D = "buspirate.com"
+// | 0x0D5 |   0x7073 | `sp`     | ECC    |
+// | 0x0D6 |   0x7269 | `ir`     | ECC    |
+// | 0x0D7 |   0x7461 | `at`     | ECC    |
+// | 0x0D8 |   0x2e65 | `e.`     | ECC    |
+// | 0x0D9 |   0x6f63 | `co`     | ECC    |
+// | 0x0DA |   0x2f6d | `m/`     | ECC    |
+// | 0x0DB |   0x5042 | `BP`     | ECC    | STRDEF offset 0x1B Len 0x08 = "BP__BOOT"
+// | 0x0DC |   0x5f5f | `__`     | ECC    |
+// | 0x0DD |   0x4f42 | `BO`     | ECC    |
+// | 0x0DE |   0x544f | `OT`     | ECC    |
+// | 0x0DF |   0x7542 | `Bu`     | ECC    | STRDEF offset 0x1F Len 0x08 = "Bus Pir8"
+// | 0x0E0 |   0x2073 | `s `     | ECC    |
+// | 0x0E1 |   0x6950 | `Pi`     | ECC    |
+// | 0x0E2 |   0x3872 | `r8`     | ECC    |
+// | 0x0E3 |   0x7542 | `Bu`     | ECC    | STRDEF offset 0x23 Len 0x0A = "Bus Pirate", Len 0x11 = "Bus Pirate 6 Rev 2"
+// | 0x0E4 |   0x2073 | `s `     | ECC    |
+// | 0x0E5 |   0x6950 | `Pi`     | ECC    |
+// | 0x0E6 |   0x6172 | `ra`     | ECC    |
+// | 0x0E7 |   0x6574 | `te`     | ECC    |
+
+
+// | Row   | Data     | Chars    | Type   | Description ()
+// |-------|----------|----------|--------|-------------------------------------------
+// | 0x0E8 |   0x3620 | ` 6`     | ECC    |
+// | 0x0E9 |   0x5220 | ` R`     | ECC    |
+// | 0x0EA |   0x5645 | `EV`     | ECC    |
+// | 0x0EB |   0x0032 | `2`<nul> | ECC    |
+// | 0x0EC |   0x0000 |          | ECC    |
+// | 0x0ED |   0x0000 |          | ECC    |
+// | 0x0EE |   0x0000 |          | ECC    |
+// | 0x0EF |   0x0000 |          | ECC    |
+// | 0x0F0 |   0x0000 |          | ECC    |
+// | 0x0F1 |   0x0000 |          | ECC    |
+// | 0x0F2 |   0x0000 |          | ECC    |
+// | 0x0F3 |   0x0000 |          | ECC    |
+// | 0x0F4 |   0x3830 | `08`     | ECC    | STRDEF offset 0x34 Len 0x17 = 
+// | 0x0F5 |   0x313A | `:1`     | ECC    | e.g., S/N 7F6E5D4C3B2A1908 --> "08:19:2A:3B:4C:5D:6E:7F" 
+// | 0x0F6 |   0x3A39 | `9:`     | ECC    | e.g., S/N AD15221F44292F36 --> "36:2F:29:44:1F:22:15:AD"
+// | 0x0F7 |   0x4132 | `2A`     | ECC    | e.g., S/N A74936336C64D158 --> "58:D1:64:6C:33:36:49:A7"
+// | 0x0F8 |   0x.... | `:3`     | ECC    |
+// | 0x0F9 |   0x.... | `B:`     | ECC    |
+// | 0x0FA |   0x.... | `4C`     | ECC    |
+// | 0x0FB |   0x.... | `:5`     | ECC    |
+// | 0x0FC |   0x.... | `D:`     | ECC    |
+// | 0x0FD |   0x.... | `6E`     | ECC    |
+// | 0x0FE |   0x.... | `:7`     | ECC    |
+// | 0x0FF |   0x.... | `F`<nul> | ECC    |
+
+#pragma endregion // Expected Results
+
 #pragma region    // static/const USB whitelabel data
+
+
 static const BP_OTP_USB_BOOT_FLAGS usb_boot_flags = {
     .usb_vid_valid          = 1,
     .usb_pid_valid          = 1,
@@ -166,7 +259,10 @@ static const BP_OTP_USB_BOOT_FLAGS usb_boot_flags = {
     .redirect_name_valid    = 1,
     .info_uf2_model_valid   = 1,
     .info_uf2_boardid_valid = 1,
+    // 6 bits are rfu
     .white_label_addr_valid = 1,
+    // 1 bit rfu
+    // 8 bits unused (only 24 bits per OTP row)
 };
 
 static const uint16_t _static_portion[] = {
@@ -334,13 +430,11 @@ bool internal_get_whitelabel_row_range(BP_OTP_ROW_RANGE *result_out) {
 #pragma endregion // Internal helper functions
 
 
-
-
 // Restartable whitelabel process ... controlled via RTT (no USB connection required)
 void bp_otp_apply_whitelabel_data(void) {
 
     // // Uncomment next line to single-step (using RTT for input)
-    // g_WaitForKey = true;
+    g_WaitForKey = true;
 
     static const uint16_t base = 0x0c0; // written so this can be changed easily
     static const size_t product_extension_rows = sizeof(_product_string) / 2u; // sizeof() includes null; rounds down to even number
@@ -415,21 +509,21 @@ void bp_otp_apply_whitelabel_data(void) {
     uint16_t tmp_p = product_revision_strdef.as_uint16;
 
     // 4. Write the portions of the first 16 rows that have valid data:
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 0: row 0x%03x\n", base + 0x0u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x0u, 0x1209u) || DIE();   // USB VID == 0x1209
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 1: row 0x%03x\n", base + 0x1u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x1u, 0x7332u) || DIE();   // USB PID == 0x7332
-    //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 2: row 0x%03x\n", base + 0x2u); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x2u, 0x....u) || DIE();   // USB BCD Device
-    //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 3: row 0x%03x\n", base + 0x3u); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x3u, 0x....u) || DIE();   // USB LangID for strings
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 4: row 0x%03x\n", base + 0x4u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x4u, 0x230Au) || DIE();   // USB MANU              ten   chars @ offset 0x23
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 5: row 0x%03x\n", base + 0x5u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x5u, tmp_p  ) || DIE();   // USB PROD              XXX   chars @ offset 0x23
-    //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 6: row 0x%03x\n", base + 0x6u); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x6u, 0x....u) || DIE();   // USB Serial Number
-    //PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 7: row 0x%03x\n", base + 0x7u); WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x7u, 0x....u) || DIE();   // USB config attributes & max power
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 8: row 0x%03x\n", base + 0x8u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x8u, 0x1B08u) || DIE();   // STOR VOLUME LABEL     eight chars @ offset 0x1b
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 9: row 0x%03x\n", base + 0x9u);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0x9u, 0x1F08u) || DIE();   // SCSI INQUIRY VENDOR   eight chars @ offset 0x1f
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index A: row 0x%03x\n", base + 0xAu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xAu, tmp_p  ) || DIE();   // SCSI INQUIRY PRODUCT  XXX   chars @ offset 0x23
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index C: row 0x%03x\n", base + 0xCu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xCu, 0x1016u) || DIE();   // redirect URL          22    chars @ offset 0x10
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index D: row 0x%03x\n", base + 0xDu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xDu, 0x140du) || DIE();   // redirect name         13    chars @ offset 0x14
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index E: row 0x%03x\n", base + 0xEu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xEu, tmp_p  ) || DIE();   // info_uf2.txt product  XXX   chars @ offset 0x23
-    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index F: row 0x%03x\n", base + 0xFu);   WAIT_FOR_KEY(); bp_otp_write_single_row_ecc(base + 0xFu, 0x3417u) || DIE();   // info_uf2.txt board ID 23    chars @ offset 0x34
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 0: row 0x%03x\n", base + 0x0u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x0u, 0x1209u) || DIE();  // USB VID == 0x1209
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 1: row 0x%03x\n", base + 0x1u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x1u, 0x7332u) || DIE();  // USB PID == 0x7332
+    //INT_DEBUG("Whitelabel Debug: Write WHITELABEL index 2: row 0x%03x\n", base + 0x2u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x2u, 0x....u) || DIE();  // USB BCD Device
+    //INT_DEBUG("Whitelabel Debug: Write WHITELABEL index 3: row 0x%03x\n", base + 0x3u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x3u, 0x....u) || DIE();  // USB LangID for strings
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 4: row 0x%03x\n", base + 0x4u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x4u, 0x230Au) || DIE();  // USB MANU              ten   chars @ offset 0x23
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 5: row 0x%03x\n", base + 0x5u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x5u, tmp_p  ) || DIE();  // USB PROD              XXX   chars @ offset 0x23
+    //INT_DEBUG("Whitelabel Debug: Write WHITELABEL index 6: row 0x%03x\n", base + 0x6u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x6u, 0x....u) || DIE();  // USB Serial Number
+    //INT_DEBUG("Whitelabel Debug: Write WHITELABEL index 7: row 0x%03x\n", base + 0x7u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x7u, 0x....u) || DIE();  // USB config attributes & max power
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 8: row 0x%03x\n", base + 0x8u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x8u, 0x1B08u) || DIE();  // STOR VOLUME LABEL     eight chars @ offset 0x1b
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index 9: row 0x%03x\n", base + 0x9u);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0x9u, 0x1F08u) || DIE();  // SCSI INQUIRY VENDOR   eight chars @ offset 0x1f
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index A: row 0x%03x\n", base + 0xAu);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0xAu, tmp_p  ) || DIE();  // SCSI INQUIRY PRODUCT  XXX   chars @ offset 0x23
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index C: row 0x%03x\n", base + 0xCu);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0xCu, 0x1016u) || DIE();  // redirect URL          22    chars @ offset 0x10
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index D: row 0x%03x\n", base + 0xDu);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0xDu, 0x140du) || DIE();  // redirect name         13    chars @ offset 0x14
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index E: row 0x%03x\n", base + 0xEu);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0xEu, tmp_p  ) || DIE();  // info_uf2.txt product  XXX   chars @ offset 0x23
+    PRINT_DEBUG("Whitelabel Debug: Write WHITELABEL index F: row 0x%03x\n", base + 0xFu);  WAIT_FOR_KEY();  bp_otp_write_single_row_ecc(base + 0xFu, 0x3417u) || DIE();  // info_uf2.txt board ID 23    chars @ offset 0x34
 
     // 5. write the `WHITE_LABEL_ADDR` to point to the base address used here
     // NOTE: this is a fixed OTP row ... only get one shot to write this, so ensuring the above values are correctly written first is important!
@@ -463,7 +557,7 @@ void bp_otp_apply_whitelabel_data(void) {
         return;
     }
 
-    PRINT_INFO("Whitelabel Info: USB BOOT FLAGS updated\n");
+    PRINT_INFO("Whitelabel Info: USB BOOT FLAGS updated\n"); WAIT_FOR_KEY();
     return;
 
     // That's it!
@@ -476,7 +570,7 @@ bool bp_otp_lock_whitelabel(void) {
     const uint16_t expect_used_row_count = 0x040;
 
     // // Uncomment next line to single-step (using RTT for input)
-    // g_WaitForKey = true;
+    g_WaitForKey = true;
 
     BP_OTP_USB_BOOT_FLAGS old_usb_boot_flags;
     if (!bp_otp_read_redundant_rows_2_of_3(0x059, &old_usb_boot_flags.as_uint32)) {
@@ -520,7 +614,7 @@ bool bp_otp_lock_whitelabel(void) {
         PRINT_ERROR("Whitelabel Error: Failed to write PAGE3_LOCK0\n");
         return false;
     }
-    PRINT_DEBUG("Whitelabel Debug: Setting PAGE3_LOCK1 (0xF87) to `0x151515` (read-only for all three)\n"); WAIT_FOR_KEY();
+    PRINT_DEBUG("Whitelabel Debug: Setting PAGE3_LOCK1 (0xF87) to `0x15` (read-only for secure, non-secure, bootloader)\n"); WAIT_FOR_KEY();
     if (!bp_otp_write_single_row_byte3x(0xF87, 0x15u)) {
         PRINT_ERROR("Whitelabel Error: Failed to write PAGE3_LOCK1\n");
         return false;

--- a/src/otp/bp_whitelabel.c
+++ b/src/otp/bp_whitelabel.c
@@ -35,7 +35,7 @@
 #define WAIT_FOR_KEY() MyWaitForAnyKey_with_discards()
 
 // decide where to single-step through the whitelabel process ... controlled via RTT (no USB connection required)
-static volatile bool g_WaitForKey = true;
+static volatile bool g_WaitForKey = false;
 static void MyWaitForAnyKey_with_discards(void) {
     if (!g_WaitForKey) {
         return;
@@ -434,7 +434,7 @@ bool internal_get_whitelabel_row_range(BP_OTP_ROW_RANGE *result_out) {
 void bp_otp_apply_whitelabel_data(void) {
 
     // // Uncomment next line to single-step (using RTT for input)
-    g_WaitForKey = true;
+    // g_WaitForKey = true;
 
     static const uint16_t base = 0x0c0; // written so this can be changed easily
     static const size_t product_extension_rows = sizeof(_product_string) / 2u; // sizeof() includes null; rounds down to even number
@@ -570,7 +570,7 @@ bool bp_otp_lock_whitelabel(void) {
     const uint16_t expect_used_row_count = 0x040;
 
     // // Uncomment next line to single-step (using RTT for input)
-    g_WaitForKey = true;
+    // g_WaitForKey = true;
 
     BP_OTP_USB_BOOT_FLAGS old_usb_boot_flags;
     if (!bp_otp_read_redundant_rows_2_of_3(0x059, &old_usb_boot_flags.as_uint32)) {

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -137,18 +137,12 @@ static void main_system_initialization(void) {
     tx_fifo_init();
     rx_fifo_init();
 
-#if defined(BP_MANUFACTURING_TEST_MODE) && BP_VER != 5
+#if defined(BP_MANUFACTURING_TEST_MODE) && RPI_PLATFORM == RP2350
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
         "Init: OTP whitelabel update\n"
         );
-    bp_otp_apply_whitelabel_data(); // inline no-op on BP5
+    bp_otp_apply_whitelabel_data();
 #endif // BP_MANUFACTURING_TEST_MODE
-
-    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_EARLY_BOOT,
-        "Init: OTP softlock\n"
-        );
-    softlock_all_otp(); // 
-
 
 #if (BP_VER == 5)
     uint8_t bp_rev = mcu_detect_revision();

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -60,6 +60,7 @@
     #include "hardware/regs/otp.h"
 #endif
 #include "otp/bp_otp.h" // OTP related functions and definitions
+#include <pico/unique_id.h>
 
 
 static mutex_t spi_mutex;
@@ -662,13 +663,15 @@ void main(void) {
         BP_FIRMWARE_HASH,
         BP_FIRMWARE_TIMESTAMP
         );
+
+    pico_unique_board_id_t id;
+    pico_get_unique_board_id(&id);
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_WARNING, BP_DEBUG_CAT_EARLY_BOOT,
-        "Init: %s with %s RAM, %s FLASH, S/N %08X%08X\n",
+        "Init: %s with %s RAM, %s FLASH, S/N %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\n",
            BP_HARDWARE_MCU,
            BP_HARDWARE_RAM,
            BP_HARDWARE_FLASH,
-           (uint32_t)(mcu_get_unique_id() >> 32),
-           (uint32_t)(mcu_get_unique_id() & 0xFFFFFFFFu)
+           id.id[0], id.id[1], id.id[2], id.id[3], id.id[4], id.id[5], id.id[6], id.id[7]
            );
     main_system_initialization();
 

--- a/src/pirate/button.c
+++ b/src/pirate/button.c
@@ -17,9 +17,9 @@ static volatile enum button_codes button_code = BP_BUTT_NO_PRESS;
 
 // poll the value of button button_id
 bool button_get(uint8_t button_id) {
-    #if RPI_PLATFORM == RP2040
+    #if RPI_PLATFORM == RP2040    // BUGBUG / TODO - This is not properly switched based on platform, but rather based on if the board's button is active high or active low.
         return gpio_get(EXT1);
-    #elif RPI_PLATFORM == RP2350
+    #elif RPI_PLATFORM == RP2350  // BUGBUG / TODO - This is not properly switched based on platform, but rather based on if the board's button is active high or active low.
         return !gpio_get(EXT1);
     #else
         #error "Platform not speficied in button.c"
@@ -71,9 +71,9 @@ void button_irq_disable(uint8_t button_id) {
 void button_init(void) {
     gpio_set_function(EXT1, GPIO_FUNC_SIO);
     gpio_set_dir(EXT1, GPIO_IN);
-    #if (RPI_PLATFORM == RP2040)
+    #if (RPI_PLATFORM == RP2040)    // BUGBUG / TODO - This is not properly switched based on platform, but rather based on if the board's button is active high or active low.
         gpio_pull_down(EXT1);
-    #elif (RPI_PLATFORM == RP2350)
+    #elif (RPI_PLATFORM == RP2350)  // BUGBUG / TODO - This is not properly switched based on platform, but rather based on if the board's button is active high or active low.
         gpio_pull_up(EXT1);
     #else
         #error "Platform not speficied in button.c"

--- a/src/pirate/hw2wire.pio
+++ b/src/pirate/hw2wire.pio
@@ -85,7 +85,11 @@ static inline void hw2wire_program_init(PIO pio, uint sm, uint offset, uint pin_
     // Try to avoid glitching the bus while connecting the IOs. Get things set
     // up so that pin is driven down when PIO asserts OE low, and pulled up
     // otherwise.
-    #if RPI_PLATFORM != RP2350
+    #if RPI_PLATFORM == RP2040
+    // TODO: Document what is done on RP2350, and why this works.
+    //       Is there intentional split ownership in RP2040 of a GPIO used by PIO?
+    //       Is there a bug on RP2350 that prevents this?
+    //       Is this a workaround for a bug on RP2040?
     gpio_pull_down(pin_scl); //we pull down so we can output 0 when the buffer is an output without manipulating the actual scl/sda pin directions
     gpio_pull_down(pin_sda);
     #endif

--- a/src/pirate/hwi2c.pio
+++ b/src/pirate/hwi2c.pio
@@ -111,7 +111,11 @@ static inline void i2c_program_init(PIO pio, uint sm, uint offset, uint pin_sda,
     // Try to avoid glitching the bus while connecting the IOs. Get things set
     // up so that pin is driven down when PIO asserts OE low, and pulled up
     // otherwise.
-    #if RPI_PLATFORM != RP2350
+    #if RPI_PLATFORM == RP2040
+    // TODO: Document what is done on RP2350, and why this works.
+    //       Is there intentional split ownership in RP2040 of a GPIO used by PIO?
+    //       Is there a bug on RP2350 that prevents this?
+    //       Is this a workaround for a bug on RP2040?
     gpio_pull_down(pin_scl); //we pull down so we can output 0 when the buffer is an output without manipulating the actual scl/sda pin directions
     gpio_pull_down(pin_sda);
     #endif

--- a/src/pirate/hwuart.pio
+++ b/src/pirate/hwuart.pio
@@ -34,7 +34,11 @@ good_stop:              ; No delay before returning to start; a little slack is
 static inline void uart_rx_program_init(PIO pio, uint sm, uint offset, uint pin, uint bits, uint baud) {
     pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, false);
     pio_gpio_init(pio, pin);
-    #if RPI_PLATFORM != RP2350
+    #if RPI_PLATFORM == RP2040
+    // TODO: Document what is done on RP2350, and why this works.
+    //       Is there intentional split ownership in RP2040 of a GPIO used by PIO?
+    //       Is there a bug on RP2350 that prevents this?
+    //       Is this a workaround for a bug on RP2040?
     gpio_pull_down(pin);
     #endif
     pio_sm_config c = uart_rx_program_get_default_config(offset);

--- a/src/pirate/rgb.c
+++ b/src/pirate/rgb.c
@@ -11,17 +11,17 @@
 #include "pirate/rgb.h"
 #include "pio_config.h"
 
-//        REV10                     REV8
+//       All others                BP5 REV8
 //
 //    11 10  9  8  7            10  9  8  7  6
-// 12    +-------+    6     11    +-------+     5
-// 13    |       |    5     12    |       |     4
-// USB   | OLED  |   []     USB   | OLED  |    []
-// 14    |       |    4     13    |       |     3
-// 15    +-------+    3     14    +-------+     2
+// 12    +-------+    6     11     +-------+     5
+// 13    |       |    5     12     |       |     4
+// USB   | OLED  |   []     USB    | OLED  |    []
+// 14    |       |    4     13     |       |     3
+// 15    +-------+    3     14     +-------+     2
 //    16 17  0  1  2            15  x  x  0  1
 //
-#define COUNT_OF_PIXELS RGB_LEN // 18 for Rev10, 16 for Rev8
+#define COUNT_OF_PIXELS RGB_LEN // 16 for 5Rev8;  Otherwise 18 (for 5Rev10+, 5XL, 6, 7...)
 
 #define BP_HW_RGB_HAS_ALL_PIXELS !(BP_VER==5 && BP_REV<=9)
 


### PR DESCRIPTION
NOTE: This PR is to a branch ... not to main.

This was manually verified by stepping through the whitelabel code using RTT on a fresh (unused) PICO board.

Other changes include:
* Add TODO to document why rp2040 pio programs differ from rp2350 (GPIO pulldown)
* Defined `STRDEF` structure for USB Whitelabel
* Defined helper function to verify the range of OTP rows used by the USB Whitelabel data
* OTP is no longer soft-locked after boot (!!!)
* Whitelabel now refers to INFO_UF2.TXT BoardID field as ... board id (not "manufacturing data")
* BoardID is now the serial number, per Ian's code fragment
* Updated other serial number displays to match the format from Ian's code fragment
* Update USB serial number ... align with other uses (transform to hex a byte at a time, not nybble).
