### PR TITLE
simplify the logic analyzer DMA structure.

### DIFF
--- a/src/binmode/fala.c
+++ b/src/binmode/fala.c
@@ -43,7 +43,7 @@ void fala_set_triggers(uint8_t trigger_pin, uint8_t trigger_level) {
 void fala_start(void) {
     // configure and arm the logic analyzer
     fala_config.actual_sample_frequency = logic_analyzer_configure(
-        fala_config.base_frequency * fala_config.oversample, DMA_BYTES_PER_CHUNK * LA_DMA_COUNT, 0x00, 0x00, false, false);
+        fala_config.base_frequency * fala_config.oversample, LA_BUFFER_SIZE, 0x00, 0x00, false, false);
     logic_analyzer_arm(false);
 }
 
@@ -59,7 +59,7 @@ void fala_print_result(void) {
     //uint32_t fala_samples = logic_analyzer_get_end_ptr();
     uint32_t fala_samples = logic_analyzer_get_samples_from_zero();
 
-    if(fala_samples > (DMA_BYTES_PER_CHUNK * LA_DMA_COUNT)){
+    if(fala_samples > (LA_BUFFER_SIZE)){
         printf(
         "\r\n%sLogic analyzer:%s invalid sample count\r\n", ui_term_color_info(), ui_term_color_reset());
     }else{

--- a/src/binmode/falaio.c
+++ b/src/binmode/falaio.c
@@ -26,7 +26,7 @@ const char falaio_name[] = "Follow along logic analyzer";
 void falaio_notify(void) {
     // get samples count
     uint32_t fala_samples = logic_analyzer_get_samples_from_zero();
-    if(fala_samples > (DMA_BYTES_PER_CHUNK * LA_DMA_COUNT)) { //invalid sample count
+    if(fala_samples > (LA_BUFFER_SIZE)) { //invalid sample count
         fala_samples = 0;
     }
     // send notification packet

--- a/src/binmode/logicanalyzer.c
+++ b/src/binmode/logicanalyzer.c
@@ -155,8 +155,6 @@ bool logic_analyzer_is_done(void) {
     return (la_status == LA_IDLE);
 }
 
-const uint32_t la_buff_size[1] = {LA_BUFFER_SIZE};
-
 void restart_dma() {
     dma_channel_config la_dma_data_config;
     dma_channel_config la_dma_control_config;
@@ -170,8 +168,8 @@ void restart_dma() {
     channel_config_set_write_increment(&la_dma_control_config, false);
     dma_channel_configure(la_dma_control_channel,
                           &la_dma_control_config,
-                          &dma_hw->ch[la_dma_data_channel].al1_transfer_count_trig, // write address
-                          &la_buff_size[0],                          // read address
+                          &dma_hw->ch[la_dma_data_channel].al2_write_addr_trig, // write address
+                          &la_buf,                          // read address
                           1,                                         // Halt after each control block
                           false                                      // Don't start yet
     );
@@ -186,9 +184,9 @@ void restart_dma() {
                                 la_dma_control_channel); // Trigger ctrl_chan when data_chan completes
     dma_channel_configure(la_dma_data_channel,
                           &la_dma_data_config,
-                          &la_buf[0],                             // write address
+                          0,                                   // write address, filled by the control channel
                           &pio_config.pio->rxf[pio_config.sm], // read address
-                          0,                      // filled by the control channel
+                          LA_BUFFER_SIZE,                      // size of transfer
                           false                                // Don't start yet
     );
 

--- a/src/binmode/logicanalyzer.c
+++ b/src/binmode/logicanalyzer.c
@@ -33,9 +33,9 @@ enum logicanalyzer_status {
 };
 
 static void restart_dma();
-
-int la_dma[LA_DMA_COUNT];
-uint8_t* la_buf;
+int la_dma_data_channel;
+int la_dma_control_channel;
+volatile uint8_t* la_buf;
 uint32_t la_ptr = 0;
 uint32_t la_ptr_reset = 0;
 uint8_t la_base_pin = LA_BPIO0;
@@ -71,7 +71,7 @@ uint32_t logic_analyzer_get_samples_from_zero(void) {
 }
 
 uint32_t logic_analyzer_get_start_ptr(uint32_t sample_count) {
-    return ((la_ptr_reset - sample_count) & 0x1ffff);
+    return ((la_ptr_reset - sample_count) % LA_BUFFER_SIZE);
 }
 
 uint32_t logic_analyzer_get_end_ptr(void) {
@@ -115,30 +115,16 @@ void logic_analyser_done(void) {
 
     busy_wait_ms(1);
 
-    int tail_dma = -1;
-    uint32_t tail_offset;
-
-    // find the final sample
-    for (uint8_t i = 0; i < count_of(la_dma); i++) {
-        if (dma_channel_is_busy(la_dma[i])) {
-            tail_dma = i;
-            break;
-        }
-    }
-    // error, return
-    if (tail_dma == -1) {
-        return;
-    }
-    
+ 
     // transfer count is the words remaining in the stalled transfer, dma deincrements on start (-1)
-    int32_t tail = DMA_BYTES_PER_CHUNK - dma_channel_hw_addr(la_dma[tail_dma])->transfer_count - 1;
+    int32_t tail = LA_BUFFER_SIZE - dma_channel_hw_addr(la_dma_data_channel)->transfer_count - 1;
 
     // add the preceding chunks of DMA to find the location in the array
     // ready to dump
-    samples_from_zero = la_ptr_reset = la_ptr = ((DMA_BYTES_PER_CHUNK * tail_dma) + tail);
+    samples_from_zero = la_ptr_reset = la_ptr = tail;
 
-    if(tail_dma==0 && tail==-1){
-        samples_from_zero=DMA_BYTES_PER_CHUNK*LA_DMA_COUNT;
+    if(tail==-1){
+        samples_from_zero = LA_BUFFER_SIZE;
     }
     if(status_leds_enabled){
         rgb_set_all(0x00, 0xff, 0); //,0x00FF00 green for dump
@@ -147,26 +133,11 @@ void logic_analyser_done(void) {
 }
 
 uint32_t logic_analyzer_get_dma_tail(void) {
-    uint8_t tail_dma = 0xff;
-    for (uint8_t i = 0; i < count_of(la_dma); i++) {
-        if (dma_channel_is_busy(la_dma[i])) {
-            tail_dma = i;
-            break;
-        }
-    }
-
-    if (tail_dma > count_of(la_dma)) {
-        // hum
-        return 0;
-    }
-
-    return dma_channel_hw_addr(la_dma[tail_dma])->transfer_count;
+    return dma_channel_hw_addr(la_dma_data_channel)->transfer_count;
 }
 
 bool logic_analyzer_is_done(void) {
     static int32_t tail;
-    uint8_t tail_dma = 0xff;
-
     if (la_status == LA_ARMED_INIT) {
         tail = logic_analyzer_get_dma_tail();
         la_status = LA_ARMED;
@@ -184,39 +155,52 @@ bool logic_analyzer_is_done(void) {
     return (la_status == LA_IDLE);
 }
 
+const uint32_t la_buff_size[1] = {LA_BUFFER_SIZE};
+
 void restart_dma() {
-    dma_channel_config la_dma_config;
-    for (uint8_t i = 0; i < count_of(la_dma); i++) {
-        dma_channel_abort(la_dma[i]);
-        la_dma_config = dma_channel_get_default_config(la_dma[i]);
-        channel_config_set_read_increment(&la_dma_config, false);          // read fixed PIO address
-        channel_config_set_write_increment(&la_dma_config, true);          // write to circular buffer
-        channel_config_set_transfer_data_size(&la_dma_config, DMA_SIZE_8); // we have 8 IO pins
-        channel_config_set_dreq(
-            &la_dma_config,
-            pio_get_dreq(pio_config.pio, pio_config.sm, false)); // &pio0_hw->rxf[sm] paces the rate of transfer
-        channel_config_set_ring(&la_dma_config, true, 15);       // loop at 2 * 8 bytes
+    dma_channel_config la_dma_data_config;
+    dma_channel_config la_dma_control_config;
+    dma_channel_abort(la_dma_control_channel);
+    dma_channel_abort(la_dma_data_channel);
+    la_dma_data_config = dma_channel_get_default_config(la_dma_data_channel);
+    la_dma_control_config = dma_channel_get_default_config(la_dma_control_channel);
 
-        int la_dma_next = (i + 1 < count_of(la_dma)) ? la_dma[i + 1] : la_dma[0];
-        channel_config_set_chain_to(&la_dma_config, la_dma_next); // chain to next DMA
+    channel_config_set_transfer_data_size(&la_dma_control_config, DMA_SIZE_32);
+    channel_config_set_read_increment(&la_dma_control_config, false);
+    channel_config_set_write_increment(&la_dma_control_config, false);
+    dma_channel_configure(la_dma_control_channel,
+                          &la_dma_control_config,
+                          &dma_hw->ch[la_dma_data_channel].al1_transfer_count_trig, // write address
+                          &la_buff_size[0],                          // read address
+                          1,                                         // Halt after each control block
+                          false                                      // Don't start yet
+    );
+    channel_config_set_transfer_data_size(&la_dma_data_config, DMA_SIZE_8);
+    channel_config_set_read_increment(&la_dma_data_config, false);
+    channel_config_set_write_increment(&la_dma_data_config, true);
+    channel_config_set_dreq(
+        &la_dma_data_config,
+        pio_get_dreq(pio_config.pio, pio_config.sm, false)); // &pio0_hw->rxf[sm] paces the rate of transfer
 
-        dma_channel_configure(la_dma[i],
-                              &la_dma_config,
-                              (volatile uint8_t*)&la_buf[DMA_BYTES_PER_CHUNK * i],
-                              &pio_config.pio->rxf[pio_config.sm],
-                              DMA_BYTES_PER_CHUNK,
-                              false);
-    }
+    channel_config_set_chain_to(&la_dma_data_config,
+                                la_dma_control_channel); // Trigger ctrl_chan when data_chan completes
+    dma_channel_configure(la_dma_data_channel,
+                          &la_dma_data_config,
+                          &la_buf[0],                             // write address
+                          &pio_config.pio->rxf[pio_config.sm], // read address
+                          0,                      // filled by the control channel
+                          false                                // Don't start yet
+    );
 
-    // start the first channel, will pause for data from PIO
-    dma_channel_start(la_dma[0]);
+    // start the control channel, the data channel will pause for data from PIO
+    dma_channel_start(la_dma_control_channel);
 }
 
 uint32_t logic_analyzer_configure(
     float freq, uint32_t samples, uint32_t trigger_mask, uint32_t trigger_direction, bool edge, bool interrupt) {
     uint32_t actual_frequency = 0;
     la_sm_done = false;
-    memset(la_buf, 0, DMA_BYTES_PER_CHUNK * LA_DMA_COUNT);
+    memset((uint8_t*)la_buf, 0, LA_BUFFER_SIZE);
 
     irq_handler_installed=interrupt;
 
@@ -301,11 +285,10 @@ void logic_analyzer_arm(bool led_indicator_enable) {
 }
 
 bool logic_analyzer_cleanup(void) {
-
-    for (uint8_t i = 0; i < count_of(la_dma); i++) {
-        dma_channel_cleanup(la_dma[i]);
-        dma_channel_unclaim(la_dma[i]);
-    }
+    dma_channel_cleanup(la_dma_control_channel);
+    dma_channel_cleanup(la_dma_data_channel);
+    dma_channel_unclaim(la_dma_data_channel);
+    dma_channel_unclaim(la_dma_control_channel);
 
     // pio_clear_instruction_memory(pio);
     if (pio_config.program) {
@@ -314,26 +297,22 @@ bool logic_analyzer_cleanup(void) {
         pio_config.program = 0;
     }
 
-    mem_free(la_buf);
+    mem_free((uint8_t*)la_buf);
 
     logicanalyzer_reset_led();
     return true;
 }
 
 bool logicanalyzer_setup(void) {
+    //note that there isn't any alignment constraint for this buffer
+    la_buf = mem_alloc(LA_BUFFER_SIZE, 0);
 
-    la_buf = mem_alloc(DMA_BYTES_PER_CHUNK * LA_DMA_COUNT, 0);
-    if (!la_buf || ((uint)la_buf != ((uint)la_buf & ~((1 << 15) - 1)))) {
-        // printf("Failed to allocate buffer. Is the scope running?\r\n");
-        return false;
-    }
 
     // high bus priority to the DMA
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
 
-    for (uint8_t i = 0; i < count_of(la_dma); i++) {
-        la_dma[i] = dma_claim_unused_channel(true);
-    }
+    la_dma_data_channel = dma_claim_unused_channel(true);
+    la_dma_control_channel = dma_claim_unused_channel(true);
 
     pio_config.program = 0;
 

--- a/src/binmode/logicanalyzer.h
+++ b/src/binmode/logicanalyzer.h
@@ -1,6 +1,4 @@
-#define DMA_BYTES_PER_CHUNK 32768
-#define LA_DMA_COUNT 4
-
+#define LA_BUFFER_SIZE (32768 * 4)
 bool logicanalyzer_setup(void);
 int logicanalyzer_status(void);
 void logic_analyzer_dump(uint8_t* txbuf);

--- a/src/toolbars/logic_bar.c
+++ b/src/toolbars/logic_bar.c
@@ -137,7 +137,7 @@ void logic_bar_redraw(uint32_t start_pos, uint32_t total_samples) {
     }
 
     uint32_t sample_ptr = logic_analyzer_get_start_ptr(total_samples);
-    sample_ptr = (sample_ptr + start_pos) & 0x1ffff;
+    sample_ptr = (sample_ptr + start_pos) % LA_BUFFER_SIZE;
     // printf("la_prt: %d, sample_ptr: %d\r\n", la_ptr, sample_ptr);
     //  freeze terminal updates
     draw_prepare();


### PR DESCRIPTION
Replaced the 4 dma data channels with 1 dma data channel and 1 control channel. This allows to free 2 dma channels and lift any alignment restriction on the la_buff buffer. Now there is only one buffer segment, so the code is simplified. 
Also replaced some hard coded values (0x1ffff) that represented the la_buffer size -1  