### PR TITLE
eeprom: read-only I2C size auto-detection with bus scan warning

### DIFF
--- a/src/commands/eeprom/eeprom_i2c.c
+++ b/src/commands/eeprom/eeprom_i2c.c
@@ -316,81 +316,140 @@ int eeprom_i2c_detect_size(uint8_t i2c_addr,
     uint8_t sig[8], cmp[8];
 
     /* read 8-byte signature at address 0 - bail early if I2C is dead */
-    if (detect_read(i2c_addr, &detect_probe1, 0, sig, 8))
+    if (detect_read(i2c_addr, &detect_probe1, 0, sig, 8)) {
+        PRINT_DEBUG("eeprom detect: read sig failed (I2C error)\n");
         return -3;
+    }
+
+    PRINT_DEBUG("eeprom detect: sig = %02X %02X %02X %02X %02X %02X %02X %02X\n",
+                sig[0], sig[1], sig[2], sig[3], sig[4], sig[5], sig[6], sig[7]);
 
     /* bus pre-scan: warn if other devices sit in the ACK scan range */
     i2c_bus_scan_warn(i2c_addr, ops);
 
-    /* uniform data: no boundary signal to track */
+    /* check for uniform data - set flag but don't bail yet.
+     * mirror and wrap probes trivially match on uniform data,
+     * but the ACK scan is data-independent and can still identify
+     * block-select chips (24X16, 24X1025) even when blank. */
     bool uniform = true;
     for (uint8_t i = 1; i < 8; i++) {
         if (sig[i] != sig[0]) { uniform = false; break; }
     }
-    if (uniform) return -1;
+    PRINT_DEBUG("eeprom detect: uniform = %s\n", uniform ? "yes" : "no");
 
-    /* phase 1: 24X01 (128B) - 1-byte mirror at address 128 */
-    if (!detect_read(i2c_addr, &detect_probe1, 128, cmp, 8) &&
-        memcmp(sig, cmp, 8) == 0)
-        return find_device(devices, count, 128, -1);
-
-    /* phase 2: 2-byte mirror probes for 24X32 through 24X256 -
-     * for chips with 2-byte addressing, no block select, and size < 64KB,
-     * reading at address size_bytes should return the same data as address 0. */
-    for (uint8_t i = 0; i < count; i++) {
-        if (devices[i].address_bytes != 2) continue;
-        if (devices[i].block_select_bits > 0) continue;
-        if (devices[i].size_bytes >= 65536u) continue;
-        if (detect_read(i2c_addr, &detect_probe2, devices[i].size_bytes, cmp, 8)) continue;
-        if (memcmp(sig, cmp, 8) == 0) return (int)i;
+    /* phase 1: 24X01 (128B) - 1-byte mirror at address 128.
+     * skip if uniform: mirror compare would trivially match any chip. */
+    if (!uniform) {
+        if (!detect_read(i2c_addr, &detect_probe1, 128, cmp, 8) &&
+            memcmp(sig, cmp, 8) == 0) {
+            PRINT_DEBUG("eeprom detect: 24X01 mirror@128 = match\n");
+            return find_device(devices, count, 128, -1);
+        }
+        PRINT_DEBUG("eeprom detect: 24X01 mirror@128 = no match\n");
     }
 
-    /* phase 3: I2C ACK scan for multi-address chips -
+    /* phase 2: 2-byte mirror probes for 24X32 through 24X256.
+     * skip if uniform: same reason as phase 1. */
+    if (!uniform) {
+        for (uint8_t i = 0; i < count; i++) {
+            if (devices[i].address_bytes != 2) continue;
+            if (devices[i].block_select_bits > 0) continue;
+            if (devices[i].size_bytes >= 65536u) continue;
+            if (detect_read(i2c_addr, &detect_probe2, devices[i].size_bytes, cmp, 8)) {
+                PRINT_DEBUG("eeprom detect: %s mirror@%lu = read error\n",
+                            devices[i].name, (unsigned long)devices[i].size_bytes);
+                continue;
+            }
+            if (memcmp(sig, cmp, 8) == 0) {
+                PRINT_DEBUG("eeprom detect: %s mirror@%lu = match\n",
+                            devices[i].name, (unsigned long)devices[i].size_bytes);
+                return (int)i;
+            }
+            PRINT_DEBUG("eeprom detect: %s mirror@%lu = no match\n",
+                        devices[i].name, (unsigned long)devices[i].size_bytes);
+        }
+    }
+
+    /* phase 3: I2C ACK scan for multi-address chips.
      * scan consecutive addresses from base+1 to base+7.
-     * block-select chips occupy 2, 4, or 8 consecutive I2C addresses. */
+     * block-select chips occupy 2, 4, or 8 consecutive I2C addresses.
+     * this is data-independent and works on blank chips. */
     uint8_t ack_count = 0;
     for (uint8_t n = 1; n <= 7; n++) {
         if (i2c_probe_ack(i2c_addr + n)) ack_count++;
         else break;
     }
+    PRINT_DEBUG("eeprom detect: ack scan = %d consecutive\n", ack_count);
 
-    if (ack_count == 0) {
-        /* only responds at base: 24X02 (256B, 1-byte addr) or 24X512 (64KB, 2-byte addr).
-         * use sequential wrap test to distinguish: 24X02 wraps at 256, 24X512 does not. */
-        uint8_t wrap[8];
-        if (!detect_read(i2c_addr, &detect_probe1, 252, wrap, 8) &&
-            memcmp(&wrap[4], sig, 4) == 0)
-            return find_device(devices, count, 256, -1);      /* 24X02 */
-
-        /* no wrap found: could be 24X512 or 24X1025 (block select offset=3 at base+8).
-         * 24X1025 does not appear at base+1 through base+7. probe base+8 directly. */
-        if (i2c_probe_ack(i2c_addr + 8))
-            return find_device(devices, count, 131072, 3);     /* 24X1025 */
-
-        return find_device(devices, count, 65536, -1);         /* 24X512 */
+    /* phase 4: 24X16 - 8 consecutive addresses, data-independent */
+    if (ack_count >= 7) {
+        PRINT_DEBUG("eeprom detect: result = 24X16 (ack_count >= 7)\n");
+        return find_device(devices, count, 2048, -1);
     }
 
-    /* for chips with multiple I2C addresses, apply the wrap test to block 1
-     * to distinguish small (256B blocks, 1-byte addr) from large (64KB blocks,
-     * 2-byte addr) chips that share the same consecutive address count. */
+    if (ack_count == 0) {
+        /* only responds at base: candidates are 24X02, 24X512, 24X1025.
+         * wrap test and base+8 probe are used to distinguish. */
+
+        if (!uniform) {
+            /* sequential wrap test: 24X02 wraps at 256, 24X512 does not. */
+            uint8_t wrap[8];
+            if (!detect_read(i2c_addr, &detect_probe1, 252, wrap, 8) &&
+                memcmp(&wrap[4], sig, 4) == 0) {
+                PRINT_DEBUG("eeprom detect: wrap@252 = match -> 24X02\n");
+                return find_device(devices, count, 256, -1);
+            }
+            PRINT_DEBUG("eeprom detect: wrap@252 = no match\n");
+        }
+
+        /* 24X1025: block select offset=3, upper bank at base+8.
+         * ACK probe is data-independent, works on blank chips. */
+        if (i2c_probe_ack(i2c_addr + 8)) {
+            PRINT_DEBUG("eeprom detect: ACK at base+8 = yes -> 24X1025\n");
+            return find_device(devices, count, 131072, 3);
+        }
+        PRINT_DEBUG("eeprom detect: ACK at base+8 = no\n");
+
+        if (uniform) {
+            PRINT_DEBUG("eeprom detect: uniform + ack_count=0 + no base+8 -> cannot detect\n");
+            return -1;
+        }
+
+        PRINT_DEBUG("eeprom detect: result = 24X512 (elimination)\n");
+        return find_device(devices, count, 65536, -1);
+    }
+
+    /* ack_count 1 or 3: need block-1 wrap test to distinguish small
+     * (24X04/24X08) from large (24X1026/24XM02) chips.
+     * wrap test is unreliable on uniform data. */
+    if (uniform) {
+        PRINT_DEBUG("eeprom detect: uniform + ack_count=%d -> cannot detect (wrap unreliable)\n", ack_count);
+        return -1;
+    }
+
     bool b1_small = block_wraps_256(i2c_addr + 1);
+    PRINT_DEBUG("eeprom detect: block-1 wrap = %s\n", b1_small ? "256B (small)" : "large");
 
     if (ack_count == 1) {
-        /* base+1 ACKs only: 24X04 (512B, small block) vs 24X1026/24XM01 (128KB, large block) */
-        if (b1_small) return find_device(devices, count, 512,    -1); /* 24X04 */
-        else          return find_device(devices, count, 131072,  0); /* 24X1026 (first 128KB with offset=0) */
+        if (b1_small) {
+            PRINT_DEBUG("eeprom detect: result = 24X04 (ack=1, small block)\n");
+            return find_device(devices, count, 512, -1);
+        }
+        PRINT_DEBUG("eeprom detect: result = 24X1026 (ack=1, large block)\n");
+        return find_device(devices, count, 131072, 0);
     }
 
     if (ack_count == 3) {
-        /* base+1..+3 ACK: 24X08 (1KB, small blocks) vs 24XM02 (256KB, large blocks) */
-        if (b1_small) return find_device(devices, count, 1024,   -1); /* 24X08 */
-        else          return find_device(devices, count, 262144, -1); /* 24XM02 */
+        if (b1_small) {
+            PRINT_DEBUG("eeprom detect: result = 24X08 (ack=3, small blocks)\n");
+            return find_device(devices, count, 1024, -1);
+        }
+        PRINT_DEBUG("eeprom detect: result = 24XM02 (ack=3, large blocks)\n");
+        return find_device(devices, count, 262144, -1);
     }
 
-    if (ack_count >= 7)
-        return find_device(devices, count, 2048, -1);          /* 24X16 */
-
-    return -2; /* unexpected ACK pattern - ambiguous */
+    PRINT_DEBUG("eeprom detect: ack_count=%d -> ambiguous\n", ack_count);
+    return -2; /* unexpected ACK pattern */
 }
 
 static bool eeprom_get_args(struct eeprom_info *args) {

--- a/src/commands/eeprom/eeprom_i2c.c
+++ b/src/commands/eeprom/eeprom_i2c.c
@@ -15,6 +15,7 @@
 #include "pirate/hwi2c_pio.h"
 #include "eeprom_base.h"
 #include "eeprom_i2c_gui.h"
+#include "ui/ui_mem_gui.h"
 #include "bytecode.h"
 #include "mode/hwi2c.h"
 
@@ -227,6 +228,170 @@ static const struct eeprom_device_t eeprom_devices[] = {
     { "24XM01",  131072, 2, 1, 0, 256, 400, &i2c_eeprom_hal },    
     { "24XM02",  262144, 2, 2, 0, 256, 400, &i2c_eeprom_hal }
 };
+
+/* probe devices: size_bytes = 0xFFFFFFFF disables bounds check in get_address,
+ * allowing reads at any address without triggering the out-of-range error. */
+static const struct eeprom_device_t detect_probe1 = {
+    "probe", 0xFFFFFFFFu, 1, 0, 0, 8, 400, &i2c_eeprom_hal
+};
+static const struct eeprom_device_t detect_probe2 = {
+    "probe", 0xFFFFFFFFu, 2, 0, 0, 8, 400, &i2c_eeprom_hal
+};
+
+/* send START + 8-bit address + STOP (no data). returns true if device ACKed. */
+static bool i2c_probe_ack(uint8_t addr_7bit) {
+    return !pio_i2c_write_array_timeout(addr_7bit << 1, NULL, 0, 0xfffffu);
+}
+
+/* read len bytes at address from i2c_addr using probe device. */
+static bool detect_read(uint8_t i2c_addr, const struct eeprom_device_t *probe,
+                         uint32_t address, uint8_t *buf, uint32_t len) {
+    struct eeprom_info ei;
+    memset(&ei, 0, sizeof(ei));
+    ei.device_address = i2c_addr;
+    ei.device = probe;
+    ei.ui = NULL;
+    return probe->hal->read(&ei, address, len, buf);
+}
+
+/* return the first device table index matching size_bytes.
+ * if bso >= 0, also requires block_select_offset == bso. */
+static int find_device(const struct eeprom_device_t *devices, uint8_t count,
+                        uint32_t size_bytes, int bso) {
+    for (uint8_t i = 0; i < count; i++) {
+        if (devices[i].size_bytes != size_bytes) continue;
+        if (bso >= 0 && devices[i].block_select_offset != (uint8_t)bso) continue;
+        return (int)i;
+    }
+    return -2;
+}
+
+/* sequential wrap test: reads 8 bytes starting at address 252 from i2c_addr
+ * using 1-byte addressing. for a chip with exactly 256B accessible at this
+ * I2C address, the read wraps at byte 255 and bytes[4..7] equal the chip's
+ * bytes at addresses 0..3. for a 2-byte address chip (64KB+), the 1-byte
+ * probe mis-points the internal address counter, and no wrap is seen.
+ * returns true if the block is 256B (wrap detected). */
+static bool block_wraps_256(uint8_t i2c_addr) {
+    uint8_t s[8], w[8];
+    if (detect_read(i2c_addr, &detect_probe1, 0, s, 8)) return false;
+    if (detect_read(i2c_addr, &detect_probe1, 252, w, 8)) return false;
+    return (memcmp(&w[4], s, 4) == 0);
+}
+
+/* scan 0x08-0x77 and warn if devices outside the EEPROM address range respond.
+ * block-select EEPROMs occupy base..base+8; anything else is unexpected and
+ * could cause false ACK hits during the consecutive-address scan. */
+static void i2c_bus_scan_warn(uint8_t eeprom_base, const ui_mem_gui_ops_t *ops) {
+    if (!ops) return;
+
+    char buf[96];
+    int  pos = 0;
+    bool any = false;
+
+    for (uint8_t addr = 0x08; addr <= 0x77; addr++) {
+        /* skip the EEPROM's own address block */
+        if (addr >= eeprom_base && addr <= eeprom_base + 8) continue;
+        if (!i2c_probe_ack(addr)) continue;
+
+        if (!any) {
+            pos = snprintf(buf, sizeof(buf), "Other I2C devices at 0x%02X", addr);
+            any = true;
+        } else if (pos + 6 < (int)sizeof(buf) - 32) {
+            /* leave room for the suffix */
+            pos += snprintf(buf + pos, sizeof(buf) - pos, ", 0x%02X", addr);
+        }
+    }
+
+    if (any) {
+        snprintf(buf + pos, sizeof(buf) - pos, " - ACK scan may be unreliable");
+        ops->warning(buf, ops->ctx);
+    }
+}
+
+int eeprom_i2c_detect_size(uint8_t i2c_addr,
+                            const struct eeprom_device_t *devices,
+                            uint8_t count,
+                            const ui_mem_gui_ops_t *ops) {
+    uint8_t sig[8], cmp[8];
+
+    /* read 8-byte signature at address 0 - bail early if I2C is dead */
+    if (detect_read(i2c_addr, &detect_probe1, 0, sig, 8))
+        return -3;
+
+    /* bus pre-scan: warn if other devices sit in the ACK scan range */
+    i2c_bus_scan_warn(i2c_addr, ops);
+
+    /* uniform data: no boundary signal to track */
+    bool uniform = true;
+    for (uint8_t i = 1; i < 8; i++) {
+        if (sig[i] != sig[0]) { uniform = false; break; }
+    }
+    if (uniform) return -1;
+
+    /* phase 1: 24X01 (128B) - 1-byte mirror at address 128 */
+    if (!detect_read(i2c_addr, &detect_probe1, 128, cmp, 8) &&
+        memcmp(sig, cmp, 8) == 0)
+        return find_device(devices, count, 128, -1);
+
+    /* phase 2: 2-byte mirror probes for 24X32 through 24X256 -
+     * for chips with 2-byte addressing, no block select, and size < 64KB,
+     * reading at address size_bytes should return the same data as address 0. */
+    for (uint8_t i = 0; i < count; i++) {
+        if (devices[i].address_bytes != 2) continue;
+        if (devices[i].block_select_bits > 0) continue;
+        if (devices[i].size_bytes >= 65536u) continue;
+        if (detect_read(i2c_addr, &detect_probe2, devices[i].size_bytes, cmp, 8)) continue;
+        if (memcmp(sig, cmp, 8) == 0) return (int)i;
+    }
+
+    /* phase 3: I2C ACK scan for multi-address chips -
+     * scan consecutive addresses from base+1 to base+7.
+     * block-select chips occupy 2, 4, or 8 consecutive I2C addresses. */
+    uint8_t ack_count = 0;
+    for (uint8_t n = 1; n <= 7; n++) {
+        if (i2c_probe_ack(i2c_addr + n)) ack_count++;
+        else break;
+    }
+
+    if (ack_count == 0) {
+        /* only responds at base: 24X02 (256B, 1-byte addr) or 24X512 (64KB, 2-byte addr).
+         * use sequential wrap test to distinguish: 24X02 wraps at 256, 24X512 does not. */
+        uint8_t wrap[8];
+        if (!detect_read(i2c_addr, &detect_probe1, 252, wrap, 8) &&
+            memcmp(&wrap[4], sig, 4) == 0)
+            return find_device(devices, count, 256, -1);      /* 24X02 */
+
+        /* no wrap found: could be 24X512 or 24X1025 (block select offset=3 at base+8).
+         * 24X1025 does not appear at base+1 through base+7. probe base+8 directly. */
+        if (i2c_probe_ack(i2c_addr + 8))
+            return find_device(devices, count, 131072, 3);     /* 24X1025 */
+
+        return find_device(devices, count, 65536, -1);         /* 24X512 */
+    }
+
+    /* for chips with multiple I2C addresses, apply the wrap test to block 1
+     * to distinguish small (256B blocks, 1-byte addr) from large (64KB blocks,
+     * 2-byte addr) chips that share the same consecutive address count. */
+    bool b1_small = block_wraps_256(i2c_addr + 1);
+
+    if (ack_count == 1) {
+        /* base+1 ACKs only: 24X04 (512B, small block) vs 24X1026/24XM01 (128KB, large block) */
+        if (b1_small) return find_device(devices, count, 512,    -1); /* 24X04 */
+        else          return find_device(devices, count, 131072,  0); /* 24X1026 (first 128KB with offset=0) */
+    }
+
+    if (ack_count == 3) {
+        /* base+1..+3 ACK: 24X08 (1KB, small blocks) vs 24XM02 (256KB, large blocks) */
+        if (b1_small) return find_device(devices, count, 1024,   -1); /* 24X08 */
+        else          return find_device(devices, count, 262144, -1); /* 24XM02 */
+    }
+
+    if (ack_count >= 7)
+        return find_device(devices, count, 2048, -1);          /* 24X16 */
+
+    return -2; /* unexpected ACK pattern - ambiguous */
+}
 
 static bool eeprom_get_args(struct eeprom_info *args) {
     // Parse action — if no action given, launch interactive GUI

--- a/src/commands/eeprom/eeprom_i2c.c
+++ b/src/commands/eeprom/eeprom_i2c.c
@@ -1,3 +1,4 @@
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY BP_DEBUG_CAT_EEPROM
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include <stdint.h>

--- a/src/commands/eeprom/eeprom_i2c_gui.c
+++ b/src/commands/eeprom/eeprom_i2c_gui.c
@@ -35,6 +35,9 @@ enum {
     /* Device menu (10 + device index) */
     ACT_DEV_BASE = 10,
 
+    /* Auto-detect size */
+    ACT_DETECT = 50,
+
     /* File menu */
     ACT_FILE_BROWSE = 100,
     ACT_FILE_SAVE_AS = 101,
@@ -64,8 +67,12 @@ typedef struct {
     const struct eeprom_device_t *devices;
     uint8_t device_count;
 
-    /* Device name pointers for the spinner (built at init) */
-    const char *dev_names[16];
+    /* Device name pointers for the spinner (built at init).
+     * +1 for the "Auto-Detect" sentinel appended at the end. */
+    const char *dev_names[17];
+
+    bool auto_detected;   /* true when execute resolved device via auto-detect */
+    char result_buf[64];  /* formatted result string for auto-detect success */
 } i2c_ctx_t;
 
 /* ── Field indices ──────────────────────────────────────────────────── */
@@ -109,6 +116,8 @@ static void on_file_change(void *c) {
 static bool exec_ready(void *c) {
     i2c_ctx_t *x = (i2c_ctx_t *)c;
     if (x->action < 0 || x->device_idx < 0) return false;
+    /* auto-detect sentinel is valid only for read (action 0) */
+    if (x->device_idx == x->device_count) return (x->action == 0);
     if (x->action == 1 || x->action == 3) { /* write or verify */
         struct editor *ed = hx_embed_editor();
         bool has_content = (ed && ed->contents && ed->content_length > 0)
@@ -185,7 +194,8 @@ static const vt100_menu_item_t action_menu_items[] = {
     { "Test",   NULL, ACT_TEST,   0 },
 };
 
-/* Device menu — built dynamically for category separators + size hints. */
+/* Device menu — built dynamically for category separators + size hints.
+ * +2 for the auto-detect entry and its leading separator. */
 
 static void format_size(uint32_t bytes, char *buf, uint8_t buf_size) {
     if (bytes < 1024)
@@ -221,6 +231,10 @@ static uint8_t build_device_menu_items(i2c_ctx_t *ctx,
             ACT_DEV_BASE + i, 0 };
         idx++;
     }
+
+    /* auto-detect entry at the bottom, separated from the device list */
+    dev_menu_items[idx++] = (vt100_menu_item_t){ NULL, NULL, 0, MENU_ITEM_SEPARATOR };
+    dev_menu_items[idx++] = (vt100_menu_item_t){ "Auto-Detect", NULL, ACT_DETECT, 0 };
     return idx;
 }
 
@@ -265,6 +279,12 @@ static void menu_dispatch(void *c, int action_id) {
     if (action_id >= ACT_DEV_BASE &&
         action_id < ACT_DEV_BASE + x->device_count) {
         x->device_idx = action_id - ACT_DEV_BASE;
+        return;
+    }
+
+    /* Auto-detect — set spinner to sentinel, detection runs in execute_cb */
+    if (action_id == ACT_DETECT) {
+        x->device_idx = x->device_count;
         return;
     }
 
@@ -329,6 +349,41 @@ static bool needs_confirm(void *c) {
 /* Bridge: translate ui_mem_gui_ops_t → eeprom_ui_ops_t for the action fns. */
 static bool execute_cb(void *c, const ui_mem_gui_ops_t *ops, const char **result) {
     i2c_ctx_t *x = (i2c_ctx_t *)c;
+
+    /* auto-detect: probe chip size read-only via address mirroring.
+     * on success, device_idx is resolved to a real entry and we fall
+     * through to the normal execute path. */
+    if (x->device_idx == x->device_count) {
+        ops->message("Probing chip size (read-only)...", ops->ctx);
+        int detected = eeprom_i2c_detect_size(x->i2c_addr,
+                                              x->devices,
+                                              x->device_count,
+                                              ops);
+        if (detected == -3) {
+            ops->error("Auto-detect failed: I2C error - check wiring and mode", ops->ctx);
+            *result = "Auto-detect: I2C error";
+            return false;
+        }
+        if (detected == -1) {
+            ops->error("Auto-detect failed: uniform data at address 0 - "
+                       "chip may be blank, select device manually", ops->ctx);
+            *result = "Auto-detect: uniform data";
+            return false;
+        }
+        if (detected == -2) {
+            ops->error("Auto-detect failed: ambiguous result - select device manually", ops->ctx);
+            *result = "Auto-detect: ambiguous";
+            return false;
+        }
+        /* resolved - update spinner and fall through */
+        x->device_idx = detected;
+        x->auto_detected = true;
+        char msg[64];
+        snprintf(msg, sizeof(msg), "Detected: %s (%lu bytes)",
+                 x->devices[detected].name,
+                 (unsigned long)x->devices[detected].size_bytes);
+        ops->message(msg, ops->ctx);
+    }
 
     /* Static work buffers — only one execute runs at a time.
      * Keeps 512+ bytes off the 4 KB stack. */
@@ -469,8 +524,15 @@ static bool execute_cb(void *c, const ui_mem_gui_ops_t *ops, const char **result
         break;
     }
 
-    *result = success ? "Last operation: Success :)"
-                      : "Last operation: FAILED";
+    if (success && x->auto_detected) {
+        snprintf(x->result_buf, sizeof(x->result_buf),
+                 "Success! - Detected %s",
+                 x->devices[x->device_idx].name);
+        *result = x->result_buf;
+    } else {
+        *result = success ? "Last operation: Success :)"
+                          : "Last operation: FAILED";
+    }
     return success;
 }
 
@@ -502,7 +564,7 @@ bool eeprom_i2c_gui(const struct eeprom_device_t *devices,
     off += ALIGN4(sizeof(i2c_ctx_t));
 
     vt100_menu_item_t *dev_menu_items = (vt100_menu_item_t *)(buf + off);
-    off += ALIGN4(sizeof(vt100_menu_item_t) * 18);
+    off += ALIGN4(sizeof(vt100_menu_item_t) * 20); /* +2 for auto-detect separator + entry */
 
     char (*dev_size_hints)[8] = (void *)(buf + off);
     off += ALIGN4(16 * 8);
@@ -514,24 +576,27 @@ bool eeprom_i2c_gui(const struct eeprom_device_t *devices,
 
     /* Init context */
     memset(ctx, 0, sizeof(*ctx));
-    ctx->action       = -1;
-    ctx->device_idx   = -1;
-    ctx->i2c_addr     = 0x50;
-    ctx->devices      = devices;
-    ctx->device_count = device_count;
+    ctx->action        = -1;
+    ctx->device_idx    = device_count; /* default to auto-detect sentinel */
+    ctx->i2c_addr      = 0x50;
+    ctx->devices       = devices;
+    ctx->device_count  = device_count;
+    ctx->auto_detected = false;
 
-    /* Build device name pointer table for the spinner */
+    /* Build device name pointer table for the spinner.
+     * Last slot is the "Auto-detect" sentinel entry. */
     uint8_t n = device_count;
     if (n > 16) n = 16;
     for (uint8_t i = 0; i < n; i++) {
         ctx->dev_names[i] = devices[i].name;
     }
+    ctx->dev_names[n] = "Auto";
 
     /* Patch the device spinner with the actual device list.
      * i2c_fields is const — copy to mutable fields, then patch. */
     memcpy(fields, i2c_fields, sizeof(ui_field_def_t) * FLD_COUNT);
     fields[FLD_DEVICE].spinner.options = ctx->dev_names;
-    fields[FLD_DEVICE].spinner.count   = n;
+    fields[FLD_DEVICE].spinner.count   = n + 1; /* +1 for Auto-detect */
 
     /* Build device menu items */
     uint8_t dev_item_count = build_device_menu_items(ctx, dev_menu_items,

--- a/src/commands/eeprom/eeprom_i2c_gui.c
+++ b/src/commands/eeprom/eeprom_i2c_gui.c
@@ -379,9 +379,13 @@ static bool execute_cb(void *c, const ui_mem_gui_ops_t *ops, const char **result
         x->device_idx = detected;
         x->auto_detected = true;
         char msg[64];
-        snprintf(msg, sizeof(msg), "Detected: %s (%lu bytes)",
-                 x->devices[detected].name,
-                 (unsigned long)x->devices[detected].size_bytes);
+        uint32_t sz = x->devices[detected].size_bytes;
+        if (sz >= 1024)
+            snprintf(msg, sizeof(msg), "Detected: %s (%luKB)",
+                     x->devices[detected].name, (unsigned long)(sz / 1024));
+        else
+            snprintf(msg, sizeof(msg), "Detected: %s (%luB)",
+                     x->devices[detected].name, (unsigned long)sz);
         ops->message(msg, ops->ctx);
     }
 
@@ -525,9 +529,17 @@ static bool execute_cb(void *c, const ui_mem_gui_ops_t *ops, const char **result
     }
 
     if (success && x->auto_detected) {
-        snprintf(x->result_buf, sizeof(x->result_buf),
-                 "Success! - Detected %s",
-                 x->devices[x->device_idx].name);
+        uint32_t sz = x->devices[x->device_idx].size_bytes;
+        if (sz >= 1024)
+            snprintf(x->result_buf, sizeof(x->result_buf),
+                     "Success! - Detected %s (%luKB)",
+                     x->devices[x->device_idx].name,
+                     (unsigned long)(sz / 1024));
+        else
+            snprintf(x->result_buf, sizeof(x->result_buf),
+                     "Success! - Detected %s (%luB)",
+                     x->devices[x->device_idx].name,
+                     (unsigned long)sz);
         *result = x->result_buf;
     } else {
         *result = success ? "Last operation: Success :)"

--- a/src/commands/eeprom/eeprom_i2c_gui.h
+++ b/src/commands/eeprom/eeprom_i2c_gui.h
@@ -14,8 +14,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "ui/ui_mem_gui.h"
 
-/* Forward declarations — avoid pulling in full eeprom_base.h */
+/* forward declarations - avoid pulling in full eeprom_base.h */
 struct eeprom_device_t;
 struct eeprom_info;
 
@@ -36,5 +37,31 @@ struct eeprom_info;
 bool eeprom_i2c_gui(const struct eeprom_device_t* devices,
                      uint8_t device_count,
                      struct eeprom_info* args);
+
+/**
+ * @brief Read-only I2C EEPROM size detection.
+ *
+ * Uses address mirroring, I2C ACK scanning, and sequential wrap tests
+ * to identify the chip without any writes.  Covers all 14 chips in the
+ * standard 24X device table.
+ *
+ * Before probing, performs a full bus scan (0x08-0x77) and warns via
+ * ops->warning() if devices outside the EEPROM's own address range
+ * (base..base+8) are found, since those may cause false ACK hits.
+ * Pass ops=NULL to suppress the bus scan warning.
+ *
+ * @param i2c_addr  7-bit I2C base address (typically 0x50)
+ * @param devices   device table to search
+ * @param count     number of entries in device table
+ * @param ops       UI ops for warning output (NULL = silent)
+ * @return          index into devices[] on success, or:
+ *                   -1  uniform data at address 0, cannot detect read-only
+ *                   -2  no match found / ambiguous ACK pattern
+ *                   -3  I2C read error
+ */
+int eeprom_i2c_detect_size(uint8_t i2c_addr,
+                            const struct eeprom_device_t *devices,
+                            uint8_t count,
+                            const ui_mem_gui_ops_t *ops);
 
 #endif /* EEPROM_I2C_GUI_H */

--- a/src/commands/eeprom/eeprom_i2c_gui.h
+++ b/src/commands/eeprom/eeprom_i2c_gui.h
@@ -53,11 +53,13 @@ bool eeprom_i2c_gui(const struct eeprom_device_t* devices,
  * @param i2c_addr  7-bit I2C base address (typically 0x50)
  * @param devices   device table to search
  * @param count     number of entries in device table
- * @param ops       UI ops for warning output (NULL = silent)
+ * @param ops       UI ops for warning/message output (NULL = silent)
  * @return          index into devices[] on success, or:
  *                   -1  uniform data at address 0, cannot detect read-only
  *                   -2  no match found / ambiguous ACK pattern
  *                   -3  I2C read error
+ *
+ * Debug: detection steps are logged via PRINT_DEBUG (SEGGER RTT).
  */
 int eeprom_i2c_detect_size(uint8_t i2c_addr,
                             const struct eeprom_device_t *devices,

--- a/src/debug_rtt.h
+++ b/src/debug_rtt.h
@@ -38,6 +38,7 @@
         E_DEBUG_CAT_EARLY_BOOT       =  1u, // (((uint32_t)1u) <<  1u), // early-in-boot (initialization)
         E_DEBUG_CAT_ONBOARD_PIXELS   =  2u, // (((uint32_t)1u) <<  2u), // onboard RGB pixels
         E_DEBUG_CAT_ONBOARD_STORAGE  =  3u, // (((uint32_t)1u) << XXu), // lcdi2c mode specific
+        E_DEBUG_CAT_EEPROM           =  4u, // (((uint32_t)1u) <<  4u), // eeprom auto-detect and operations
         // E_DEBUG_CAT_USB_HID          = XXu, // (((uint32_t)1u) << XXu), // USB based HID interactions
         // E_DEBUG_CAT_USB_CDC          = XXu, // (((uint32_t)1u) << XXu), // USB based serial port
         // E_DEBUG_CAT_USB_MSC          = XXu, // (((uint32_t)1u) << XXu), // USB based mass storage commands
@@ -96,6 +97,7 @@
 #define BP_DEBUG_CAT_EARLY_BOOT       ((bp_debug_category_t){ E_DEBUG_CAT_EARLY_BOOT       }) // early-in-boot (initialization)
 #define BP_DEBUG_CAT_ONBOARD_PIXELS   ((bp_debug_category_t){ E_DEBUG_CAT_ONBOARD_PIXELS   }) // onboard RGB pixels
 #define BP_DEBUG_CAT_ONBOARD_STORAGE  ((bp_debug_category_t){ E_DEBUG_CAT_ONBOARD_STORAGE  }) // onboard storage (e.g., to root cause FS corruption)
+#define BP_DEBUG_CAT_EEPROM           ((bp_debug_category_t){ E_DEBUG_CAT_EEPROM           }) // eeprom auto-detect and operations
 // #define BP_DEBUG_CAT_USB_HID          ((bp_debug_category_t){ E_DEBUG_CAT_USB_HID          }) // USB based HID interactions
 // #define BP_DEBUG_CAT_USB_CDC          ((bp_debug_category_t){ E_DEBUG_CAT_USB_CDC          }) // USB based serial port
 // #define BP_DEBUG_CAT_USB_MSC          ((bp_debug_category_t){ E_DEBUG_CAT_USB_MSC          }) // USB based mass storage commands


### PR DESCRIPTION
## Summary
- Read-only I2C EEPROM size auto-detection via sequential address mirroring (no writes to chip)
- Bus scan warning when non-EEPROM devices share the I2C bus (prevents false ACK hits)
- Auto-Detect menu entry in GUI, defaults to auto-detect on first execute
- Human-readable size display in detection results and result messages
- SEGGER RTT debug logging under dedicated BP_DEBUG_CAT_EEPROM category

Rebased from PR #294 (merged into refactor2026-2-gui) onto refactor2026-2. Conflicts in eeprom_i2c_gui.c resolved: kept pointer-based ctx allocation from refactor2026-2, integrated auto-detect additions, expanded dev_menu_items buffer from 18 to 20 for the auto-detect separator + entry.