### PR TITLE
Added binmode "Transparent UART"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -575,6 +575,9 @@ set(buspirate_common
         pirate/irio_pio.c
         binmode/irtoy-irman.h
         binmode/irtoy-irman.c
+        # Modified by DereIBims: add Transparent UART binary mode sources.
+        binmode/transparent_uart.h
+        binmode/transparent_uart.c
 
         #toolbars
         toolbars/logic_bar.c

--- a/src/binmode/binmodes.c
+++ b/src/binmode/binmodes.c
@@ -15,6 +15,7 @@
  * 
  * @author Bus Pirate Project
  * @date 2024-2026
+ * Modified by DereIBims: added Transparent UART binary mode registration.
  */
 
 #include <string.h>
@@ -33,6 +34,7 @@
 #include "binmode/falaio.h"
 #include "binmode/irtoy-irman.h"
 #include "binmode/irtoy-air.h"
+#include "binmode/transparent_uart.h"
 #include "lib/arduino-ch32v003-swio/arduino_ch32v003.h"
 #include "pirate/storage.h" // File system related
 #include "usb_rx.h"
@@ -176,6 +178,19 @@ const binmode_t binmodes[] = {
         .binmode_setup = irtoy_air_setup,
         .binmode_cleanup = irtoy_air_cleanup,
         .binmode_service = irtoy_air_service,
+    },
+    {
+        .lock_terminal = false,
+        .can_save_config = false,
+        .reset_to_hiz = false,
+        .pullup_enabled = false,
+        .psu_en_voltage = 0,
+        .psu_en_current = 0,
+        .button_to_exit = false,
+        .binmode_name = transparent_uart_name,
+        .binmode_setup = transparent_uart_setup,
+        .binmode_cleanup = transparent_uart_cleanup,
+        .binmode_service = transparent_uart_service,
     },
 };
 

--- a/src/binmode/binmodes.h
+++ b/src/binmode/binmodes.h
@@ -1,3 +1,5 @@
+// Modified by DereIBims: added Transparent UART binary mode registration.
+
 void binmode_setup(void);
 void binmode_service(void);
 void binmode_cleanup(void);
@@ -11,6 +13,7 @@ enum {
     BINMODE_USE_FALA,
     BINMODE_USE_IRTOY_IRMAN,
     BINMODE_USE_IRTOY_AIR,
+    BINMODE_USE_TRANSPARENT_UART,
     BINMODE_MAXPROTO
 };
 

--- a/src/binmode/transparent_uart.c
+++ b/src/binmode/transparent_uart.c
@@ -176,6 +176,13 @@ void transparent_uart_setup(void) {
         return;
     }
 
+    if (system_config.mode != DIO) {
+        ui_help_error(T_MODE_ERROR_NO_EFFECT);
+        printf("%s%s\r\n%s> m DIO%s\r\n",
+            ui_term_color_info(), GET_T(T_CMDLN_MODE), ui_term_color_prompt(), ui_term_color_reset());
+        return;
+    }
+
     cdc_line_coding_t coding;
     tud_cdc_n_get_line_coding(TRANSPARENT_UART_CDC_ITF, &coding);
     transparent_uart_line_coding_changed(TRANSPARENT_UART_CDC_ITF,
@@ -189,13 +196,6 @@ void transparent_uart_setup(void) {
         ui_help_error(T_MODE_INVALID_OPTION);
         return;
     }
-
-    /* Relinquish pins owned by the current CLI bus mode, then use DIO as the
-     * base mode so DTR and RTS remain available as driven BIO pins. */
-    modes[system_config.mode].protocol_cleanup();
-    system_config.mode = DIO;
-    modes[system_config.mode].protocol_setup_exc();
-    printf("%s%s:%s DIO\r\n", ui_term_color_info(), GET_T(T_MODE_MODE), ui_term_color_reset());
 
     setup_uart_pins();
     apply_line_coding(&config);

--- a/src/binmode/transparent_uart.c
+++ b/src/binmode/transparent_uart.c
@@ -1,0 +1,264 @@
+/**
+ * @file transparent_uart.c
+ * @brief Host-configured USB CDC to hardware UART binary mode.
+ *
+ * Copyright (c) 2026 DereIBims. MIT License.
+ */
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "hardware/uart.h"
+#include "tusb.h"
+#include "pirate.h"
+#include "pirate/bio.h"
+#include "system_config.h"
+#include "bytecode.h"
+#include "command_struct.h"
+#include "modes.h"
+#include "ui/ui_help.h"
+#include "ui/ui_term.h"
+#include "mode/hwuart.h"
+#include "binmode/transparent_uart.h"
+
+#define TRANSPARENT_UART_CDC_ITF 1
+#define TRANSPARENT_UART_DTR_PIN M_UART_CTS
+
+typedef struct {
+    uint32_t bit_rate;
+    uint8_t stop_bits;
+    uint8_t parity;
+    uint8_t data_bits;
+} transparent_uart_host_config_t;
+
+const char transparent_uart_name[] = "Transparent UART";
+
+static transparent_uart_host_config_t host_config;
+static uint32_t line_coding_sequence;
+static uint32_t applied_line_coding_sequence;
+static bool mode_active;
+static bool uart_active;
+static uint8_t cdc_rx_buffer[64];
+static uint32_t cdc_rx_count;
+static uint32_t cdc_rx_index;
+
+void transparent_uart_line_coding_changed(
+    uint8_t itf, uint32_t bit_rate, uint8_t stop_bits, uint8_t parity, uint8_t data_bits) {
+    if (itf != TRANSPARENT_UART_CDC_ITF) {
+        return;
+    }
+
+    __atomic_add_fetch(&line_coding_sequence, 1, __ATOMIC_ACQ_REL);
+    __atomic_store_n(&host_config.bit_rate, bit_rate, __ATOMIC_RELAXED);
+    __atomic_store_n(&host_config.stop_bits, stop_bits, __ATOMIC_RELAXED);
+    __atomic_store_n(&host_config.parity, parity, __ATOMIC_RELAXED);
+    __atomic_store_n(&host_config.data_bits, data_bits, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&line_coding_sequence, 1, __ATOMIC_RELEASE);
+}
+
+void transparent_uart_line_state_changed(uint8_t itf, bool dtr, bool rts) {
+    if (itf != TRANSPARENT_UART_CDC_ITF) {
+        return;
+    }
+
+    /* GPIO writes are safe from either RP2040 core. */
+    if (__atomic_load_n(&mode_active, __ATOMIC_ACQUIRE)) {
+        bio_put(TRANSPARENT_UART_DTR_PIN, !dtr);
+        bio_put(M_UART_RTS, !rts);
+    }
+}
+
+static uint32_t snapshot_line_coding(transparent_uart_host_config_t* snapshot) {
+    uint32_t before;
+    uint32_t after;
+    do {
+        before = __atomic_load_n(&line_coding_sequence, __ATOMIC_ACQUIRE);
+        if (before & 1u) {
+            continue;
+        }
+        snapshot->bit_rate = __atomic_load_n(&host_config.bit_rate, __ATOMIC_RELAXED);
+        snapshot->stop_bits = __atomic_load_n(&host_config.stop_bits, __ATOMIC_RELAXED);
+        snapshot->parity = __atomic_load_n(&host_config.parity, __ATOMIC_RELAXED);
+        snapshot->data_bits = __atomic_load_n(&host_config.data_bits, __ATOMIC_RELAXED);
+        after = __atomic_load_n(&line_coding_sequence, __ATOMIC_ACQUIRE);
+    } while (before != after || (after & 1u));
+    return after;
+}
+
+static bool line_coding_to_uart(const transparent_uart_host_config_t* config,
+                                uint* stop_bits,
+                                uart_parity_t* parity) {
+    if (config->bit_rate < 1 || config->bit_rate > 7372800 ||
+        config->data_bits < 5 || config->data_bits > 8) {
+        return false;
+    }
+
+    switch (config->stop_bits) {
+        case CDC_LINE_CODING_STOP_BITS_1:
+            *stop_bits = 1;
+            break;
+        case CDC_LINE_CODING_STOP_BITS_2:
+            *stop_bits = 2;
+            break;
+        default:
+            return false;
+    }
+
+    switch (config->parity) {
+        case CDC_LINE_CODING_PARITY_NONE:
+            *parity = UART_PARITY_NONE;
+            break;
+        case CDC_LINE_CODING_PARITY_ODD:
+            *parity = UART_PARITY_ODD;
+            break;
+        case CDC_LINE_CODING_PARITY_EVEN:
+            *parity = UART_PARITY_EVEN;
+            break;
+        default:
+            return false;
+    }
+    return true;
+}
+
+static bool apply_line_coding(const transparent_uart_host_config_t* config) {
+    uint stop_bits;
+    uart_parity_t parity;
+    if (!line_coding_to_uart(config, &stop_bits, &parity)) {
+        if (uart_active) {
+            uart_deinit(M_UART_PORT);
+            uart_active = false;
+        }
+        return false;
+    }
+
+    if (uart_active) {
+        uart_tx_wait_blocking(M_UART_PORT);
+    }
+    uart_init(M_UART_PORT, config->bit_rate);
+    uart_set_format(M_UART_PORT, config->data_bits, stop_bits, parity);
+    uart_active = true;
+    return true;
+}
+
+static void setup_uart_pins(void) {
+    static const char pin_labels[][5] = { "TX->", "RX<-", "DTR", "RTS" };
+
+    bio_buf_output(M_UART_TX);
+    bio_buf_input(M_UART_RX);
+    bio_set_function(M_UART_TX, GPIO_FUNC_UART);
+    bio_set_function(M_UART_RX, GPIO_FUNC_UART);
+
+    bio_set_function(TRANSPARENT_UART_DTR_PIN, GPIO_FUNC_SIO);
+    bio_put(TRANSPARENT_UART_DTR_PIN, true);
+    bio_output(TRANSPARENT_UART_DTR_PIN);
+    bio_set_function(M_UART_RTS, GPIO_FUNC_SIO);
+    bio_put(M_UART_RTS, true);
+    bio_output(M_UART_RTS);
+
+    /* Transparent UART does not use hardware CTS flow control. */
+    uart_set_hw_flow(M_UART_PORT, false, false);
+
+    system_bio_update_purpose_and_label(true, M_UART_TX, BP_PIN_MODE, pin_labels[0]);
+    system_bio_update_purpose_and_label(true, M_UART_RX, BP_PIN_MODE, pin_labels[1]);
+    system_bio_update_purpose_and_label(true, TRANSPARENT_UART_DTR_PIN, BP_PIN_MODE, pin_labels[2]);
+    system_bio_update_purpose_and_label(true, M_UART_RTS, BP_PIN_MODE, pin_labels[3]);
+}
+
+void transparent_uart_setup(void) {
+    __atomic_store_n(&mode_active, false, __ATOMIC_RELEASE);
+    uart_active = false;
+    cdc_rx_count = 0;
+    cdc_rx_index = 0;
+
+    /* Same voltage measurement and standard messages as the UART bridge. */
+    if (!ui_help_check_vout_vref()) {
+        ui_help_error(T_MODE_NO_VOUT_VREF_ERROR);
+        printf("%s%s%s\r\n", ui_term_color_info(), GET_T(T_MODE_NO_VOUT_VREF_HINT), ui_term_color_reset());
+        return;
+    }
+
+    cdc_line_coding_t coding;
+    tud_cdc_n_get_line_coding(TRANSPARENT_UART_CDC_ITF, &coding);
+    transparent_uart_line_coding_changed(TRANSPARENT_UART_CDC_ITF,
+        coding.bit_rate, coding.stop_bits, coding.parity, coding.data_bits);
+
+    transparent_uart_host_config_t config = { 0 };
+    applied_line_coding_sequence = snapshot_line_coding(&config);
+    uint stop_bits;
+    uart_parity_t parity;
+    if (!line_coding_to_uart(&config, &stop_bits, &parity)) {
+        ui_help_error(T_MODE_INVALID_OPTION);
+        return;
+    }
+
+    /* Relinquish pins owned by the current CLI bus mode, then use DIO as the
+     * base mode so DTR and RTS remain available as driven BIO pins. */
+    modes[system_config.mode].protocol_cleanup();
+    system_config.mode = DIO;
+    modes[system_config.mode].protocol_setup_exc();
+    printf("%s%s:%s DIO\r\n", ui_term_color_info(), GET_T(T_MODE_MODE), ui_term_color_reset());
+
+    setup_uart_pins();
+    apply_line_coding(&config);
+
+    system_config.binmode_usb_rx_queue_enable = false;
+    system_config.binmode_usb_tx_queue_enable = false;
+    __atomic_store_n(&mode_active, true, __ATOMIC_RELEASE);
+
+    /* Apply the current host state once; later changes arrive via callback. */
+    uint8_t line_state = tud_cdc_n_get_line_state(TRANSPARENT_UART_CDC_ITF);
+    transparent_uart_line_state_changed(
+        TRANSPARENT_UART_CDC_ITF, (line_state & 0x01u) != 0, (line_state & 0x02u) != 0);
+}
+
+void transparent_uart_service(void) {
+    if (!__atomic_load_n(&mode_active, __ATOMIC_ACQUIRE)) {
+        return;
+    }
+
+    transparent_uart_host_config_t config = { 0 };
+    uint32_t coding_sequence = snapshot_line_coding(&config);
+    if (coding_sequence != applied_line_coding_sequence) {
+        applied_line_coding_sequence = coding_sequence;
+        if (!apply_line_coding(&config)) {
+            ui_help_error(T_MODE_INVALID_OPTION);
+        }
+    }
+
+    if (!uart_active) {
+        return;
+    }
+
+    if (cdc_rx_index >= cdc_rx_count) {
+        uint32_t available = tud_cdc_n_available(TRANSPARENT_UART_CDC_ITF);
+        cdc_rx_count = tud_cdc_n_read(
+            TRANSPARENT_UART_CDC_ITF, cdc_rx_buffer, MIN(available, sizeof(cdc_rx_buffer)));
+        cdc_rx_index = 0;
+    }
+    while (cdc_rx_index < cdc_rx_count && uart_is_writable(M_UART_PORT)) {
+        uart_putc_raw(M_UART_PORT, cdc_rx_buffer[cdc_rx_index++]);
+    }
+
+    uint8_t buffer[64];
+    uint32_t write_available = tud_cdc_n_write_available(TRANSPARENT_UART_CDC_ITF);
+    uint32_t count = 0;
+    while (count < MIN(write_available, sizeof(buffer)) && uart_is_readable(M_UART_PORT)) {
+        buffer[count++] = uart_getc(M_UART_PORT);
+    }
+    if (count) {
+        tud_cdc_n_write(TRANSPARENT_UART_CDC_ITF, buffer, count);
+        tud_cdc_n_write_flush(TRANSPARENT_UART_CDC_ITF);
+    }
+}
+
+void transparent_uart_cleanup(void) {
+    bool was_active = __atomic_exchange_n(&mode_active, false, __ATOMIC_ACQ_REL);
+    system_config.binmode_usb_rx_queue_enable = true;
+    system_config.binmode_usb_tx_queue_enable = true;
+
+    if (was_active || uart_active) {
+        hwuart_cleanup();
+    }
+    uart_active = false;
+    cdc_rx_count = 0;
+    cdc_rx_index = 0;
+}

--- a/src/binmode/transparent_uart.h
+++ b/src/binmode/transparent_uart.h
@@ -1,0 +1,25 @@
+/**
+ * @file transparent_uart.h
+ * @brief Host-configured USB CDC to hardware UART binary mode.
+ *
+ * Copyright (c) 2026 DereIBims. MIT License.
+ */
+
+#ifndef TRANSPARENT_UART_H
+#define TRANSPARENT_UART_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+extern const char transparent_uart_name[];
+
+void transparent_uart_setup(void);
+void transparent_uart_service(void);
+void transparent_uart_cleanup(void);
+
+/** TinyUSB CDC event entry points. Non-binary CDC interfaces are ignored. */
+void transparent_uart_line_coding_changed(
+    uint8_t itf, uint32_t bit_rate, uint8_t stop_bits, uint8_t parity, uint8_t data_bits);
+void transparent_uart_line_state_changed(uint8_t itf, bool dtr, bool rts);
+
+#endif // TRANSPARENT_UART_H

--- a/src/usb_rx.c
+++ b/src/usb_rx.c
@@ -17,6 +17,7 @@
  * 
  * @author Bus Pirate Project
  * @date 2024-2026
+ * Modified by DereIBims: forward CDC line-state and line-coding events to Transparent UART.
  */
 
 #include <stdio.h>
@@ -32,6 +33,7 @@
 #include "pirate/bio.h"
 #include "system_config.h"
 #include "debug_uart.h"
+#include "binmode/transparent_uart.h"
 
 void rx_uart_irq_handler(void);
 
@@ -164,7 +166,19 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
     BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_CAT_TEMP,
         "--> tud_cdc_line_state_cb(%d, %d, %d)\n", itf, dtr, rts
         );
-    system_config.rts = rts;
+    if (itf == 0) {
+        system_config.rts = rts;
+    }
+    transparent_uart_line_state_changed(itf, dtr, rts);
+}
+
+// Invoked when the host changes baud rate, framing, parity or data bits.
+void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* line_coding) {
+    transparent_uart_line_coding_changed(itf,
+        line_coding->bit_rate,
+        line_coding->stop_bits,
+        line_coding->parity,
+        line_coding->data_bits);
 }
 
 // insert a byte into the queue


### PR DESCRIPTION
Adds a new binary mode: Transparent UART.

The second USB CDC interface is used as a standard USB-to-UART adapter while the main Bus Pirate terminal remains available.

UART settings such as baud rate, data bits, parity and stop bits are taken directly from the host instead of the Bus Pirate configuration.
Flow Control is off.

That way, the Bus Pirate acts like any normal USB <-> UART chip

DIO mode is required (checked befor starting) and VOUT/VREF are checked before starting.

Validated with flashing some ESPs.