### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build_*/**
 .env
 
 src/translation/history/new__en-us.json
+
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "ansi-colours": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689380286,
+        "narHash": "sha256-35QJIHShtwuL9SmI2fOHjAG6knediD2JZKV/QNmjrPk=",
+        "owner": "mina86",
+        "repo": "ansi_colours",
+        "rev": "84c64b3d560b51a15a9889f30ebb977815d3945e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mina86",
+        "ref": "v1.2.2",
+        "repo": "ansi_colours",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pico-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753763866,
+        "narHash": "sha256-8ubZW6yQnUTYxQqYI6hi7s3kFVQhe5EaxVvHmo93vgk=",
+        "ref": "refs/tags/2.2.0",
+        "rev": "a1438dff1d38bd9c65dbd693f0e5db4b9ae91779",
+        "revCount": 1208,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/raspberrypi/pico-sdk"
+      },
+      "original": {
+        "ref": "refs/tags/2.2.0",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/raspberrypi/pico-sdk"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ansi-colours": "ansi-colours",
+        "nixpkgs": "nixpkgs",
+        "pico-sdk": "pico-sdk"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "Bus Pirate 5 firmware";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    pico-sdk = {
+      url = "git+https://github.com/raspberrypi/pico-sdk?ref=refs/tags/2.2.0&submodules=1";
+      flake = false;
+    };
+
+    ansi-colours = {
+      url = "github:mina86/ansi_colours/v1.2.2";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, pico-sdk, ansi-colours }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.gcc14Stdenv.mkDerivation {
+            pname = "bus-pirate5-rev10-firmware";
+            version = self.shortRev or self.dirtyShortRev or "unknown";
+
+            src = pkgs.lib.cleanSource ./.;
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              gcc-arm-embedded-14
+              python3
+              picotool
+            ];
+
+            configurePhase = ''
+              runHook preConfigure
+              cmake -S . -B build \
+                -DPICO_SDK_PATH=${pico-sdk} \
+                -DANSI_COLOURS_PATH=${ansi-colours} \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DGIT_COMMIT_HASH=${self.shortRev or self.dirtyShortRev or "unknown"} \
+                -Dpicotool_DIR=${pkgs.picotool}/lib/cmake/picotool
+              runHook postConfigure
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+              cmake --build build --parallel $NIX_BUILD_CORES --target bus_pirate5_rev10
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out
+              cp build/src/bus_pirate5_rev10.uf2 $out/
+              runHook postInstall
+            '';
+
+            dontStrip = true;
+            dontFixup = true;
+          };
+        });
+
+      # cmake -S . -B build_rp2040
+      # cmake --build build_rp2040 --parallel --target bus_pirate5_rev10
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = (pkgs.mkShell.override { stdenv = pkgs.gcc14Stdenv; }) {
+            packages = with pkgs; [
+              gcc-arm-embedded-14
+              cmake
+              python3
+              git
+            ];
+
+            shellHook = ''
+              export PICO_SDK_PATH="${pico-sdk}"
+            '';
+          };
+        });
+    };
+}

--- a/readme.md
+++ b/readme.md
@@ -125,12 +125,32 @@ cp docker/debug.env .env
 # run the debug version of the services
 docker compose run dev-debug
 ```
+### build using nix
 
-### Building without LGPL3 protected component
-**NOTE** by doing the following you may not need to distribute the binaries under LGPL3 license terms. 
+Either build using nix directly
 
-To compile the firmware without LGPL3 components, simply add the following flags to the configuration step above:  
-`-DUSE_LGPL3=NO -DLEGACY_ANSI_COLOURS_ENABLED=NO`
+```shell
+$ nix build
+$ file result/bus_pirate5_rev10.uf2
+result/bus_pirate5_rev10.uf2: UF2 firmware image, family Raspberry Pi RP2040, address 0x10000000, 3572 total blocks
+```
+
+or using nix to get a development shell, which is more convenient for incremental builds:
+
+```shell
+$ nix develop
+$ cmake -S . -B build_rp2040
+-- Build files have been written to: /home/zoid/clone/BusPirate5-firmware/build_rp2040
+$ cmake --build build_rp2040 --parallel --target bus_pirate5_rev10
+Memory region         Used Size  Region Size  %age Used
+           FLASH:     1169872 B        16 MB      6.97%
+             RAM:      224840 B       256 KB     85.77%
+       SCRATCH_X:          4 KB         4 KB    100.00%
+       SCRATCH_Y:          4 KB         4 KB    100.00%
+[100%] Built target bus_pirate5_rev10
+$ file ./build_rp2040/src/bus_pirate5_rev10.uf2
+./build_rp2040/src/bus_pirate5_rev10.uf2: UF2 firmware image, family Raspberry Pi RP2040, address 0x10000000, 3572 total blocks
+```
 
 ## Other open source licenses
 


### PR DESCRIPTION
Nix allows easy building without having to worry about dependencies or messing up your local environment, similar to docker.

```
> nix build
> file result/bus_pirate5_rev10.uf2
result/bus_pirate5_rev10.uf2: UF2 firmware image, family Raspberry Pi RP2040, address 0x10000000, 3572 total blocks

> nix develop
cmake -S . -B build_rp2040
cmake --build build_rp2040 --parallel --target bus_pirate5_rev10
```

GCC15 does not seem to be compatible with this pico-sdk